### PR TITLE
#3386 Finish the project-backend-structure skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -116,7 +116,7 @@ For example:
 
 ## Localization
 - Use the `__()` helper function for localization and translation of strings. Use translation keys. For example: `__('view_common.my.folder.structure.welcome_to_the_website')`.
-- The language folder exists in the root of the project. Translation files are located in `lang/{locale}/` and should be organized by relevant class name (such as `Spell` -> `spells.php`) or folder structure for views (such as `view_common` or `view_dungeon`). For example: `lang/en/auth.php`, `lang/en/dashboard.php`, etc.
+- The language folder exists in the root of the project. Translation files are located in `lang/{locale}/` and should be organized by relevant class name (such as `Spell` -> `spells.php`) or folder structure for views (such as `view_common` or `view_dungeon`). For example: `lang/en_US/auth.php`, `lang/en_US/dashboard.php`, etc.
 - Only ever edit localization files in the `lang/en_US` directory. All other languages are handled externally.
 - For blade.php files, the translation keys matches exactly the file structure and name. For example, `resources/views/common/footer.blade.php` would have translation keys like `view_common.footer.copyright`.
 

--- a/.claude/skills/project-backend-structure/SKILL.md
+++ b/.claude/skills/project-backend-structure/SKILL.md
@@ -1,68 +1,280 @@
 ---
 name: project-backend-structure
-description: This skill is still being written. Do not ever load it. Helps with understanding the PHP backend structure and coding standards in this project. Use when architectural decisions need to be made, or when the user wants to write a new backend feature. Do not use when writing front-end JavaScript, or any language other than PHP. Do not use this skill when attempting to understand generic Laravel structure.
+description: Architectural map of the PHP backend — every app/ directory explained, the Service/Logic/Repository/Model layering, container bindings per provider, and newcomer gotchas. Use when making architectural decisions, writing a new backend feature, or deciding where a new class belongs. Do not use for front-end JavaScript or any language other than PHP, and not for generic Laravel structure questions.
 ---
 
-# Project overview
+# Project Backend Structure
+
+## Overview
+
+Laravel 12 with the streamlined (Laravel 11+) structure: there is **no** `app/Console/Kernel.php`
+or `app/Http/Kernel.php`. Middleware and exception wiring live in `bootstrap/app.php`, the
+schedule lives in `routes/console.php`, and providers are registered in `bootstrap/providers.php`.
+The backend is ~1,500 PHP files across 21 top-level directories under `app/`.
+
+The layering for a typical request:
 
 ```
-app/Commands - contains all Laravel artisan commands
-  → <folder> - grouped by subject
-  → Traits - re-usable functionality across commands
-app/Events - contains events that are dispatched to the front-end using Reverb, not used internally
-  → ContextEvent.php - base class
-  → Models
-    → ContextModelEvent.php - base class to synchronize a model
-    → <folder> - grouped by model
-  →
-app/Features - contains feature flag classes
-app/Http/Controllers/
-  → Admin - Admin-only functionality for usage across the site
-  → AdminTools - Admin-only functionality for usage inside the admin panel
-  → Ajax - all XHR/Ajax functionality
-  → Api
-    → V1/InternalTeam - accessible for users with the `internal team` role
-    → V1/Public - accessible for everyone with a registered account
-  →
-  →
-  →
-  →
-  →
-  →
-  →
-  →
+Route → Middleware → Controller (+ FormRequest) → Service (interface-injected)
+      → Repository (interface-injected) → Model
 ```
 
-## Commands
+`app/Logic` sits beside this stack as stateless, container-free domain primitives that Services
+consume.
 
-A common pattern is commands extending custom base classes and commands extending other commands. Be mindful of this
-when creating new commands.
+## The `app/` directory map
 
