### PR TITLE
Release v15.2.7 - MDT v6.1.20, heatmap fix

### DIFF
--- a/database/seeders/releases/v15.2.7.json
+++ b/database/seeders/releases/v15.2.7.json
@@ -1,84 +1,84 @@
 {
-    "id": 366,
-    "release_changelog_id": 373,
-    "version": "v15.2.6",
+    "id": 367,
+    "release_changelog_id": 374,
+    "version": "v15.2.7",
     "title": "MDT v6.1.20, heatmap fix",
     "backup_db": 0,
     "silent": 0,
     "spotlight": 0,
     "released": 1,
-    "created_at": "2026-07-07T10:26:27+00:00",
-    "updated_at": "2026-07-07T10:26:27+00:00",
+    "created_at": "2026-07-07T17:04:22+00:00",
+    "updated_at": "2026-07-07T17:04:22+00:00",
     "changelog": {
-        "id": 373,
-        "release_id": 366,
+        "id": 374,
+        "release_id": 367,
         "description": null,
         "changes": [
             {
-                "release_changelog_id": 373,
+                "release_changelog_id": 374,
                 "release_changelog_category_id": 1,
                 "ticket_id": 3370,
                 "is_public": 1,
                 "change": "MDT updated to v6.1.20 - all dungeon mapping brought up-to-date."
             },
             {
-                "release_changelog_id": 373,
+                "release_changelog_id": 374,
                 "release_changelog_category_id": 5,
                 "ticket_id": 2947,
                 "is_public": 1,
                 "change": "Fixed the heatmap sometimes not loading on the weekly route page."
             },
             {
-                "release_changelog_id": 373,
+                "release_changelog_id": 374,
                 "release_changelog_category_id": 1,
                 "ticket_id": 3368,
                 "is_public": 0,
                 "change": "make:githubreleasepullrequest can now update an existing release PR (owner/case mismatch fixed)."
             },
             {
-                "release_changelog_id": 373,
+                "release_changelog_id": 374,
                 "release_changelog_category_id": 1,
                 "ticket_id": 3366,
                 "is_public": 0,
                 "change": "Improved deployment/release skills."
             },
             {
-                "release_changelog_id": 373,
+                "release_changelog_id": 374,
                 "release_changelog_category_id": 1,
                 "ticket_id": 3366,
                 "is_public": 0,
                 "change": "Thumbnails are no longer generated locally when running a production copy."
             },
             {
-                "release_changelog_id": 373,
+                "release_changelog_id": 374,
                 "release_changelog_category_id": 1,
                 "ticket_id": 3371,
                 "is_public": 0,
                 "change": "Added git worktree + isolated Docker stack workflow."
             },
             {
-                "release_changelog_id": 373,
+                "release_changelog_id": 374,
                 "release_changelog_category_id": 1,
                 "ticket_id": 3358,
                 "is_public": 0,
                 "change": "Removed code related to the mapping environment that no longer exists."
             },
             {
-                "release_changelog_id": 373,
+                "release_changelog_id": 374,
                 "release_changelog_category_id": 5,
                 "ticket_id": 3376,
                 "is_public": 0,
                 "change": "Demo dungeon routes are now preserved when reseeding dungeon data."
             },
             {
-                "release_changelog_id": 373,
+                "release_changelog_id": 374,
                 "release_changelog_category_id": 1,
                 "ticket_id": 3386,
                 "is_public": 0,
                 "change": "Finished the project-backend-structure skill."
             },
             {
-                "release_changelog_id": 373,
+                "release_changelog_id": 374,
                 "release_changelog_category_id": 1,
                 "ticket_id": 3389,
                 "is_public": 0,


### PR DESCRIPTION
General changes:
  * #3370 MDT updated to v6.1.20 - all dungeon mapping brought up-to-date.
  * #3368 make:githubreleasepullrequest can now update an existing release PR (owner/case mismatch fixed).
  * #3366 Improved deployment/release skills.
  * #3366 Thumbnails are no longer generated locally when running a production copy.
  * #3371 Added git worktree + isolated Docker stack workflow.
  * #3358 Removed code related to the mapping environment that no longer exists.
  * #3386 Finished the project-backend-structure skill.
  * #3389 Added DungeonRoutePolicy feature tests.

Bugfixes:
  * #2947 Fixed the heatmap sometimes not loading on the weekly route page.
  * #3376 Demo dungeon routes are now preserved when reseeding dungeon data.

Closes #3370
Closes #3368
Closes #3366
Closes #3366
Closes #3371
Closes #3358
Closes #3386
Closes #3389
Closes #2947
Closes #3376