### PR TITLE
#3371 Git worktree + isolated Docker stack workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,21 @@ Branch formats are as follows:
 
 - The project is under Git version control.
 - Any newly created files should be staged.
-- Commits should not be done unless explicitly asked.
+- In the main checkout, commits should not be done unless explicitly asked (see the worktree
+  exception below).
+
+### Git worktrees
+- By default, do every task from an isolated git worktree with its own Docker `app` stack, created
+  with `sh/worktree.sh create <issue>-<slug>`. Run all commands (artisan, tests, `composer run
+  fix`/`analyse`) through that worktree's `app` container from inside the worktree dir, and tear it
+  down with `sh/worktree.sh remove <issue>-<slug>` when done. Only skip this when the user says to
+  work directly in the main checkout.
+- **The worktree and its branch are yours: you may commit, push, and open a MR without asking.**
+  Commit as you go, push the branch with `sh/worktree.sh push` (uses a scoped write deploy key so no
+  password is prompted), and open the MR to `development` with `gh`. This autonomy applies only to a
+  worktree you created — in the main checkout, still ask before committing.
+- The worktree shares the main stack's database/redis, so keep migrations non-destructive and never
+  run `migrate:fresh`/`migrate:refresh` in a worktree. See the `worktree-docker` skill for details.
 
 ## Github
 