-Use the available traits as much as possible and create new traits when needed.
+```
+app/
+├── Console/Commands    Artisan commands, subfoldered by domain (MDT, Mapping, CombatLog,
+│                       Dungeon, Github, Release, Scheduler, ...). Shared traits in
+│                       Console/Commands/Traits. Commands extend custom base classes and
+│                       sometimes other commands — check the hierarchy before adding one.
+├── Email               Custom mailables (e.g. CustomPasswordResetEmail.php). Tiny.
+├── Events              Broadcast events for Reverb (see Events section). No PHP listeners.
+├── Exceptions          Handler.php (bound in AppServiceProvider) + its structured-logging
+│                       companion in Exceptions/Logging/.
+├── Features            Laravel Pennant feature-flag classes, one class per flag
+│                       (e.g. Heatmap.php, NpcCompendium.php). Pure class definitions.
+├── Helpers             Global FUNCTION files (CustomHelper.php, ColorHelper.php), loaded via
+│                       require_once in HelperServiceProvider — NOT PSR-4 classes.
+├── Http                Controllers, FormRequests, request DTOs, middleware, resources
+│                       (see Http section).
+├── Jobs                Queued jobs, all `implements ShouldQueue`, no shared base class.
+│                       Subfolders Jobs/CombatLog, Jobs/Logging.
+├── Larex               Override of the Larex CSV↔translation importer (Crowdin sync tooling,
+│                       config/larex.php). Not app domain code.
+├── Logging             StructuredLogging base infrastructure (see structured-logging skill).
+├── Logic               Stateless domain primitives (see Logic vs Service section).
+├── Models              Eloquent models (see Models section).
+├── Overrides           Subclasses of framework internals (CustomRateLimiter.php, wired in
+│                       AppServiceProvider). Framework-behavior overrides live here.
+├── Policies            Laravel authorization policies, one per model that needs one
+│                       (DungeonRoutePolicy, TeamPolicy, ...).
+├── Providers           Service providers — each has a single binding responsibility
+│                       (see Providers section).
+├── Repositories        Repository pattern: Interfaces/, Database/, Stub/, Swoole/
+│                       (see repository-pattern skill).
+├── Rules               Custom validation rules `implements ValidationRule`
+│                       (e.g. DungeonRouteLevelRule.php).
+├── SeederHelpers       RelationImport machinery for the dungeon JSON seeder
+│                       (see seeder-load / seeder-save skills).
+├── Service             The business-logic layer (see Service section).
+├── Traits              Cross-cutting traits not tied to models (SavesArrayToJsonFile,
+│                       CompressesImages, UserCurrentTime). Model traits live in
+│                       app/Models/Traits, service traits in app/Service/Traits.
+└── Vendor              In-repo vendored third-party code (Vendor/SemVer/Version.php).
+                        Not Composer's vendor/.
+```
 
-## Events
+## Service layer — `app/Service`
 
-Laravel events that are dispatched to the front-end using Reverb. There is no backend (PHP) handler for any of these
-events.
+The primary business-logic layer: ~41 domain folders (DungeonRoute, Season, CombatLog,
+CombatLogEvent, MDT, Npc, Spell, MapContext, Mapping, Cache, Cloudflare, Patreon, RaiderIO,
+Wowhead, Discord, Metric, Coordinates, PathFinding, User, Expansion, GameVersion, ...).
 
-## Feature Flags
+Conventions:
 
