### PR TITLE
Release v6.4.8 - Fixed incorrect season detection for some S2 dungeons

### DIFF
--- a/app/Models/Expansion.php
+++ b/app/Models/Expansion.php
@@ -28,8 +28,8 @@ use Illuminate\Support\Collection;
  *
  * @property Collection|Dungeon[] $dungeons
  * @property TimewalkingEvent|null $timewalkingevent
- * @property Season|null $currentseason
- * @property Season|null $nextseason
+ * @property Season|null $currentSeason
+ * @property Season|null $nextSeason
  *
  * @mixin Eloquent
  */
@@ -108,11 +108,15 @@ class Expansion extends CacheModel
     /**
      * @return HasOne
      */
-    public function currentseason(): HasOne
+    public function currentSeason(): HasOne
     {
+        $region = GameServerRegion::getUserOrDefaultRegion();
+
         return $this->hasOne(Season::class)
             ->where('expansion_id', $this->id)
-            ->where('start', '<', $this->getUserNow())
+            ->whereRaw('DATE_ADD(DATE_ADD(`start`, INTERVAL ? day), INTERVAL ? hour) < ?',
+                [$region->reset_day_offset, $region->reset_hours_offset, $this->getUserNow()]
+            )
             ->orderBy('start', 'desc')
             ->limit(1);
     }
@@ -120,11 +124,15 @@ class Expansion extends CacheModel
     /**
      * @return HasOne
      */
-    public function nextseason(): HasOne
+    public function nextSeason(): HasOne
     {
+        $region = GameServerRegion::getUserOrDefaultRegion();
+
         return $this->hasOne(Season::class)
             ->where('expansion_id', $this->id)
-            ->where('start', '>=', $this->getUserNow())
+            ->whereRaw('DATE_ADD(DATE_ADD(`start`, INTERVAL ? day), INTERVAL ? hour) >= ?',
+                [$region->reset_day_offset, $region->reset_hours_offset, $this->getUserNow()]
+            )
             ->orderBy('start')
             ->limit(1);
     }

--- a/app/Service/Expansion/ExpansionService.php
+++ b/app/Service/Expansion/ExpansionService.php
@@ -52,7 +52,7 @@ class ExpansionService implements ExpansionServiceInterface
      */
     public function getCurrentSeason(Expansion $expansion): ?Season
     {
-        return $expansion->currentseason;
+        return $expansion->currentSeason;
     }
 
     /**

--- a/app/Service/Season/SeasonService.php
+++ b/app/Service/Season/SeasonService.php
@@ -152,7 +152,7 @@ class SeasonService implements SeasonServiceInterface
             $expansion = $this->expansionService->getCurrentExpansion();
         }
 
-        return $expansion->nextseason;
+        return $expansion->nextSeason;
     }
 
     /**

--- a/app/Service/Season/SeasonService.php
+++ b/app/Service/Season/SeasonService.php
@@ -172,11 +172,6 @@ class SeasonService implements SeasonServiceInterface
         $seasonStart = $season->start($region);
 
         if ($seasonStart->gt($date)) {
-
-            dd($region);
-
-//            dd($season, $seasonStart->toDateTimeString(), $date->toDateTimeString());
-
             throw new Exception('Season at calculation is wrong; cannot find the affix group at a specific time
             because the season start date is past the target date!');
         }

--- a/app/Service/View/ViewService.php
+++ b/app/Service/View/ViewService.php
@@ -69,10 +69,10 @@ class ViewService implements ViewServiceInterface
                 ->where('active', true);
 
             $currentExpansion = $this->expansionService->getCurrentExpansion();
-            $currentSeason    = $currentExpansion->currentseason;
+            $currentSeason    = $currentExpansion->currentSeason;
 
             $nextExpansion = $this->expansionService->getNextExpansion() ?? $currentExpansion;
-            $nextSeason    = $nextExpansion->nextseason;
+            $nextSeason    = $nextExpansion->nextSeason;
 
             /** @var Release $latestRelease */
             $latestRelease          = Release::latest()->first();

--- a/database/seeders/releases/v6.4.8.json
+++ b/database/seeders/releases/v6.4.8.json
@@ -1,0 +1,28 @@
+{
+    "id": 170,
+    "release_changelog_id": 177,
+    "version": "v6.4.8",
+    "title": "Fixed incorrect season detection for some S2 dungeons",
+    "silent": 0,
+    "spotlight": 0,
+    "created_at": "2023-05-08T09:37:26+00:00",
+    "updated_at": "2023-05-08T09:37:26+00:00",
+    "changelog": {
+        "id": 177,
+        "release_id": 170,
+        "description": null,
+        "changes": [
+            {
+                "release_changelog_id": 177,
+                "release_changelog_category_id": 5,
+                "ticket_id": 1685,
+                "change": "Calculation for when the current\/next season is for certain dungeons was incorrect and did not take into account timezones etc.",
+                "category": {
+                    "id": 5,
+                    "key": "bugfixes",
+                    "name": "releasechangelogcategories.bugfixes"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Bugfixes:
  * #1685 Calculation for when the current/next season is for certain dungeons was incorrect and did not take into account timezones etc.