### PR TITLE
#3376 Preserve demo dungeon routes on reseed via forceCreate

### DIFF
--- a/database/seeders/DungeonDataSeeder.php
+++ b/database/seeders/DungeonDataSeeder.php
@@ -439,7 +439,10 @@ class DungeonDataSeeder extends Seeder implements TableSeederInterface
             elseif ($mapping->getPostSaveRelationParsers()->isNotEmpty()) {
                 /** @var class-string<Model> $mappingClass */
                 $mappingClass = $mapping->getClass();
-                $createdModel = $mappingClass::from(DatabaseSeeder::getTempTableName($mappingClass))->create($modelData);
+                // forceCreate (not create) so non-$fillable columns exported by mapping:save are imported
+                // verbatim. DungeonRoute keeps demo, pull_gradient etc. out of $fillable to block user-facing
+                // mass assignment; dropping them here would silently reset demo routes to demo = false.
+                $createdModel = $mappingClass::from(DatabaseSeeder::getTempTableName($mappingClass))->forceCreate($modelData);
                 $updatedModels++;
             } // We don't need to do post-processing, add it to the list to be saved
             else {

--- a/tests/Feature/Database/Seeders/DungeonDataSeederTest.php
+++ b/tests/Feature/Database/Seeders/DungeonDataSeederTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Database\Seeders;
 
+use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Npc\NpcCharacteristic;
 use App\Models\Npc\NpcSpell;
 use App\Models\Spell\Spell;
@@ -104,5 +105,24 @@ final class DungeonDataSeederTest extends PublicTestCase
             NpcCharacteristic::query()->where('npc_id', self::SENTINEL_NPC_ID)->delete();
             SpellDungeon::query()->where('spell_id', self::SENTINEL_SPELL_ID)->delete();
         }
+    }
+
+    #[Test]
+    public function run_givenDemoDungeonRoutes_preservesDemoFlagAcrossReseed(): void
+    {
+        // Arrange - rollback() deletes every demo = true route and rebuilds them from the JSON files,
+        // which do contain demo routes, so a healthy re-seed must leave demo routes behind.
+
+        // Act
+        $this->artisan('db:seedone', ['className' => 'DungeonDataSeeder'])->assertSuccessful();
+
+        // Assert - the rebuild uses forceCreate() so the demo column (deliberately kept out of
+        // $fillable) is imported verbatim. With a plain create() mass assignment would drop demo and
+        // every rebuilt route would land as demo = false, dropping this count to zero (#3376).
+        $this->assertGreaterThan(
+            0,
+            DungeonRoute::query()->where('demo', true)->count(),
+            'Demo dungeon routes must survive a re-seed with demo = true',
+        );
     }
 }


### PR DESCRIPTION
Fixes #3376.

## Problem

`DungeonDataSeeder::rollback()` deletes every `demo = true` route and rebuilds them from each dungeon's `dungeonroutes.json`. The rebuild used a mass-assignment `create()`, which silently drops any column not in `DungeonRoute::$fillable` — including `demo` (only in `$hidden`), plus `pull_gradient`, `pull_gradient_apply_always`, `dungeon_difficulty` and `created_at`. So each demo route came back as `demo = false`, and `mapping:save` (which filters `demo = true`) then exported empty `dungeonroutes.json` files. Recurred for anyone running `db:seedone DungeonDataSeeder` (or the suite) against the shared dev DB.

## Fix

Switch that one `create()` to `forceCreate()`. This branch is reached **only** by DungeonRoute (it is the sole mapping with post-save relation parsers, and it is non-persistent so it never hits the `setRawAttributes()` branch), so the change is fully scoped to the seeder's trusted import path. It mirrors the `setRawAttributes()` bypass already used a few lines above in the `isPersistent()` branch, and imports every exported column verbatim.

`demo` stays out of `$fillable`, so no user-facing mass-assignment path can flip `demo = true` — the security concern raised in the issue is avoided (no `$fillable` change).

## The "full db:seed didn't reproduce it" puzzle

Confirmed the DungeonRoute code path is byte-identical for `db:seedone` and full `db:seed` (both go through `DatabaseSeeder::run()` → the same transaction → the same `create()` branch). There is no second code path by which a full seed could set `demo = 1` while `db:seedone` sets `demo = 0`; the pre-fix discrepancy was an environment/measurement artifact. It is moot after this fix.

## Verification (against the shared dev DB)

- `db:seedone DungeonDataSeeder` → `demo = 1` count holds at **36**; `bbzlbOX` has exactly one `demo = 1` row with its original `created_at` preserved.
- Full `db:seed` → `demo = 1` count holds at **36**.
- Reverting to `create()` drops the count to 0 (regression test fails), re-applying restores it.
- New regression test `run_givenDemoDungeonRoutes_preservesDemoFlagAcrossReseed` + existing `DungeonDataSeederTest` — 3 passed.
- `composer run fix` — 0 changes. `composer run analyse` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)