-Default Laravel feature flags are used in this project through pure class definitions only.
+- **Interface + implementation pair per service**: `Service/Coordinates/CoordinatesServiceInterface.php`
+  + `CoordinatesService.php`. Always inject the interface, never the concrete class.
+- **Large domains hold multiple services in one folder.** `Service/DungeonRoute/` contains
+  `DungeonRouteService`, `DungeonRouteSaveService`, `DungeonRouteSearchService`,
+  `CoverageService`, `MapDrawingService`, `ThumbnailService`, `DiscoverService` — each with its
+  own interface.
+- **Environment variants**: `Dev...`/`...Stub` implementations exist for local/test contexts
+  (e.g. `Cache/DevCacheService`, `DungeonRoute/DevDiscoverService`,
+  `Season/SeasonServiceStub`). Bindings switch on environment in the provider.
+- **Per-service sub-namespaces** as needed: `Logging/` (the structured-logging companion,
+  see structured-logging skill), `Dtos/`, `Exceptions/`, `Models/`, `Builders/`, `Filters/`.
+  `Service/CombatLog/` is the richest example (Builders, DataExtractors, Dtos, Filters,
+  ResultEvents, Splitters).
+- Shared service traits: `Service/Traits/` (e.g. `Curl.php`).
+
+**Registration**: all service interfaces are bound in
+`app/Providers/KeystoneGuruServiceProvider.php::register()` (~64 bindings). Some are
+environment-conditional, e.g.:
+
+```php
+if (app()->runningUnitTests() || app()->environment('local')) {
+    $this->app->bind(RaiderIOApiServiceInterface::class, RaiderIOKeystoneGuruApiService::class);
+} else {
+    $this->app->bind(RaiderIOApiServiceInterface::class, RaiderIOApiService::class);
+}
+```
+
+Adding a new service = folder (or existing domain folder) + `{Name}ServiceInterface` +
+`{Name}Service` + binding in `KeystoneGuruServiceProvider` + (usually) a `Logging/` companion
+bound in `LoggingServiceProvider`.
+
+## Logic vs Service — the distinction
+
+- **`app/Logic`** = stateless, framework-light domain primitives. Never bound in the container;
+  instantiated directly. Contents: `Logic/Structs` (value objects: `LatLng`, `IngameXY`,
+  `MapBounds`, `PathNode`), `Logic/MDT` (MDT Lua parsing: Entity/Lua/Data/Exception),
+  `Logic/CombatLog` (CombatEvents, SpecialEvents, Guid), `Logic/Datatables` (+ ColumnHandler),
+  `Logic/MapContext`, `Logic/SimulationCraft`, `Logic/Utils` (HtmlSanitizer, Stopwatch, Counter).
+- **`app/Service`** = injectable, interface-backed orchestration of repositories, models,
+  logging, caching, and external APIs. Services consume Logic structs/parsers.
+
+Rule of thumb: if it needs the container, DB, or config, it's a Service; if it's pure
+computation/parsing over values, it's Logic.
+
+## Models — `app/Models`
+
+~45 flat root models plus domain subfolders (153 model files in total): `DungeonRoute`, `Enemies`, `Floor`, `KillZone`,
+`Mapping`, `Npc`, `Spell`, `Tags`, `AffixGroup`, `GameVersion`, `Metrics`, `Patreon`,
+`CombatLog`, `Laratrust`, ...
+
+### `Model` vs `CacheModel`
+
+`app/Models/CacheModel.php` is `Model` + the `Cachable` trait from laravel-model-caching —
+every query on such a model is transparently cached. Mostly-static reference data extends
+`CacheModel` (`Season`, `Expansion`, `Dungeon`, `Npc`, `Release`, `MapIconType`,
+`CharacterClass`, ...); frequently-written user data extends plain `Model`. Choose
+deliberately when creating a model: wrongly picking `CacheModel` causes stale-data bugs, and
+cache busting is tied to the model-caching package (`config/laravel-model-caching.php`).
+
+- `User` extends `Authenticatable implements LaratrustUser` (Laratrust roles/permissions).
+- Model traits: `app/Models/Traits` — `HasVertices`, `HasLatLng`, `HasTags`/`Taggable`,
+  `BitMasks`, `GeneratesPublicKey`, `HasIconFile`, `HasMetrics`, `SeederModel`,
+  `SerializesDates`, `Reportable`, `HasStart`, ...
+- Model interfaces: `app/Models/Interfaces` — `HasLatLngInterface`, `HasVerticesInterface`,
+  `TracksPageViewInterface`, `CloneForNewMappingVersionInterface`, ...
+- Every model gets a repository (see repository-pattern skill).
+
+### Mapping-versioned models
+
+The dungeon "mapping" (enemies, packs, patrols, map icons, floor unions, mountable areas, ...)
+is versioned via `app/Models/Mapping/MappingVersion.php`. Mapping-mutable models implement
+`App\Models\Mapping\MappingModelInterface` and (when cloneable to a new version)
+`App\Models\Interfaces\CloneForNewMappingVersionInterface`. Every mapping-versioned row carries
+a `mapping_version_id`, so **queries must scope to the relevant mapping version**. When a new
+mapping version is cut, rows are cloned forward; audit trail via `MappingChangeLog` /
+`MappingCommitLog`. Mapping models also need seeder import/export handling — see the
+seeder-load and seeder-save skills.
+
+## Http layer — `app/Http`
+
+### Controller taxonomy (`app/Http/Controllers`)
+
+- Root: base `Controller.php` + main page controllers (`SiteController`, `TeamController`,
+  `ProfileController`, `NpcController`, `ReleaseController`, ...).
+- `Admin/` — admin CRUD pages; `AdminTools/` — the admin tools/batch pages (see
+  admin-tools-page / admin-batch-page skills).
+- `Ajax/` — ~30 `Ajax*Controller` classes for the map editor's async CRUD, one per model
+  (`AjaxEnemyController`, `AjaxKillZoneController`, ...), with base
+  `AjaxMappingModelBaseController.php`.
+- `Api/V1/` — public REST API: `Public/`, `InternalTeam/`, and `Spec/` (OpenAPI attributes for
+  l5-swagger). Controllers prefixed `API...`. See the api-endpoint skill.
+- Domain folders: `Dungeon/`, `DungeonRoute/`, `Compendium/`, `Floor/`, `Speedrun/`, `Auth/`,
+  `Webhook/`, and `Javascript/` (serves generated JS data like map context).
+
+### FormRequests vs Request DTOs — don't conflate
+
+- `app/Http/Requests/` — validation `FormRequest` classes (mostly named `*FormRequest`, some just
+  `*Request`), subfoldered per model/domain plus `Api/V1/...`.
+- `app/Http/Models/Request/` — plain DTO classes (base `RequestModel.php`) that give a validated
+  request body a typed shape (e.g. `CombatLog/Route/CombatLogRoute*RequestModel.php`). These are
+  **not** validators; a controller typically validates with a FormRequest and then builds a
+  RequestModel from it.
+
+### Middleware & Resources
+
+- `app/Http/Middleware`: `OnlyAjax`, `ReadOnlyMode`, `LegalAgreed`, `ViewCacheBuster`,
+  `TracksUserIpAddress`, `EnsureFeatureIsActive` (Pennant), plus `Middleware/Api`
+  (`ApiAuthentication`, `ApiRole`, `ApiMetrics`) and `Middleware/Language`. Aliases and groups
+  are declared in `bootstrap/app.php`.
+- `app/Http/Resources`: API JSON resources subfoldered per model, plus shared pagination
+  resources (`PaginationMetaResource` etc.).
+- `app/Http/View/Composers`: Blade view composers.
+
+## Routing — `routes/`
+
+| File | Purpose |
+|---|---|
+| `web.php` (~800 lines) | Main site + editor + Ajax routes, organized in `Route::prefix()/middleware()` groups |
+| `api.php` | The `/api/v1` REST surface |
+| `console.php` | Scheduled commands (replaces the old Kernel schedule) |
+| `channels.php` | Broadcast channel authorization (live sessions, route editing) |
+| `breadcrumbs.php` | Diglactic breadcrumbs definitions (not routes) |
+
+## Providers — who binds what
+
+| Provider | Responsibility |
+|---|---|
+| `KeystoneGuruServiceProvider` | All service interface→implementation bindings (~64), env-conditional swaps, view composers, boot glue |
+| `RepositoryServiceProvider` | All repository bindings (~116), one per model |
+| `LoggingServiceProvider` | Every `{X}LoggingInterface` → implementation (~49, structured logging) |
+| `ControllerServiceProvider` | Controller-support services |
+| `PathFindingServiceProvider` | Pathfinding + killzone-path services |
+| `HelperServiceProvider` | `require_once`s the global-function helper files |
+| `AppServiceProvider` | Exception handler binding, rate limiters (via `Overrides\CustomRateLimiter`) |
+| `HorizonServiceProvider` / `TelescopeServiceProvider` / `OctaneServiceProvider` | Third-party wiring |
+
+## Events — `app/Events`
+
+Laravel broadcast events pushed to the front-end via Reverb; **there are no PHP listeners** for
+these. Base class `ContextEvent` (`abstract`, `implements ShouldBroadcast`) broadcasts on a
+presence channel derived from its context model (route-edit or live-session). Model
+CRUD events live under `Events/Models/<ModelName>/` with base `ContextModelEvent` /
+`ModelChangedEvent` / `ModelDeletedEvent` — this is what keeps collaborative map editing in
+sync. Also `Events/LiveSession/`, `Events/OverpulledEnemy/`.
+
+## Feature flags — `app/Features`
+
+Laravel Pennant, pure class definitions only (one class per flag). Routes are gated with the
+`feature_active` middleware (`EnsureFeatureIsActive`). See the pennant-development skill.
 
 ## API
 
 ### Authorization
 
