### PR TITLE
#41 Fixed where switching maps while having a killzone selected would…

### DIFF
--- a/app/Models/DungeonRoute.php
+++ b/app/Models/DungeonRoute.php
@@ -336,6 +336,10 @@ class DungeonRoute extends Model
         //$this->difficulty = $request->get('difficulty', $this->difficulty);
         $this->difficulty = 1;
         $this->teeming = $request->get('teeming', $this->teeming);
+        // @TODO TEMP FIX
+        if($this->teeming === null){
+            $this->teeming = 0;
+        }
 
         if (Auth::user()->hasPaidTier('unlisted-routes')) {
             $this->unlisted = intval($request->get('unlisted', 0)) > 0;

--- a/resources/assets/js/custom/dungeonmap.js
+++ b/resources/assets/js/custom/dungeonmap.js
@@ -110,6 +110,10 @@ class DungeonMap extends Signalable {
             });
         });
 
+        this.leafletMap.on(L.Draw.Event.TOOLBAROPENED, function (e) {
+            // If a killzone was selected, unselect it now
+            self.setSelectModeKillZone(null);
+        });
         this.leafletMap.on(L.Draw.Event.DELETESTART, function (e) {
             self.deleteModeActive = true;
         });
@@ -312,7 +316,10 @@ class DungeonMap extends Signalable {
 
         this.signal('map:beforerefresh', {dungeonmap: this});
 
+        // If a killzone was selected, unselect it now
+        this.setSelectModeKillZone(null);
         this.mapObjectGroupFetchSuccessCount = 0;
+
         if (this.mapTileLayer !== null) {
             this.leafletMap.removeLayer(this.mapTileLayer);
         }
@@ -455,9 +462,10 @@ class DungeonMap extends Signalable {
      */
     setSelectModeKillZone(killzone = null) {
         let changed = this.currentSelectModeKillZone !== killzone;
+        let previousKillzone = this.currentSelectModeKillZone;
         this.currentSelectModeKillZone = killzone;
         if (changed) {
-            this.signal('map:killzoneselectmodechanged', {killzone: killzone});
+            this.signal('map:killzoneselectmodechanged', {previousKillzone: previousKillzone, killzone: killzone});
         }
     }
 

--- a/resources/assets/js/custom/killzone.js
+++ b/resources/assets/js/custom/killzone.js
@@ -54,6 +54,15 @@ class KillZone extends MapObject {
             self.map.setSelectModeKillZone(null);
             self.removeExistingConnectionsToEnemies();
         });
+
+        // External change (due to delete mode being started, for example)
+        this.map.register('map:killzoneselectmodechanged', this, function (event) {
+            let killzone = event.data.killzone;
+            let previousKillzone = event.data.previousKillzone;
+            if (killzone === null && previousKillzone === self) {
+                self.cancelSelectMode(true);
+            }
+        });
     }
 
     /**
@@ -223,10 +232,12 @@ class KillZone extends MapObject {
     /**
      * Stops select mode of this KillZone.
      */
-    cancelSelectMode() {
+    cancelSelectMode(externalChange = false) {
         console.assert(this instanceof KillZone, this, 'this is not an KillZone');
-        if (this.map.isKillZoneSelectModeEnabled()) {
-            this.map.setSelectModeKillZone(null);
+        if (this.map.isKillZoneSelectModeEnabled() || externalChange) {
+            if(!externalChange){
+                this.map.setSelectModeKillZone(null);
+            }
             this.layer.setIcon(LeafletKillZoneIcon);
 
             let self = this;

--- a/resources/views/common/forms/register.blade.php
+++ b/resources/views/common/forms/register.blade.php
@@ -8,7 +8,7 @@ $width = $modal ? '12' : '6';
     {{ csrf_field() }}
 
     <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
-        <label for="{{ $modalClass }}register_name" class="control-label">{{ __('Name') }}</label>
+        <label for="{{ $modalClass }}register_name" class="control-label">{{ __('Username') }}</label>
 
         <div class="col-md-{{ $width }}">
             <input id="{{ $modalClass }}register_name" type="text" class="form-control" name="name" value="{{ old('name') }}" required autofocus>

--- a/resources/views/misc/changelog.blade.php
+++ b/resources/views/misc/changelog.blade.php
@@ -4,6 +4,22 @@
 
 @section('content')
     <h4>
+        2018/10/11 - v2
+    </h4>
+
+    <p>
+        Map changes:
+    <ul>
+        <li>
+            Fixed where switching maps while having a killzone selected would leave you locked out of selecting new killzones.
+        </li>
+        <li>
+            Interacting with the toolbox while having a killzone selected will now disable the selection on the killzone. This led to multiple issues.
+        </li>
+    </ul>
+    </p>
+
+    <h4>
         2018/10/11
     </h4>
     <p>


### PR DESCRIPTION
… leave you locked out of selecting new killzones. Interacting with the toolbox while having a killzone selected will now disable the selection on the killzone. This led to multiple issues.