--- a/.claude/skills/worktree-docker/SKILL.md
+++ b/.claude/skills/worktree-docker/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: worktree-docker
+description: Use when starting a task that should run in an isolated git worktree with its own Docker app stack, or when the user mentions worktrees, parallel branches, or running multiple checkouts side by side. Covers sh/worktree.sh (create/down/remove/list), how the isolated stack shares the main DB/redis, and how to run artisan/tests inside it. Do not use for the main development stack or generic docker-compose questions.
+---
+
+# Worktree + Docker stack
+
+Run each task in its own git **worktree** with a minimal Docker stack (`app` + `nginx`) that shares
+the main stack's database, redis, reverb, etc. This lets parallel agents work without colliding.
+
+By default, **every task starts in a fresh worktree** created with `sh/worktree.sh` (see the "Git
+worktrees" rule in `.claude/CLAUDE.md`), unless the user says otherwise.
+
+## Prerequisite
+
+The **main stack must be running** — the worktree attaches to its shared containers/network. If it
+isn't, start it from the main repo: `docker compose up -d`.
+
+## Create a worktree
+
+```bash
+sh/worktree.sh create <issue>-<slug>            # branches off origin/development
+sh/worktree.sh create <issue>-<slug> <base-ref> # or off an explicit base
+```
+
+This creates the worktree at `../keystone.guru-worktrees/<issue>-<slug>`, copies the main `.env`
+(never read — a plain shell `cp`), rewrites only `APP_URL`/`URL_HOST` to the worktree's port,
+appends `COMPOSE_PROJECT_NAME` / `COMPOSE_FILE` / `WORKTREE_HTTP_PORT` to that copy, starts the
+stack, wires up the shared services, and prints the URL (e.g. `http://localhost:8100`).
+
+## Run commands in the worktree
+
+From **inside the worktree dir**, the normal project command pattern just works — `COMPOSE_FILE`
+and `COMPOSE_PROJECT_NAME` come from the worktree `.env`, so no extra flags are needed:
+
+```bash
+cd ../keystone.guru-worktrees/<issue>-<slug>
+docker compose exec -T app php artisan <cmd>
+docker compose exec -T app php artisan test --compact --filter=<name>
+docker compose exec -T app composer run fix
+docker compose exec -T app composer run analyse
+```
+
+Open `http://localhost:<port>` in a browser to view the worktree's front-end.
+
+## How the isolation works
+
+- The stack (`docker-compose.worktree.yml`) reuses the prebuilt `keystone.guru` image and
+  bind-mounts the worktree checkout — **no rebuild**.
+- Each worktree runs on its **own private network**. The worktree `app` is intentionally NOT put on
+  the main shared network (that would clash with the main `app` DNS alias and let the main nginx
+  serve worktree code). Instead `sh/worktree.sh` attaches the shared containers (`db`,
+  `db-combatlog`, `redis`, `reverb`, `app-assets`, `opensearch-node1`, `influxdb`) INTO the
+  worktree network with matching aliases — so the copied `.env` needs no host changes and the main
+  stack stays untouched.
+
+## Shared database — keep migrations non-destructive
+
+All worktrees and your main app share the single `keystone.guru.dev` schema (tests run against it;
+there is no `RefreshDatabase`). A migration in one worktree affects everyone, so:
+
+- Keep migrations **non-destructive** (project policy: only drop a column in a follow-up ticket once
+  the code no longer uses it and is deployed).
+- **Never** run `migrate:fresh` / `migrate:refresh` in a worktree — it wipes the shared DB.
+
+## Horizon (opt-in — only when changing queue workers)
+
+Redis is shared, so a worktree Horizon competes with the main one for jobs. While iterating:
+
+```bash
+# from the MAIN repo: pause the main worker so it doesn't steal your jobs
+docker compose -p keystoneguru stop horizon
+# in the worktree: run the worker against your code
+docker compose exec -T app php artisan horizon        # or: php artisan queue:work --once
+# when done, restart the main worker
+docker compose -p keystoneguru start horizon
+```
+
+## Cron (opt-in — rarely needed)
+
+Cron just runs artisan commands, so test the specific command directly in the worktree app
+(`php artisan <command>`), rather than spinning up a `cron` container.
+
+## Commit, push & open a MR (autonomous)
+
+The worktree and its branch are yours — commit as you go, then push and open a MR without asking:
+
+```bash
+# from inside the worktree
+git add -A && git commit -m "#<issue> <what changed>"
+sh/worktree.sh push                         # pushes the current branch via the scoped deploy key
+gh pr create --repo RaiderIO/keystone.guru --base development --head <issue>-<slug> \
+  --title "#<issue> <title>" --body "..."
+```
+
+`sh/worktree.sh push` uses a passphraseless **write deploy key** scoped to this repo
+(`~/.ssh/keystone_worktree_ed25519`, override with `KSG_WORKTREE_DEPLOY_KEY`) so no password is
+prompted. It runs `ssh -F /dev/null` to bypass `~/.ssh/config` (which maps github.com to a
+passphrase-protected key). Commits are SSH-signed with the existing (passphraseless) signing key, so
+signing is non-interactive too.
+
+To re-provision the deploy key (e.g. on a new machine): generate a passphraseless key and register it
+as a write deploy key —
+`gh api -X POST repos/RaiderIO/keystone.guru/keys -f title=claude-worktree-push -f key="$(cat ~/.ssh/keystone_worktree_ed25519.pub)" -F read_only=false`.
+
+## Tear down
+
+```bash
+sh/worktree.sh down   <issue>-<slug>   # stop the stack, keep the checkout
+sh/worktree.sh remove <issue>-<slug>   # stop the stack and remove the worktree
+sh/worktree.sh list                    # list worktrees and running stacks
+```

--- a/docker-compose.worktree.yml
+++ b/docker-compose.worktree.yml
@@ -1,0 +1,35 @@
+# Minimal per-worktree stack (app + nginx) for running an isolated checkout alongside the main
+# stack. Managed by sh/worktree.sh — see the `worktree-docker` skill for the full workflow.
+#
+# Design notes:
+# - No `container_name` here on purpose: Compose auto-names containers `<project>-<service>-1`,
+#   so each worktree (unique COMPOSE_PROJECT_NAME) gets its own non-colliding names.
+# - Reuses the prebuilt `keystone.guru` image (no `build:`), so starting a worktree never rebuilds.
+# - Runs on its OWN private default network. The worktree app is deliberately NOT placed on the
+#   main shared network — sh/worktree.sh instead attaches the shared service containers (db, redis,
+#   reverb, ...) INTO this private network with their DNS aliases. That keeps `nginx -> app`
+#   resolving to the worktree's own app and leaves the main stack completely untouched.
+# - nginx resolves every upstream in docker-compose/nginx/keystone.guru.conf at startup (app,
+#   reverb, app-swoole), so sh/worktree.sh attaches all of them. Note: the couple of octane-only
+#   endpoints proxied to `app-swoole` hit the MAIN stack's octane (main code), not the worktree —
+#   fine for browsing, but test swoole-endpoint changes by running your own octane if needed.
+services:
+  app:
+    image: keystone.guru
+    restart: "no"
+    working_dir: /var/www/
+    volumes:
+      - ./:/var/www
+      - ~/.ssh:/root/.ssh
+
+  nginx:
+    image: nginx:alpine
+    restart: "no"
+    working_dir: /var/www/
+    depends_on:
+      - app
+    volumes:
+      - ./:/var/www
+      - ./docker-compose/nginx:/etc/nginx/conf.d
+    ports:
+      - "${WORKTREE_HTTP_PORT}:80"

--- a/sh/worktree.sh
+++ b/sh/worktree.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+#
+# worktree.sh — manage isolated git worktrees, each with its own minimal Docker stack
+# (app + nginx) that shares the main stack's database/redis/etc.
+#
+# See the `worktree-docker` skill for the full workflow and rationale.
+#
+# Usage:
+#   sh/worktree.sh create <issue>-<slug> [base-ref]   # default base-ref: origin/development
+#   sh/worktree.sh down   <issue>-<slug>              # stop the stack, keep the checkout
+#   sh/worktree.sh remove <issue>-<slug>              # stop the stack and remove the worktree
+#   sh/worktree.sh list                               # list worktrees and their stacks
+#
+set -euo pipefail
+
+# The main stack's Compose project name and shared network (project name with dots stripped,
+# suffixed with the compose network key `keystone.guru`).
+MAIN_PROJECT="keystoneguru"
+SHARED_NET="${MAIN_PROJECT}_keystone.guru"
+
+# Shared service containers to attach into each worktree network, as "alias:container" pairs.
+# The alias matches the service DNS name the app expects (from .env), so no .env host rewrites.
+SHARED_SERVICES="
+db:keystone.guru-db-prod
+db-combatlog:keystone.guru-db-prod-combatlog
+redis:keystone.guru-redis
+reverb:keystone.guru-reverb
+app-swoole:keystone.guru-app-swoole
+app-assets:keystone.guru-app-assets
+opensearch-node1:keystone.guru-opensearch-node1
+influxdb:keystone.guru-influxdb
+"
+
+PORT_RANGE_START=8100
+PORT_RANGE_END=8199
+
+# Scoped, passphraseless deploy key (write access, RaiderIO/keystone.guru only) for non-interactive
+# pushes of worktree branches. `-F /dev/null` bypasses ~/.ssh/config, which maps github.com to a
+# passphrase-protected key that would otherwise hang on an askpass prompt.
+DEPLOY_KEY="${KSG_WORKTREE_DEPLOY_KEY:-$HOME/.ssh/keystone_worktree_ed25519}"
+WORKTREE_GIT_SSH="ssh -F /dev/null -i $DEPLOY_KEY -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+WORKTREES_DIR="$(dirname "$REPO_ROOT")/keystone.guru-worktrees"
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+sanitize() {
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_-' '-' | sed 's/-*$//'
+}
+
+project_name() {
+    printf 'ksg-%s' "$(sanitize "$1")"
+}
+
+port_in_use() {
+    ss -ltnH 2>/dev/null | awk '{print $4}' | sed 's/.*://' | grep -qx "$1"
+}
+
+find_free_port() {
+    local port
+    for port in $(seq "$PORT_RANGE_START" "$PORT_RANGE_END"); do
+        if ! port_in_use "$port"; then
+            printf '%s' "$port"
+            return 0
+        fi
+    done
+    die "no free host port in ${PORT_RANGE_START}-${PORT_RANGE_END}"
+}
+
+# Locate the private network Compose created for a project (robust against name sanitisation).
+worktree_network() {
+    docker network ls \
+        --filter "label=com.docker.compose.project=$1" \
+        --format '{{.Name}}' | head -n1
+}
+
+cmd_create() {
+    local branch="${1:-}"
+    local base="${2:-origin/development}"
+    [ -n "$branch" ] || die "usage: worktree.sh create <issue>-<slug> [base-ref]"
+
+    local project wt_path net port
+    project="$(project_name "$branch")"
+    wt_path="$WORKTREES_DIR/$branch"
+
+    # Guard: the main stack must be running so the shared network + containers exist.
+    docker network inspect "$SHARED_NET" >/dev/null 2>&1 \
+        || die "main stack network '$SHARED_NET' not found — start the main stack first (docker compose up -d)"
+    [ -f "$REPO_ROOT/.env" ] || die "no .env in main repo ($REPO_ROOT) to copy"
+
+    # 1. Create the worktree (reuse existing branch if present, else branch off base).
+    if [ -d "$wt_path" ]; then
+        echo "==> worktree dir already exists: $wt_path"
+    else
+        mkdir -p "$WORKTREES_DIR"
+        git -C "$REPO_ROOT" fetch origin --quiet 2>/dev/null || true
+        if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch"; then
+            echo "==> adding worktree for existing branch '$branch'"
+            git -C "$REPO_ROOT" worktree add "$wt_path" "$branch"
+        else
+            echo "==> adding worktree '$branch' off '$base'"
+            git -C "$REPO_ROOT" worktree add "$wt_path" -b "$branch" "$base"
+        fi
+    fi
+
+    # 2. Copy the main .env verbatim (shell copy — contents are never read).
+    cp "$REPO_ROOT/.env" "$wt_path/.env"
+
+    # 2b. Bootstrap: if the base branch predates this file, seed it from the main repo so the
+    #     worktree can start. Only when missing — a worktree that legitimately edits it is untouched.
+    if [ ! -f "$wt_path/docker-compose.worktree.yml" ]; then
+        echo "==> base branch lacks docker-compose.worktree.yml — copying from main repo"
+        cp "$REPO_ROOT/docker-compose.worktree.yml" "$wt_path/docker-compose.worktree.yml"
+    fi
+
+    # 2c. Seed git-ignored build artifacts from the main checkout when missing. vendor/ is required
+    #     to boot artisan; the public/* assets let the browser render (blade mix() needs the
+    #     manifest). Each is an independent copy the worktree can rebuild if its deps/assets change.
+    echo "==> seeding build artifacts from main repo (vendor + compiled assets)"
+    [ -f "$REPO_ROOT/vendor/autoload.php" ] || die "main repo has no vendor/ — run composer install there first"
+    local rel
+    for rel in vendor version \
+        public/mix-manifest.json public/css public/js public/main.js public/resources \
+        public/vendor public/webfonts public/images \
+        public/VERSION public/COMMITHASH public/LASTCOMMITDATETIME; do
+        if [ -e "$REPO_ROOT/$rel" ] && [ ! -e "$wt_path/$rel" ]; then
+            cp -a "$REPO_ROOT/$rel" "$wt_path/$rel"
+            echo "  + $rel"
+        fi
+    done
+
+    # 3. Pick a free host port for this worktree's nginx.
+    port="$(find_free_port)"
+
+    # 4. Point URL vars at the worktree port (sed-replace: phpdotenv keeps the FIRST occurrence,
+    #    so appending would not override), then append the Compose wiring. Only the worktree's
+    #    own copy is touched.
+    sed -i -E \
+        -e "s#^APP_URL=.*#APP_URL=http://localhost:${port}#" \
+        -e "s#^URL_HOST=.*#URL_HOST=http://localhost:${port}#" \
+        "$wt_path/.env"
+    cat >> "$wt_path/.env" <<EOF
+
+# --- added by sh/worktree.sh (worktree: ${branch}) ---
+COMPOSE_PROJECT_NAME=${project}
+COMPOSE_FILE=docker-compose.worktree.yml
+WORKTREE_HTTP_PORT=${port}
+EOF
+
+    # 5. Bring up the stack (reads COMPOSE_* + WORKTREE_HTTP_PORT from the worktree .env).
+    echo "==> starting stack '$project' (nginx on :$port)"
+    ( cd "$wt_path" && docker compose up -d )
+
+    # 6. Attach the shared service containers into this worktree's private network with aliases.
+    net="$(worktree_network "$project")"
+    [ -n "$net" ] || die "could not find worktree network for project '$project'"
+    echo "==> attaching shared services to $net"
+    local pair alias container
+    for pair in $SHARED_SERVICES; do
+        alias="${pair%%:*}"
+        container="${pair#*:}"
+        if ! docker inspect "$container" >/dev/null 2>&1; then
+            echo "  ! $container not found — skipping (alias $alias)"
+            continue
+        fi
+        if docker network connect --alias "$alias" "$net" "$container" 2>/dev/null; then
+            echo "  + $container (alias: $alias)"
+        else
+            echo "  = $container already attached (alias: $alias)"
+        fi
+    done
+
+    # nginx resolves ALL upstreams (app, app-swoole, reverb) at startup and refuses to boot if any
+    # is missing, so it must be (re)started only after the shared services above are attached.
+    ( cd "$wt_path" && docker compose restart nginx >/dev/null 2>&1 ) || true
+
+    # 7. First-boot init inside the worktree app (shared DB is already migrated/seeded — no seed).
+    echo "==> initialising worktree app"
+    ( cd "$wt_path" && docker compose exec -T app sh -lc '
+        mkdir -p storage/app/public/imagecache storage/app/public/expansions storage/debugbar \
+                 storage/framework/cache storage/framework/sessions storage/framework/views storage/logs
+        # php-fpm serves as www-data, but storage/ and bootstrap/cache come from the checkout owned by
+        # the host user, so the web process cannot write logs/compiled-views/cache. Make them writable
+        # (mirrors docker_init.sh) — without this, web requests hang while failing to log warnings.
+        chown -R www-data:www-data storage bootstrap/cache
+        php artisan storage:link >/dev/null 2>&1 || true
+        php artisan config:clear >/dev/null 2>&1 || true
+    ' ) || echo "  ! init step reported an issue — check the app container"
+
+    cat <<EOF
+
+==> Worktree ready.
+    Branch:   $branch
+    Path:     $wt_path
+    Project:  $project
+    URL:      http://localhost:$port
+
+    Work in it:
+      cd $wt_path
+      docker compose exec -T app php artisan <cmd>
+      docker compose exec -T app php artisan test --compact --filter=<name>
+
+    Tear down when done:
+      $SCRIPT_DIR/worktree.sh remove $branch
+EOF
+}
+
+cmd_down() {
+    local branch="${1:-}"
+    [ -n "$branch" ] || die "usage: worktree.sh down <issue>-<slug>"
+    local project net wt_path pair container
+    project="$(project_name "$branch")"
+    wt_path="$WORKTREES_DIR/$branch"
+    net="$(worktree_network "$project")"
+
+    # Disconnect the attached shared containers first — otherwise Compose cannot remove the network
+    # (it's still "in use") and it lingers.
+    if [ -n "$net" ]; then
+        for pair in $SHARED_SERVICES; do
+            container="${pair#*:}"
+            docker network disconnect -f "$net" "$container" 2>/dev/null || true
+        done
+    fi
+
+    if [ -d "$wt_path" ]; then
+        ( cd "$wt_path" && docker compose down )
+    else
+        # No checkout left; tear down by project name (dummy port satisfies interpolation).
+        WORKTREE_HTTP_PORT=0 docker compose -p "$project" \
+            -f "$REPO_ROOT/docker-compose.worktree.yml" down 2>/dev/null || true
+    fi
+    # Remove the network if Compose left it behind.
+    [ -n "$net" ] && docker network rm "$net" >/dev/null 2>&1 || true
+    echo "==> stack '$project' stopped"
+}
+
+cmd_remove() {
+    local branch="${1:-}"
+    [ -n "$branch" ] || die "usage: worktree.sh remove <issue>-<slug>"
+    local wt_path="$WORKTREES_DIR/$branch"
+
+    if [ ! -d "$wt_path" ]; then
+        cmd_down "$branch"
+        echo "==> no worktree checkout at $wt_path"
+        return 0
+    fi
+    # Seeded build artifacts (vendor/, public/*, version) are untracked and expected, so they must
+    # not block removal — but genuine uncommitted changes to TRACKED files should.
+    if [ -n "$(git -C "$wt_path" status --porcelain --untracked-files=no)" ]; then
+        die "worktree '$branch' has uncommitted changes to tracked files — commit/stash first, or force:
+       git -C $REPO_ROOT worktree remove --force $wt_path"
+    fi
+    cmd_down "$branch"
+
+    # Containers ran as root/www-data and wrote files (storage, bootstrap/cache, .phpunit.cache, ...)
+    # the host user can't delete. Restore host ownership of the whole worktree via a root container
+    # (reusing the always-present keystone.guru image) so git worktree remove can delete it.
+    docker run --rm -v "$WORKTREES_DIR:/wt" keystone.guru \
+        chown -R "$(id -u):$(id -g)" "/wt/$branch" >/dev/null 2>&1 || true
+
+    git -C "$REPO_ROOT" worktree remove --force "$wt_path"
+    echo "==> worktree '$branch' removed"
+}
+
+cmd_push() {
+    [ -f "$DEPLOY_KEY" ] || die "deploy key not found at $DEPLOY_KEY — see the worktree-docker skill for setup"
+    local branch
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    [ -n "$branch" ] && [ "$branch" != "HEAD" ] || die "not on a branch (run from inside the worktree checkout)"
+    echo "==> pushing '$branch' with the scoped deploy key"
+    GIT_SSH_COMMAND="$WORKTREE_GIT_SSH" git push -u origin "$branch" "$@"
+}
+
+cmd_list() {
+    echo "== git worktrees =="
+    git -C "$REPO_ROOT" worktree list
+    echo
+    echo "== running worktree stacks =="
+    docker ps --filter "name=ksg-" \
+        --format 'table {{.Names}}\t{{.Ports}}\t{{.Status}}' || true
+}
+
+main() {
+    local cmd="${1:-}"
+    shift || true
+    case "$cmd" in
+        create) cmd_create "$@" ;;
+        down)   cmd_down "$@" ;;
+        remove) cmd_remove "$@" ;;
+        push)   cmd_push "$@" ;;
+        list)   cmd_list "$@" ;;
+        *)
+            cat >&2 <<EOF
+usage: worktree.sh <command> [args]
+
+  create <issue>-<slug> [base-ref]   create a worktree + isolated Docker stack (base: origin/development)
+  down   <issue>-<slug>              stop the stack, keep the checkout
+  remove <issue>-<slug>              stop the stack and remove the worktree
+  push   [git-push-args...]          push the current branch via the scoped deploy key
+  list                              list worktrees and running stacks
+EOF
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
Closes #3371.

