### PR TITLE
#537 Keystone level implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log
 .env
 .phpstorm.meta.php
 _ide_helper.php
+/storage/debugbar/

--- a/app/Http/Controllers/APIDungeonRouteController.php
+++ b/app/Http/Controllers/APIDungeonRouteController.php
@@ -16,6 +16,7 @@ use App\Logic\Datatables\ColumnHandler\DungeonRoutes\DungeonColumnHandler;
 use App\Logic\Datatables\ColumnHandler\DungeonRoutes\DungeonRouteAffixesColumnHandler;
 use App\Logic\Datatables\ColumnHandler\DungeonRoutes\DungeonRouteAttributesColumnHandler;
 use App\Logic\Datatables\ColumnHandler\DungeonRoutes\EnemyForcesColumnHandler;
+use App\Logic\Datatables\ColumnHandler\DungeonRoutes\KeystoneLevelColumnHandler;
 use App\Logic\Datatables\ColumnHandler\DungeonRoutes\RatingColumnHandler;
 use App\Logic\Datatables\ColumnHandler\DungeonRoutes\ViewsColumnHandler;
 use App\Logic\Datatables\DungeonRoutesDatatablesHandler;
@@ -181,7 +182,10 @@ class APIDungeonRouteController extends Controller
             // Allow sorting by views
             new ViewsColumnHandler($dtHandler),
             // Allow sorting by rating
-            new RatingColumnHandler($dtHandler)
+            new RatingColumnHandler($dtHandler),
+            // Allow sorting by keystone level
+            new KeystoneLevelColumnHandler($dtHandler),
+
         ])->applyRequestToBuilder()->getResult();
     }
 

--- a/app/Http/Requests/DungeonRouteFormRequest.php
+++ b/app/Http/Requests/DungeonRouteFormRequest.php
@@ -34,6 +34,7 @@ class DungeonRouteFormRequest extends FormRequest
             'teeming' => 'nullable|int',
             'template' => 'nullable|int',
             'seasonal_index' => 'int',
+            'keystone_level' => 'int|min:2|max:30',
 
             'faction_id' => ['required', Rule::exists('factions', 'id'), new SiegeOfBoralusFactionRule($this->request)],
 

--- a/app/Models/DungeonRoute.php
+++ b/app/Models/DungeonRoute.php
@@ -37,6 +37,7 @@ use Illuminate\Support\Facades\DB;
  * @property $published boolean
  * @property $unlisted boolean
  * @property $demo boolean
+ * @property $keystone_level int
  *
  * @property $setup array
  * @property $avg_rating double
@@ -531,6 +532,7 @@ class DungeonRoute extends Model
 
         $this->pull_gradient = $request->get('pull_gradient', '');
         $this->pull_gradient_apply_always = (int)$request->get('pull_gradient_apply_always', 0);
