### PR TITLE
#3427 Footer no longer shows a truncated tag as the deployed revision

### DIFF
--- a/app/Service/View/ViewService.php
+++ b/app/Service/View/ViewService.php
@@ -146,17 +146,28 @@ class ViewService implements ViewServiceInterface
             return [
                 'version'        => $version,
                 'revision'       => $appRevision,
-                'nameAndVersion' => sprintf(
-                    '%s® © 2018-%d %s - %s (%s), MDT %s',
-                    config('app.name'),
-                    date('Y'),
-                    'RaiderIO, Inc.',
-                    $version,
-                    substr($appRevision, 0, 6),
-                    config('keystoneguru.mdt.version'),
-                ),
+                'nameAndVersion' => $this->formatAppNameAndVersion($version, $appRevision),
             ];
         });
+    }
+
+    /**
+     * The version file contains a release tag in deployed images (#3320) but a commit hash in dev/CI.
+     * Tags are shown in full (omitted entirely when they duplicate the release version); hashes are shortened.
+     */
+    public function formatAppNameAndVersion(string $version, string $appRevision): string
+    {
+        $revisionDisplay = str_starts_with($appRevision, 'v') ? $appRevision : substr($appRevision, 0, 6);
+
+        return sprintf(
+            '%s® © 2018-%d %s - %s%s, MDT %s',
+            config('app.name'),
+            date('Y'),
+            'RaiderIO, Inc.',
+            $version,
+            $revisionDisplay === $version ? '' : sprintf(' (%s)', $revisionDisplay),
+            config('keystoneguru.mdt.version'),
+        );
     }
 
     public function getUserCount(): int

--- a/tests/Feature/App/Service/View/ViewServiceTest.php
+++ b/tests/Feature/App/Service/View/ViewServiceTest.php
@@ -107,4 +107,44 @@ final class ViewServiceTest extends PublicTestCase
         yield ['/api_keys/sendgrid_keys.json'];
         yield ['/'];
     }
+
+    /**
+     * @throws Exception
+     * @throws Throwable
+     */
+    #[Test]
+    #[DataProvider('formatAppNameAndVersion_givenRevision_returnsExpectedNameAndVersion_dataProvider')]
+    public function formatAppNameAndVersion_givenRevision_returnsExpectedNameAndVersion(
+        string $version,
+        string $appRevision,
+        string $expectedRevisionSuffix,
+    ): void {
+        // Arrange
+        $viewService = ServiceFixtures::getViewServiceMock(
+            testCase: $this,
+        );
+
+        // Act
+        $result = $viewService->formatAppNameAndVersion($version, $appRevision);
+
+        // Assert
+        $this->assertSame(sprintf(
+            '%s® © 2018-%d RaiderIO, Inc. - %s%s, MDT %s',
+            config('app.name'),
+            date('Y'),
+            $version,
+            $expectedRevisionSuffix,
+            config('keystoneguru.mdt.version'),
+        ), $result);
+    }
+
+    public static function formatAppNameAndVersion_givenRevision_returnsExpectedNameAndVersion_dataProvider(): \Generator
+    {
+        // Deployed image: version file contains the tag of the latest release - pure duplication, omitted
+        yield 'tag equal to release version' => ['v15.2.8', 'v15.2.8', ''];
+        // Mid-deploy or stale container: the deployed tag differs from the latest release row - show it in full
+        yield 'tag differing from release version' => ['v15.2.8', 'v15.2.7', ' (v15.2.7)'];
+        // Dev/CI: version file contains a commit hash - show the short hash
+        yield 'commit hash' => ['v15.2.8', 'a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4', ' (a1b2c3)'];
+    }
 }


### PR DESCRIPTION
Closes #3427

Since #3320 the `version` file baked into release images contains the release tag instead of a commit hash, so the footer's `substr($appRevision, 0, 6)` rendered `v15.2.7 (v15.2.)`.

- Extracted the footer string construction into `ViewService::formatAppNameAndVersion()` (pure, testable without the version file / DB).
- Tags are now shown in full — and omitted entirely when they duplicate the latest release's version (the normal production case). Commit hashes (dev/CI) keep the 6-char short form.
- Feature test covering all three cases (tag-equal, tag-different, hash).

`composer run fix` applied; PhpStan clean on both touched files (the worktree-wide analyse failure is pre-existing in unrelated MDT/HasLatLng files and this code passes phpstan in CI).