Enables working from isolated git worktrees, each with its own minimal Docker `app` + `nginx` stack that shares the main stack's database/redis/reverb/etc. — so parallel work (e.g. multiple agents) doesn't collide.

## What's added
- **`docker-compose.worktree.yml`** — minimal `app` + `nginx` stack: no hardcoded `container_name`/ports, its own private network, reuses the prebuilt `keystone.guru` image (no rebuild).
- **`sh/worktree.sh`** — `create` / `down` / `remove` / `push` / `list`:
  - `create` branches off `origin/development`, copies the main `.env` (never read) and sets a unique `COMPOSE_PROJECT_NAME`/port, seeds git-ignored build artifacts (`vendor/`, compiled `public/*`, `version`) from the main checkout, attaches the shared service containers into the worktree network by DNS alias (so the copied `.env` needs no host rewrites), chowns `storage`/`bootstrap/cache` for the `www-data` fpm user, and restarts nginx after the upstreams are attached.
  - `down`/`remove` detach the shared containers first (so the network can be removed) and restore host file ownership before deleting.
  - `push` pushes the current branch via a scoped write **deploy key** for non-interactive pushes.
- **`.claude/skills/worktree-docker/`** — the workflow skill.
- **`.claude/CLAUDE.md`** — default to worktrees; commit/push/MR autonomy within a worktree.

## Isolation model
Each worktree runs on its own private network; the worktree `app` is deliberately **not** put on the main shared network (that would clash with the main `app` DNS alias and let the main nginx serve worktree code). Instead the shared containers are attached into the worktree network with aliases (`db`, `redis`, `reverb`, …). The main stack stays untouched.

## Verification
Full lifecycle validated against a throwaway worktree: `create` → `artisan` boots, shared DB reachable, web `/` + `/login` return 200 fast, `58` unit tests pass → `remove` → containers, network, and dir all gone; main stack unaffected throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)