+        $this->keystone_level = $request->get('keystone_level', 2);
 
         if (Auth::check()) {
             $user = User::findOrFail(Auth::id());
@@ -677,6 +679,7 @@ class DungeonRoute extends Model
         $dungeonroute->seasonal_index = $this->seasonal_index;
         $dungeonroute->teeming = $this->teeming;
         $dungeonroute->published = $published;
+        $dungeonroute->keystone_level = $this->keystone_level;
         $dungeonroute->save();
 
         // Clone the relations of this route into the new route.

--- a/resources/assets/js/custom/inline/dungeonroute/edit.js
+++ b/resources/assets/js/custom/inline/dungeonroute/edit.js
@@ -77,6 +77,7 @@ class DungeonrouteEdit extends InlineCode {
                 attributes: $('#attributes').val(),
                 faction_id: $('#faction_id').val(),
                 seasonal_index: $('#seasonal_index').val(),
+                keystone_level: $('#keystone_level').val(),
                 specialization:
                     $('.specializationselect select').map(function () {
                         return $(this).val();

--- a/resources/assets/js/custom/inline/dungeonroute/table.js
+++ b/resources/assets/js/custom/inline/dungeonroute/table.js
@@ -32,7 +32,7 @@ class DungeonrouteTable extends InlineCode {
             }
             let affixes = $('#affixes').val();
             let attributes = $('#attributes').val();
-
+            let keystone_level = $('#keystone_level').val();
             // Find wherever the columns are we're looking for, then filter using them
             // https://stackoverflow.com/questions/32598279/how-to-get-name-of-datatable-column
             $.each(self._dt.settings().init().columns, function (index, value) {
@@ -42,6 +42,8 @@ class DungeonrouteTable extends InlineCode {
                     self._dt.column(index).search(affixes);
                 } else if (value.name === 'routeattributes.name') {
                     self._dt.column(index).search(attributes);
+                } else if (value.name === 'keystone_level') {
+                    self._dt.column(index).search(keystone_level);
                 }
             });
             self._dt.draw();
@@ -142,7 +144,7 @@ class DungeonrouteTable extends InlineCode {
             'lengthMenu': [25],
             'bLengthChange': false,
             // Order by affixes by default
-            'order': [[1 + (self._viewMode === 'biglist' ? 1 : 0), 'asc']],
+            'order': [[2 + (self._viewMode === 'biglist' ? 1 : 0), 'asc']],
             'columns': self._getColumns(),
             'language': {
                 'emptyTable': lang.get('messages.datatable_no_routes_in_table')
@@ -239,6 +241,14 @@ class DungeonrouteTable extends InlineCode {
                 'title': lang.get('messages.dungeon_label'),
                 'data': 'dungeon.name',
                 'name': 'dungeon_id',
+                'render': function (data, type, row, meta) {
+                    return data;
+                },
+            },
+            keystone_level: {
+                'title': lang.get('messages.keystone_level_label'),
+                'data': 'keystone_level',
+                'name': 'keystone_level',
                 'render': function (data, type, row, meta) {
                     return data;
                 },

--- a/resources/assets/js/custom/inline/dungeonroute/tableview.js
+++ b/resources/assets/js/custom/inline/dungeonroute/tableview.js
@@ -28,6 +28,7 @@ class RoutesTableView extends TableView {
         this._columns = {
             list: [
                 {name: 'dungeon', width: '15%'},
+                {name: 'keystone_level', width: '5%'},
                 {name: 'affixes', width: '15%'},
                 {name: 'attributes', width: '15%'},
                 {name: 'setup', width: '15%'},
@@ -39,6 +40,7 @@ class RoutesTableView extends TableView {
             biglist: [
                 {name: 'preview', width: '15%', clickable: false},
                 {name: 'dungeon', width: '13%', className: 'd-none d-md-table-cell'},
+                {name: 'keystone_level', width: '5%'},
                 {name: 'features', width: '20%'},
                 {name: 'author', width: '10%'},
                 {name: 'enemy_forces', width: '5%'},
@@ -61,6 +63,7 @@ class ProfileTableView extends TableView {
             list: [
                 {name: 'title', width: '15%'},
                 {name: 'dungeon', width: '15%'},
+                {name: 'keystone_level', width: '5%'},
                 {name: 'affixes', width: '15%', className: 'd-none d-lg-table-cell'},
                 {name: 'attributes', width: '15%', className: 'd-none d-lg-table-cell'},
                 // {name: 'setup', width: '15%', className: 'd-none d-lg-table-cell'},
@@ -71,6 +74,7 @@ class ProfileTableView extends TableView {
                 {name: 'preview', width: '15%', clickable: false},
                 {name: 'title', width: '15%'},
                 {name: 'dungeon', width: '13%', className: 'd-none d-md-table-cell'},
+                {name: 'keystone_level', width: '5%'},
                 {name: 'features', width: '25%'},
                 {name: 'actions', width: '7%', clickable: false},
             ]

--- a/resources/lang/en/js.php
+++ b/resources/lang/en/js.php
@@ -327,6 +327,7 @@ return [
     'preview_label'      => 'Preview',
     'title_label'        => 'Title',
     'dungeon_label'      => 'Dungeon',
+    'keystone_level_label'  => 'Keystone Level',
     'features_label'     => 'Features',
     // 'affixes_label' => 'Affixes',
     // 'attributes_label' => 'Attributes',

--- a/resources/views/common/dungeonroute/table.blade.php
+++ b/resources/views/common/dungeonroute/table.blade.php
@@ -70,6 +70,10 @@ $cookieViewMode = isset($_COOKIE['routes_viewmode']) &&
             'data-count-selected-text' => __('{0} affixes selected')]) !!}
     </div>
     <div class="col-lg pl-1 pr-1">
+        {!! Form::label('keystone_level', __('Keystone level')) !!}
+        {!! Form::select('keystone_level', array_combine(range(2,30), range(2,30)), 10, ['class' => 'form-control selectpicker', 'id' => 'keystone_level']) !!}
+    </div>
+    <div class="col-lg pl-1 pr-1">
         @include('common.dungeonroute.attributes', [
         'selectedIds' => array_merge( [-1], \App\Models\RouteAttribute::all()->pluck('id')->toArray() ),
         'showNoAttributes' => true])

--- a/resources/views/common/maps/editsidebar.blade.php
+++ b/resources/views/common/maps/editsidebar.blade.php
@@ -322,6 +322,17 @@ if (\Illuminate\Support\Facades\Auth::check()) {
 {{--                </label>--}}
 {{--                {!! Form::checkbox('teeming', 1, $model->teeming, ['id' => 'teeming', 'class' => 'form-control left_checkbox']) !!}--}}
             </div>
+
+            <div class="form-group">
+                <label for="keystone_level">
+                    {{ __('Keystone Level') }}<span class="form-required">*</span>
+                    <i class="fas fa-info-circle" data-toggle="tooltip" title="{{
+                    __('For which keystone level is the route planned for?')
+                     }}"></i>
+                </label>
+                {!! Form::select('keystone_level', array_combine(range(2,30), range(2,30)), $model->keystone_level, ['class' => 'form-control selectpicker', 'id' => 'keystone_level']) !!}
+            </div>
+
             @include('common.dungeonroute.attributes', ['dungeonroute' => $model])
 
             <h3 class='mt-1'>

--- a/resources/views/common/maps/viewsidebar.blade.php
+++ b/resources/views/common/maps/viewsidebar.blade.php
@@ -64,6 +64,14 @@ $floorSelection = (!isset($floorSelect) || $floorSelect) && $model->dungeon->flo
 {{--                    </div>--}}
 {{--                </div>--}}
                 <div class="row view_dungeonroute_details_row mt-2">
+                    <div class="col-5 col-md-6 font-weight-bold">
+                        {{ __('Key Level') }}:
+                    </div>
+                    <div class="col-7 col-md-6">
+                        {{ $model->keystone_level }}
+                    </div>
+                </div>
+                <div class="row view_dungeonroute_details_row mt-2">
                     <div class="col font-weight-bold">
                         {{ __('Group setup') }}:
                     </div>

--- a/resources/views/dungeonroute/new.blade.php
+++ b/resources/views/dungeonroute/new.blade.php
@@ -49,6 +49,16 @@ $defaultSelectedAffixes = old('affixes') ?? [$currentAffixGroup->id];
 {{--            </label>--}}
 {{--            {!! Form::checkbox('template', 1, 0, ['class' => 'form-control left_checkbox']) !!}--}}
 {{--        </div>--}}
+        <div class="form-group">
+            <label for="keystone_level">
+                {{ __('Keystone Level') }}<span class="form-required">*</span>
+                <i class="fas fa-info-circle" data-toggle="tooltip" title="{{
+                    __('For which keystone level is the route planned for?')
+                     }}"></i>
+            </label>
+            {!! Form::select('keystone_level', array_combine(range(2,30), range(2,30)), 10, ['class' => 'form-control selectpicker']) !!}
+        </div>
+
         <h3>
             {{ __('Affixes') }} <span class="form-required">*</span>
         </h3>


### PR DESCRIPTION
I implemented the Keystone level on dungeon routes.

It defaults to a 10, the level list is from 2 to 30.

The next best feature to add for this would be to hide the affix in the table that are not active on that key level (Example only Tyrannical on a +2). Didn't find yet how to do it.

I'm greatman on the discord server if you want to chat :)

New page:
![image](https://user-images.githubusercontent.com/95754/103449500-f11d1900-4c76-11eb-8aa7-54574fd7fece.png)

Edit page:
![image](https://user-images.githubusercontent.com/95754/103449412-080f3b80-4c76-11eb-910a-0ba9fe572482.png)

Search Page (It does a >=):
![image](https://user-images.githubusercontent.com/95754/103449502-fe3a0800-4c76-11eb-933b-e4caf2153a60.png)