-Authorization is done using Auth: Basic. No API keys exist.
+Authorization is done using Auth: Basic. No API keys exist. `ApiAuthentication` middleware plus
+`api_role` (Laratrust) for the internal-team surface.
 
-### Open API Spec
+### OpenAPI spec
 
-All endpoints must be documented with an Open API Spec - both request and response payloads.
-
-After performing changes to the API Spec the Swagger docs must be regenerated using this command:
+All endpoints must be documented with an OpenAPI spec — both request and response payloads
+(attributes live with the `Api/V1` controllers and `Spec/`). After changing the spec,
+regenerate the Swagger docs:
 
 ```bash
 php artisan l5-swagger:generate --all && php artisan vendor:publish --provider="L5Swagger\L5SwaggerServiceProvider"
 ```
 
-## System Prompt
+## Config
+
+`config/keystoneguru.php` is the central project config: super admins, asset/tile base URLs,
+game constants (keystone levels, affixes), route limits, thumbnail/discover/heatmap/API
+settings, external integrations (RaiderIO, Patreon, MDT), combat-log tuning. Other
+project-specific configs: `laratrust.php`, `laravel-model-caching.php`, `larex.php`,
+`discord-logger.php`, `github.php`, `pennant.php`, `influxdb.php`, `opensearch-laravel.php`.
+
+## Related skills
+
+- **repository-pattern** — adding a repository for a new model
+- **structured-logging** — the `{Service}Logging` companion-class pattern
+- **seeder-load / seeder-save** — importing/exporting mapping models via the dungeon JSON seeders
+- **api-endpoint** — writing a new public API v1 endpoint
+- **admin-tools-page / admin-batch-page** — new admin pages
+- **combatlog-data-pipeline** — the combat-log extraction subsystem
+
+## Newcomer gotchas
+
+- `app/Helpers` files are global-function includes (`require_once` in `HelperServiceProvider`),
+  not autoloaded classes.
+- `app/Vendor`, `app/Overrides`, and `app/Larex` are in-repo forks/overrides of third-party or
+  framework code — not app domain code.
+- Everything is interface-injected: a new service/repository is invisible until its binding is
+  added to the right provider (services → `KeystoneGuruServiceProvider`, repositories →
+  `RepositoryServiceProvider`, logging companions → `LoggingServiceProvider`).
+- Choose `CacheModel` vs `Model` deliberately — `CacheModel` transparently caches all queries.
+- Mapping-mutable models must implement the mapping interfaces, scope queries by
+  `mapping_version_id`, and be wired into seeder import (`SeederHelpers`) and export
+  (`mapping:save`).
+- `Http/Models/Request` DTOs are not FormRequests — validation happens in `Http/Requests`.
+- `Stub`/`Swoole` repository variants and `Dev.../...Stub` service variants exist because of
+  Octane/Swoole long-lived workers — state must not leak across requests; check
+  `app/Repositories/Swoole/` before assuming a repository is request-scoped.
+- Laravel 12 structure: no Kernel files — schedule in `routes/console.php`, middleware in
+  `bootstrap/app.php`.


