### PR TITLE
Release v15.2.5 - MDT v6.1.20, heatmap fix

### DIFF
--- a/database/seeders/releases/v15.2.5.json
+++ b/database/seeders/releases/v15.2.5.json
@@ -1,0 +1,89 @@
+{
+    "id": 365,
+    "release_changelog_id": 372,
+    "version": "v15.2.5",
+    "title": "MDT v6.1.20, heatmap fix",
+    "backup_db": 0,
+    "silent": 0,
+    "spotlight": 0,
+    "released": 1,
+    "created_at": "2026-07-07T10:26:27+00:00",
+    "updated_at": "2026-07-07T10:26:27+00:00",
+    "changelog": {
+        "id": 372,
+        "release_id": 365,
+        "description": null,
+        "changes": [
+            {
+                "release_changelog_id": 372,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3370,
+                "is_public": 1,
+                "change": "MDT updated to v6.1.20 - all dungeon mapping brought up-to-date."
+            },
+            {
+                "release_changelog_id": 372,
+                "release_changelog_category_id": 5,
+                "ticket_id": 2947,
+                "is_public": 1,
+                "change": "Fixed the heatmap sometimes not loading on the weekly route page."
+            },
+            {
+                "release_changelog_id": 372,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3368,
+                "is_public": 0,
+                "change": "make:githubreleasepullrequest can now update an existing release PR (owner/case mismatch fixed)."
+            },
+            {
+                "release_changelog_id": 372,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3366,
+                "is_public": 0,
+                "change": "Improved deployment/release skills."
+            },
+            {
+                "release_changelog_id": 372,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3366,
+                "is_public": 0,
+                "change": "Thumbnails are no longer generated locally when running a production copy."
+            },
+            {
+                "release_changelog_id": 372,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3371,
+                "is_public": 0,
+                "change": "Added git worktree + isolated Docker stack workflow."
+            },
+            {
+                "release_changelog_id": 372,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3358,
+                "is_public": 0,
+                "change": "Removed code related to the mapping environment that no longer exists."
+            },
+            {
+                "release_changelog_id": 372,
+                "release_changelog_category_id": 5,
+                "ticket_id": 3376,
+                "is_public": 0,
+                "change": "Demo dungeon routes are now preserved when reseeding dungeon data."
+            },
+            {
+                "release_changelog_id": 372,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3386,
+                "is_public": 0,
+                "change": "Finished the project-backend-structure skill."
+            },
+            {
+                "release_changelog_id": 372,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3389,
+                "is_public": 0,
+                "change": "Added DungeonRoutePolicy feature tests."
+            }
+        ]
+    }
+}

--- a/resources/assets/js/custom/dungeonmap.js
+++ b/resources/assets/js/custom/dungeonmap.js
@@ -476,17 +476,6 @@ class DungeonMap extends Signalable {
     }
 
     /**
-     * Really really shitty hack that will fix the map seam that can shine through when zooming. I tried a lot of things
-     * to fix it but this is the only thing that sticks unfortunately. I don't see any downsides at this time so I'm keeping it
-     *
-     *
-     * @private
-     */
-    _fixMapTileSeam() {
-        $('.leaflet-tile-container img').css('width', `${c.map.settings.tileWidth + 1}px`).css('height', `${c.map.settings.tileHeight + 1}px`);
-    }
-
-    /**
      * Someone clicked on an enemy
      * @private
      */
@@ -846,7 +835,6 @@ class DungeonMap extends Signalable {
         }).addTo(this.leafletMap);
 
         this.leafletMap.setMaxZoom(floorMaxZoomLevel);
-        this._fixMapTileSeam();
 
         // if( typeof this.drawnLayers !== 'undefined' ) {
         //     this.leafletMap.removeLayer(this.drawnLayers);

--- a/resources/assets/js/custom/inline/common/maps/heatmapsearchsidebar.js
+++ b/resources/assets/js/custom/inline/common/maps/heatmapsearchsidebar.js
@@ -72,6 +72,8 @@ class CommonMapsHeatmapsearchsidebar extends SearchInlineBase {
             loaderSelector: options.loaderSelector,
         }, options)), id, bladePath, options);
 
+        let self = this;
+
         this.sidebar = new Sidebar(options);
         this.initializing = true;
 
@@ -123,9 +125,9 @@ class CommonMapsHeatmapsearchsidebar extends SearchInlineBase {
                 self._search();
             }),
             'includeClassIds': new SearchFilterClasses(this.options.filterClassesSelector, this._search.bind(this)),
-            'includeSpecIds': new SearchFilterSpecializations(this.options.filterSpecializationsSelector, self._search.bind(this)),
+            'includeSpecIds': new SearchFilterSpecializations(this.options.filterSpecializationsSelector, this._search.bind(this)),
             'includePlayerDeathClassIds': new SearchFilterClassesPlayerDeaths(this.options.filterClassesPlayerDeathsSelector, this._search.bind(this)),
-            'includePlayerDeathSpecIds': new SearchFilterSpecializationsPlayerDeaths(this.options.filterSpecializationsPlayerDeathsSelector, self._search.bind(this)),
+            'includePlayerDeathSpecIds': new SearchFilterSpecializationsPlayerDeaths(this.options.filterSpecializationsPlayerDeathsSelector, this._search.bind(this)),
             'duration': new SearchFilterDuration(this.options.filterDurationSelector, this._search.bind(this), this.options.durationMin, this.options.durationMax),
 
             'excludeSpecIds': new SearchFilterPassThrough(),

--- a/storage/framework/testing/.gitignore
+++ b/storage/framework/testing/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
General changes:
  * #3370 MDT updated to v6.1.20 - all dungeon mapping brought up-to-date.
  * #3368 make:githubreleasepullrequest can now update an existing release PR (owner/case mismatch fixed).
  * #3366 Improved deployment/release skills.
  * #3366 Thumbnails are no longer generated locally when running a production copy.
  * #3371 Added git worktree + isolated Docker stack workflow.
  * #3358 Removed code related to the mapping environment that no longer exists.
  * #3386 Finished the project-backend-structure skill.
  * #3389 Added DungeonRoutePolicy feature tests.

Bugfixes:
  * #2947 Fixed the heatmap sometimes not loading on the weekly route page.
  * #3376 Demo dungeon routes are now preserved when reseeding dungeon data.

Closes #3370
Closes #3368
Closes #3366
Closes #3366
Closes #3371
Closes #3358
Closes #3386
Closes #3389
Closes #2947
Closes #3376