### PR TITLE
#2947 Fix heatmap IndexSizeError when map container has zero width

### DIFF
--- a/resources/assets/js/custom/dungeonmap.js
+++ b/resources/assets/js/custom/dungeonmap.js
@@ -45,6 +45,8 @@ class DungeonMap extends Signalable {
 
         /** @type Boolean */
         this._refreshingMap = false;
+        /** @type {?Number} requestAnimationFrame handle used while waiting for the map container to gain a non-zero size */
+        this._mapSizedRafId = null;
 
         this.options = options;
 
@@ -688,11 +690,44 @@ class DungeonMap extends Signalable {
     }
 
     /**
-     * Create instances of all controls that will be added to the map (UI on the map itself)
-     * @param editableLayers
-     * @returns {*[]}
+     * Runs the callback once the Leaflet map has a non-zero size, forcing a re-measure when the
+     * container was not laid out yet. Runs synchronously when the map is already sized.
+     * @param callback {Function}
      * @private
      */
+    _whenMapSized(callback) {
+        console.assert(this instanceof DungeonMap, 'this is not a DungeonMap', this);
+
+        // Cancel a gate still pending from a previous refresh so a stale callback never runs.
+        if (this._mapSizedRafId !== null) {
+            window.cancelAnimationFrame(this._mapSizedRafId);
+            this._mapSizedRafId = null;
+        }
+
+        // Fast path: Leaflet already knows a non-zero size (e.g. a floor change after first load).
+        if (this.leafletMap.getSize().x > 0) {
+            callback();
+
+            return;
+        }
+
+        let self = this;
+        let attempt = function () {
+            self._mapSizedRafId = null;
+
+            // Leaflet caches its size and only recomputes on invalidateSize(), so poll the container
+            // width directly to detect when the browser has actually laid the map out.
+            if (self.leafletMap.getContainer().clientWidth > 0) {
+                self.leafletMap.invalidateSize();
+                callback();
+            } else {
+                self._mapSizedRafId = window.requestAnimationFrame(attempt);
+            }
+        };
+
+        this._mapSizedRafId = window.requestAnimationFrame(attempt);
+    }
+
     _addMapControls(editableLayers) {
         console.assert(this instanceof DungeonMap, 'this is not a DungeonMap', this);
 
@@ -835,13 +870,18 @@ class DungeonMap extends Signalable {
             $('.leaflet-control-attribution').hide();
         }
 
-        for (let index in this.mapPlugins) {
-            this.mapPlugins[index].removeFromMap();
-        }
+        // Plugins such as the heatmap size their Leaflet layers to the map container. On first load the
+        // map initializes synchronously (DOMContentLoaded) before #map is laid out, so its size can be 0 —
+        // a canvas sized to 0 crashes (IndexSizeError). Defer (re)loading plugins until the map is sized.
+        this._whenMapSized(() => {
+            for (let index in this.mapPlugins) {
+                this.mapPlugins[index].removeFromMap();
+            }
 
-        for (let index in this.mapPlugins) {
-            this.mapPlugins[index].addToMap();
-        }
+            for (let index in this.mapPlugins) {
+                this.mapPlugins[index].addToMap();
+            }
+        });
 
         // Add new controls; we're all loaded now and user should now be able to edit their route
         this._addMapControls(this.editableLayers);
@@ -961,6 +1001,12 @@ class DungeonMap extends Signalable {
             );
         }
     }
+}
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = DungeonMap;
 }
 
 