### PR DESCRIPTION
Closes #3386.

Rewrites the `project-backend-structure` skill from a 68-line stub (marked "do not ever load") into a complete architectural map of the PHP backend, so any future session can orient in the codebase from the skill alone.

## What's covered
- All 21 `app/` top-level directories with purpose + a representative file, including the non-obvious ones (`Larex`, `Overrides`, `Vendor`, `Helpers` as `require_once` function files).
- The Service / Logic / Repository / Model layering, and the Logic-vs-Service distinction.
- Container bindings per provider (which provider binds services vs repositories vs logging companions).
- `Model` vs `CacheModel`, model traits/interfaces, and mapping-versioned models.
- Http taxonomy, and the FormRequest vs `Http/Models/Request` DTO gotcha.
- Routing, config, and a "newcomer gotchas" section. Cross-references sibling skills instead of duplicating them.

## Also
- Fixes the `.claude/CLAUDE.md` localization example (`lang/en/...` → `lang/en_US/...`) that contradicted the "only edit `lang/en_US`" rule on the next line.

## Verification
Every factual claim was spot-checked against the code, and an independent agent answered three newcomer questions ("where do I add a new service?", "Model or CacheModel?", "FormRequest vs RequestModel?") from the skill alone and verified the answers — all correct. Two numeric errors it caught (directory count, root-model count) were fixed. Docs-only change; no test or static-analysis impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)