--- a/resources/assets/js/custom/dungeonmap.test.js
+++ b/resources/assets/js/custom/dungeonmap.test.js
@@ -1,0 +1,77 @@
+// DungeonMap is a global-script class in the concatenated bundle; the only thing it needs at
+// module-load time is its base class `Signalable` (for `extends`). Stubbing that lets us require the
+// source. We exercise `_whenMapSized` on a bare prototype instance (Object.create) so none of the
+// heavy constructor (Leaflet map creation, event wiring) has to run.
+
+global.Signalable = class Signalable {
+};
+
+const DungeonMap = require('./dungeonmap');
+
+/**
+ * Builds a minimal object that satisfies `_whenMapSized`: the `_mapSizedRafId` field, a fake
+ * leafletMap, and a controllable requestAnimationFrame queue.
+ * @param options {{mapSizeX?: Number, containerWidth?: Number}}
+ */
+function createGate({mapSizeX = 0, containerWidth = 0} = {}) {
+    const size = {x: mapSizeX, y: 100};
+    const container = {clientWidth: containerWidth};
+
+    const map = Object.create(DungeonMap.prototype);
+    map._mapSizedRafId = null;
+    map.leafletMap = {
+        getSize: () => size,
+        getContainer: () => container,
+        invalidateSize: vi.fn(),
+    };
+
+    const rafCallbacks = [];
+    window.requestAnimationFrame = vi.fn((callback) => {
+        rafCallbacks.push(callback);
+
+        return rafCallbacks.length;
+    });
+    window.cancelAnimationFrame = vi.fn();
+
+    return {map, size, container, rafCallbacks};
+}
+
+describe('DungeonMap._whenMapSized', () => {
+    it('whenMapSized_givenSizedMap_runsCallbackSynchronously', () => {
+        const {map} = createGate({mapSizeX: 500});
+        const callback = vi.fn();
+
+        map._whenMapSized(callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+        expect(map.leafletMap.invalidateSize).not.toHaveBeenCalled();
+    });
+
+    it('whenMapSized_givenZeroSizeUntilLaidOut_invalidatesSizeThenRunsCallback', () => {
+        const {map, container, rafCallbacks} = createGate({mapSizeX: 0, containerWidth: 0});
+        const callback = vi.fn();
+
+        map._whenMapSized(callback);
+
+        // Still zero width: the first frame reschedules instead of running the callback.
+        rafCallbacks.shift()();
+        expect(callback).not.toHaveBeenCalled();
+
+        // The container is laid out; the next frame invalidates the size and runs the callback.
+        container.clientWidth = 500;
+        rafCallbacks.shift()();
+
+        expect(map.leafletMap.invalidateSize).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('whenMapSized_givenPendingGate_cancelsPreviousFrame', () => {
+        const {map} = createGate({mapSizeX: 0, containerWidth: 0});
+
+        map._whenMapSized(vi.fn());
+        map._whenMapSized(vi.fn());
+
+        expect(window.cancelAnimationFrame).toHaveBeenCalledTimes(1);
+    });
+});

--- a/resources/assets/js/custom/mapplugins/heatplugin.js
+++ b/resources/assets/js/custom/mapplugins/heatplugin.js
@@ -6,6 +6,8 @@ class HeatPlugin extends MapPlugin {
 
         this.hidden = false;
         this.heatLayer = null;
+        /** The requestAnimationFrame handle used while we wait for the map container to gain a non-zero size */
+        this._deferredAddHeatLayerRafId = null;
         this.draw = false;
         /** A grid of weights for each coordinate for each floor - used for the tooltips */
         this.weightByFloorIdGrid = [];
@@ -147,6 +149,13 @@ class HeatPlugin extends MapPlugin {
             return;
         }
 
+        // The heat layer may not exist yet when its addition was deferred until the map container
+        // gained a non-zero size. The data is retained in rawLatLngsByFloorId and re-applied once
+        // the layer is created (see _deferAddHeatLayer).
+        if (this.heatLayer === null) {
+            return;
+        }
+
         let result = [];
         if (this.rawLatLngsByFloorId.hasOwnProperty(floorId)) {
             result = this.rawLatLngsByFloorId[floorId];
@@ -167,9 +176,15 @@ class HeatPlugin extends MapPlugin {
             return;
         }
 
-        this.heatLayer = L.heatLayer([], $.extend({}, c.map.heatmapSettings));
-
-        this.heatLayer.addTo(this.map.leafletMap);
+        // The #map container may still have zero width when the map initializes (for example when it
+        // was hidden and then shown). Leaflet.heat sizes its canvas to the map's size; a zero width makes
+        // simpleheat call getImageData(0, ...) which throws an IndexSizeError. Only add the layer once the
+        // map has a non-zero size, deferring until the container has been laid out if necessary.
+        if (this.map.leafletMap.getSize().x > 0) {
+            this._addHeatLayer();
+        } else {
+            this._deferAddHeatLayer();
+        }
         // let self = this;
         // Debug function that adds latLngs to your mouse location as you move around
         // this.map.leafletMap.on({
@@ -187,8 +202,48 @@ class HeatPlugin extends MapPlugin {
         // });
     }
 
+    _addHeatLayer() {
+        console.assert(this instanceof HeatPlugin, 'this is not an instance of HeatPlugin', this);
+
+        this.heatLayer = L.heatLayer([], $.extend({}, c.map.heatmapSettings));
+
+        this.heatLayer.addTo(this.map.leafletMap);
+    }
+
+    _deferAddHeatLayer() {
+        console.assert(this instanceof HeatPlugin, 'this is not an instance of HeatPlugin', this);
+
+        // Guard against stacking multiple deferrals if addToMap() is somehow called again while one is pending.
+        if (this._deferredAddHeatLayerRafId !== null) {
+            window.cancelAnimationFrame(this._deferredAddHeatLayerRafId);
+        }
+
+        let self = this;
+        let attempt = function () {
+            self._deferredAddHeatLayerRafId = null;
+
+            // Leaflet caches the map size and only recomputes it on invalidateSize(), so polling getSize()
+            // would keep returning the stale zero. Read the container width directly to detect when the
+            // container has actually been laid out, then force Leaflet to re-measure before adding the layer.
+            if (self.map.leafletMap.getContainer().clientWidth > 0) {
+                self.map.leafletMap.invalidateSize();
+                self._addHeatLayer();
+                // The floor data may have arrived while we were waiting, so (re)apply it now.
+                self._applyLatLngsForFloor(getState().getCurrentFloor().id);
+            } else {
+                self._deferredAddHeatLayerRafId = window.requestAnimationFrame(attempt);
+            }
+        };
+
+        this._deferredAddHeatLayerRafId = window.requestAnimationFrame(attempt);
+    }
+
     setOptions(options) {
         console.assert(this instanceof HeatPlugin, 'this is not an instance of HeatPlugin', this);
+
+        if (this.heatLayer === null) {
+            return;
+        }
 
         this.heatLayer.setOptions(options);
     }
@@ -198,6 +253,13 @@ class HeatPlugin extends MapPlugin {
 
         if (!this.isEnabled()) {
             return;
+        }
+
+        // Cancel any pending deferred add so a queued frame doesn't add an orphaned layer after removal.
+        // refreshLeafletMap() removes and re-adds all plugins, which can otherwise leave duplicate layers.
+        if (this._deferredAddHeatLayerRafId !== null) {
+            window.cancelAnimationFrame(this._deferredAddHeatLayerRafId);
+            this._deferredAddHeatLayerRafId = null;
         }
 
         if (this.heatLayer !== null) {
@@ -277,4 +339,10 @@ class HeatPlugin extends MapPlugin {
 
         this.setLatLngs([]);
     }
+}
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = HeatPlugin;
 }

--- a/resources/assets/js/custom/mapplugins/heatplugin.js
+++ b/resources/assets/js/custom/mapplugins/heatplugin.js
@@ -6,8 +6,6 @@ class HeatPlugin extends MapPlugin {
 
         this.hidden = false;
         this.heatLayer = null;
-        /** The requestAnimationFrame handle used while we wait for the map container to gain a non-zero size */
-        this._deferredAddHeatLayerRafId = null;
         this.draw = false;
         /** A grid of weights for each coordinate for each floor - used for the tooltips */
         this.weightByFloorIdGrid = [];
@@ -176,15 +174,9 @@ class HeatPlugin extends MapPlugin {
             return;
         }
 
-        // The #map container may still have zero width when the map initializes (for example when it
-        // was hidden and then shown). Leaflet.heat sizes its canvas to the map's size; a zero width makes
-        // simpleheat call getImageData(0, ...) which throws an IndexSizeError. Only add the layer once the
-        // map has a non-zero size, deferring until the container has been laid out if necessary.
-        if (this.map.leafletMap.getSize().x > 0) {
-            this._addHeatLayer();
-        } else {
-            this._deferAddHeatLayer();
-        }
+        this.heatLayer = L.heatLayer([], $.extend({}, c.map.heatmapSettings));
+
+        this.heatLayer.addTo(this.map.leafletMap);
         // let self = this;
         // Debug function that adds latLngs to your mouse location as you move around
         // this.map.leafletMap.on({
@@ -202,42 +194,6 @@ class HeatPlugin extends MapPlugin {
         // });
     }
 
-    _addHeatLayer() {
-        console.assert(this instanceof HeatPlugin, 'this is not an instance of HeatPlugin', this);
-
-        this.heatLayer = L.heatLayer([], $.extend({}, c.map.heatmapSettings));
-
-        this.heatLayer.addTo(this.map.leafletMap);
-    }
-
-    _deferAddHeatLayer() {
-        console.assert(this instanceof HeatPlugin, 'this is not an instance of HeatPlugin', this);
-
-        // Guard against stacking multiple deferrals if addToMap() is somehow called again while one is pending.
-        if (this._deferredAddHeatLayerRafId !== null) {
-            window.cancelAnimationFrame(this._deferredAddHeatLayerRafId);
-        }
-
-        let self = this;
-        let attempt = function () {
-            self._deferredAddHeatLayerRafId = null;
-
-            // Leaflet caches the map size and only recomputes it on invalidateSize(), so polling getSize()
-            // would keep returning the stale zero. Read the container width directly to detect when the
-            // container has actually been laid out, then force Leaflet to re-measure before adding the layer.
-            if (self.map.leafletMap.getContainer().clientWidth > 0) {
-                self.map.leafletMap.invalidateSize();
-                self._addHeatLayer();
-                // The floor data may have arrived while we were waiting, so (re)apply it now.
-                self._applyLatLngsForFloor(getState().getCurrentFloor().id);
-            } else {
-                self._deferredAddHeatLayerRafId = window.requestAnimationFrame(attempt);
-            }
-        };
-
-        this._deferredAddHeatLayerRafId = window.requestAnimationFrame(attempt);
-    }
-
     setOptions(options) {
         console.assert(this instanceof HeatPlugin, 'this is not an instance of HeatPlugin', this);
 
@@ -253,13 +209,6 @@ class HeatPlugin extends MapPlugin {
 
         if (!this.isEnabled()) {
             return;
-        }
-
-        // Cancel any pending deferred add so a queued frame doesn't add an orphaned layer after removal.
-        // refreshLeafletMap() removes and re-adds all plugins, which can otherwise leave duplicate layers.
-        if (this._deferredAddHeatLayerRafId !== null) {
-            window.cancelAnimationFrame(this._deferredAddHeatLayerRafId);
-            this._deferredAddHeatLayerRafId = null;
         }
 
         if (this.heatLayer !== null) {

--- a/resources/assets/js/custom/mapplugins/heatplugin.js
+++ b/resources/assets/js/custom/mapplugins/heatplugin.js
@@ -177,6 +177,9 @@ class HeatPlugin extends MapPlugin {
         this.heatLayer = L.heatLayer([], $.extend({}, c.map.heatmapSettings));
 
         this.heatLayer.addTo(this.map.leafletMap);
+        // The map defers plugin loading until it has a non-zero size, so floor data may have already
+        // arrived (and been stored but not rendered while heatLayer was still null); (re)apply it now.
+        this._applyLatLngsForFloor(getState().getCurrentFloor().id);
         // let self = this;
         // Debug function that adds latLngs to your mouse location as you move around
         // this.map.leafletMap.on({

--- a/resources/assets/js/custom/mapplugins/heatplugin.test.js
+++ b/resources/assets/js/custom/mapplugins/heatplugin.test.js
@@ -1,0 +1,154 @@
+// Global stubs ($, L, getState) come from the shared Vitest setup file
+// (resources/assets/js/test/setup.js). HeatPlugin additionally needs its base class and a
+// handful of globals it references at construction time, so those are defined before requiring
+// the source. Anything test-specific (heatLayer factory, map size, requestAnimationFrame) is
+// overridden per test below.
+
+global.MapPlugin = class MapPlugin {
+    constructor(map) {
+        this.map = map;
+    }
+
+    addToMap() {
+    }
+
+    removeFromMap() {
+    }
+
+    toggle() {
+    }
+};
+
+global.MapContextDungeonExplore = class MapContextDungeonExplore {
+};
+
+global.COMBAT_LOG_EVENT_DATA_TYPE_PLAYER_POSITION = 'player_position';
+global.COMBAT_LOG_EVENT_DATA_TYPE_ENEMY_POSITION = 'enemy_position';
+global.COMBAT_LOG_EVENT_DATA_TYPE_ENEMY_FAILURE = 'enemy_failure';
+global.isMobile = () => true;
+
+const HeatPlugin = require('./heatplugin');
+
+/**
+ * Builds a HeatPlugin backed by mock Leaflet/state objects.
+ * @param options {{mapSizeX?: Number, containerWidth?: Number}}
+ */
+function createHeatPlugin({mapSizeX = 100, containerWidth = 100} = {}) {
+    const heatLayer = {
+        addTo: vi.fn(),
+        setLatLngs: vi.fn(),
+        setOptions: vi.fn(),
+    };
+
+    global.L.heatLayer = vi.fn(() => heatLayer);
+
+    const container = {clientWidth: containerWidth};
+    const leafletMap = {
+        getSize: () => ({x: mapSizeX, y: 100}),
+        getContainer: () => container,
+        invalidateSize: vi.fn(),
+        addLayer: vi.fn(),
+        removeLayer: vi.fn(),
+    };
+
+    const map = {
+        leafletMap,
+        register: vi.fn(),
+    };
+
+    global.getState = () => ({
+        register: vi.fn(),
+        getMapContext: () => new global.MapContextDungeonExplore(),
+        getCurrentFloor: () => ({id: 1}),
+    });
+
+    const plugin = new HeatPlugin(map);
+
+    return {plugin, heatLayer, leafletMap, container};
+}
+
+beforeEach(() => {
+    global.c = {map: {heatmapSettings: {}}};
+    global.$ = {...global.$, extend: (target, ...sources) => Object.assign(target, ...sources)};
+});
+
+describe('HeatPlugin.addToMap', () => {
+    it('addToMap_givenZeroWidthContainer_doesNotAddLayerImmediately', () => {
+        const {plugin} = createHeatPlugin({mapSizeX: 0, containerWidth: 0});
+
+        expect(() => plugin.addToMap()).not.toThrow();
+
+        expect(global.L.heatLayer).not.toHaveBeenCalled();
+        expect(plugin.heatLayer).toBeNull();
+    });
+
+    it('addToMap_givenNonZeroWidthContainer_addsLayer', () => {
+        const {plugin, heatLayer, leafletMap} = createHeatPlugin({mapSizeX: 100});
+
+        plugin.addToMap();
+
+        expect(global.L.heatLayer).toHaveBeenCalledTimes(1);
+        expect(heatLayer.addTo).toHaveBeenCalledWith(leafletMap);
+        expect(plugin.heatLayer).toBe(heatLayer);
+    });
+});
+
+describe('HeatPlugin deferred add', () => {
+    let rafCallbacks;
+
+    beforeEach(() => {
+        rafCallbacks = [];
+        window.requestAnimationFrame = vi.fn((callback) => {
+            rafCallbacks.push(callback);
+            return rafCallbacks.length;
+        });
+        window.cancelAnimationFrame = vi.fn();
+    });
+
+    it('addToMap_givenZeroWidthThenNonZeroWidth_addsLayerOnceLaidOut', () => {
+        const {plugin, heatLayer, leafletMap, container} = createHeatPlugin({mapSizeX: 0, containerWidth: 0});
+
+        plugin.addToMap();
+
+        // Still zero width: the first frame re-schedules instead of adding the layer.
+        rafCallbacks.shift()();
+        expect(global.L.heatLayer).not.toHaveBeenCalled();
+
+        // The container is laid out; the next frame invalidates the size and adds the layer.
+        container.clientWidth = 500;
+        rafCallbacks.shift()();
+
+        expect(leafletMap.invalidateSize).toHaveBeenCalledTimes(1);
+        expect(global.L.heatLayer).toHaveBeenCalledTimes(1);
+        expect(plugin.heatLayer).toBe(heatLayer);
+    });
+
+    it('removeFromMap_givenPendingDeferredAdd_cancelsPendingFrame', () => {
+        const {plugin} = createHeatPlugin({mapSizeX: 0, containerWidth: 0});
+
+        plugin.addToMap();
+        plugin.removeFromMap();
+
+        expect(window.cancelAnimationFrame).toHaveBeenCalledTimes(1);
+
+        // A frame that fires after removal must not add a layer.
+        rafCallbacks.shift()();
+        expect(global.L.heatLayer).not.toHaveBeenCalled();
+    });
+});
+
+describe('HeatPlugin null-layer guards', () => {
+    it('toggle_givenNullHeatLayer_doesNotThrow', () => {
+        const {plugin} = createHeatPlugin({mapSizeX: 0, containerWidth: 0});
+
+        expect(plugin.heatLayer).toBeNull();
+        expect(() => plugin.toggle(true)).not.toThrow();
+    });
+
+    it('setOptions_givenNullHeatLayer_doesNotThrow', () => {
+        const {plugin} = createHeatPlugin({mapSizeX: 0, containerWidth: 0});
+
+        expect(plugin.heatLayer).toBeNull();
+        expect(() => plugin.setOptions({radius: 10})).not.toThrow();
+    });
+});

--- a/resources/assets/js/custom/mapplugins/heatplugin.test.js
+++ b/resources/assets/js/custom/mapplugins/heatplugin.test.js
@@ -77,6 +77,17 @@ describe('HeatPlugin.addToMap', () => {
         expect(heatLayer.addTo).toHaveBeenCalledWith(leafletMap);
         expect(plugin.heatLayer).toBe(heatLayer);
     });
+
+    it('addToMap_givenDataArrivedWhileDeferred_reAppliesFloorData', () => {
+        const {plugin, heatLayer} = createHeatPlugin();
+
+        // Simulate floor data that arrived (and was stored) while the map deferred plugin loading.
+        plugin.rawLatLngsByFloorId[1] = [[1, 2, 3]];
+
+        plugin.addToMap();
+
+        expect(heatLayer.setLatLngs).toHaveBeenCalledWith([[1, 2, 3]]);
+    });
 });
 
 describe('HeatPlugin null-layer guards', () => {

--- a/resources/assets/js/custom/mapplugins/heatplugin.test.js
+++ b/resources/assets/js/custom/mapplugins/heatplugin.test.js
@@ -1,8 +1,7 @@
 // Global stubs ($, L, getState) come from the shared Vitest setup file
 // (resources/assets/js/test/setup.js). HeatPlugin additionally needs its base class and a
 // handful of globals it references at construction time, so those are defined before requiring
-// the source. Anything test-specific (heatLayer factory, map size, requestAnimationFrame) is
-// overridden per test below.
+// the source. Anything test-specific (heatLayer factory, state) is overridden per test below.
 
 global.MapPlugin = class MapPlugin {
     constructor(map) {
@@ -30,10 +29,10 @@ global.isMobile = () => true;
 const HeatPlugin = require('./heatplugin');
 
 /**
- * Builds a HeatPlugin backed by mock Leaflet/state objects.
- * @param options {{mapSizeX?: Number, containerWidth?: Number}}
+ * Builds a HeatPlugin backed by mock Leaflet/state objects. The map-level size gate lives in
+ * DungeonMap now, so addToMap() here simply adds the layer.
  */
-function createHeatPlugin({mapSizeX = 100, containerWidth = 100} = {}) {
+function createHeatPlugin() {
     const heatLayer = {
         addTo: vi.fn(),
         setLatLngs: vi.fn(),
@@ -42,11 +41,7 @@ function createHeatPlugin({mapSizeX = 100, containerWidth = 100} = {}) {
 
     global.L.heatLayer = vi.fn(() => heatLayer);
 
-    const container = {clientWidth: containerWidth};
     const leafletMap = {
-        getSize: () => ({x: mapSizeX, y: 100}),
-        getContainer: () => container,
-        invalidateSize: vi.fn(),
         addLayer: vi.fn(),
         removeLayer: vi.fn(),
     };
@@ -64,7 +59,7 @@ function createHeatPlugin({mapSizeX = 100, containerWidth = 100} = {}) {
 
     const plugin = new HeatPlugin(map);
 
-    return {plugin, heatLayer, leafletMap, container};
+    return {plugin, heatLayer, leafletMap};
 }
 
 beforeEach(() => {
@@ -73,17 +68,8 @@ beforeEach(() => {
 });
 
 describe('HeatPlugin.addToMap', () => {
-    it('addToMap_givenZeroWidthContainer_doesNotAddLayerImmediately', () => {
-        const {plugin} = createHeatPlugin({mapSizeX: 0, containerWidth: 0});
-
-        expect(() => plugin.addToMap()).not.toThrow();
-
-        expect(global.L.heatLayer).not.toHaveBeenCalled();
-        expect(plugin.heatLayer).toBeNull();
-    });
-
-    it('addToMap_givenNonZeroWidthContainer_addsLayer', () => {
-        const {plugin, heatLayer, leafletMap} = createHeatPlugin({mapSizeX: 100});
+    it('addToMap_givenEnabled_addsLayer', () => {
+        const {plugin, heatLayer, leafletMap} = createHeatPlugin();
 
         plugin.addToMap();
 
@@ -93,60 +79,16 @@ describe('HeatPlugin.addToMap', () => {
     });
 });
 
-describe('HeatPlugin deferred add', () => {
-    let rafCallbacks;
-
-    beforeEach(() => {
-        rafCallbacks = [];
-        window.requestAnimationFrame = vi.fn((callback) => {
-            rafCallbacks.push(callback);
-            return rafCallbacks.length;
-        });
-        window.cancelAnimationFrame = vi.fn();
-    });
-
-    it('addToMap_givenZeroWidthThenNonZeroWidth_addsLayerOnceLaidOut', () => {
-        const {plugin, heatLayer, leafletMap, container} = createHeatPlugin({mapSizeX: 0, containerWidth: 0});
-
-        plugin.addToMap();
-
-        // Still zero width: the first frame re-schedules instead of adding the layer.
-        rafCallbacks.shift()();
-        expect(global.L.heatLayer).not.toHaveBeenCalled();
-
-        // The container is laid out; the next frame invalidates the size and adds the layer.
-        container.clientWidth = 500;
-        rafCallbacks.shift()();
-
-        expect(leafletMap.invalidateSize).toHaveBeenCalledTimes(1);
-        expect(global.L.heatLayer).toHaveBeenCalledTimes(1);
-        expect(plugin.heatLayer).toBe(heatLayer);
-    });
-
-    it('removeFromMap_givenPendingDeferredAdd_cancelsPendingFrame', () => {
-        const {plugin} = createHeatPlugin({mapSizeX: 0, containerWidth: 0});
-
-        plugin.addToMap();
-        plugin.removeFromMap();
-
-        expect(window.cancelAnimationFrame).toHaveBeenCalledTimes(1);
-
-        // A frame that fires after removal must not add a layer.
-        rafCallbacks.shift()();
-        expect(global.L.heatLayer).not.toHaveBeenCalled();
-    });
-});
-
 describe('HeatPlugin null-layer guards', () => {
     it('toggle_givenNullHeatLayer_doesNotThrow', () => {
-        const {plugin} = createHeatPlugin({mapSizeX: 0, containerWidth: 0});
+        const {plugin} = createHeatPlugin();
 
         expect(plugin.heatLayer).toBeNull();
         expect(() => plugin.toggle(true)).not.toThrow();
     });
 
     it('setOptions_givenNullHeatLayer_doesNotThrow', () => {
-        const {plugin} = createHeatPlugin({mapSizeX: 0, containerWidth: 0});
+        const {plugin} = createHeatPlugin();
 
         expect(plugin.heatLayer).toBeNull();
         expect(() => plugin.setOptions({radius: 10})).not.toThrow();


### PR DESCRIPTION
Fixes #2947.

## Problem
The whole map bootstraps **synchronously on `DOMContentLoaded`** (`inline.blade` → `CommonMapsMap.activate` → `_initDungeonMap` → `new DungeonMap` → `refreshLeafletMap`), i.e. before the browser lays out the percentage/flex-sized `#map` container. Leaflet caches a stale size of `0`, and `HeatPlugin.addToMap()` (called in the plugin loop of `refreshLeafletMap`) creates an `L.heatLayer` whose canvas is sized to `0` → `IndexSizeError: getImageData ... source width is 0`. This aborted map loading intermittently on the explore and weekly-route/heatmap pages.

## Fix — a map-level size gate around the plugin loop
Rather than guarding each plugin individually, the deferral now lives once in `DungeonMap`:

- **`DungeonMap._whenMapSized(callback)`** wraps the plugin remove/add loop in `refreshLeafletMap()`. It runs the callback synchronously when the map already has a non-zero size (floor changes after first load); otherwise it polls the container's `clientWidth` via `requestAnimationFrame` (Leaflet caches a stale `0` from `getSize()`), calls `invalidateSize()` to refresh the cache, then runs the callback. A pending gate is cancelled before a new one is scheduled, so repeated refreshes can't stack. This means future plugins never need their own deferral code.
- **`HeatPlugin`** is reverted to adding its layer directly. It re-applies the current floor's data right after creating the layer, so data that arrived during the (~1 frame) gate window renders instead of silently waiting. The `heatLayer === null` guards in `_applyLatLngsForFloor()`/`setOptions()` stay, since the layer is briefly null during the gate.

## Tests
- `dungeonmap.test.js` (new): exercises `_whenMapSized` on an `Object.create(prototype)` instance (sync path, zero-size-until-laid-out + `invalidateSize`, pending-gate cancellation).
- `heatplugin.test.js`: layer add, floor-data re-apply, and the null-layer guards.

Full JS suite: 105 passed. This is a unit test of the gate; the `refreshLeafletMap` wiring is not integration-tested (impractical in jsdom). No PHP changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
