### PR TITLE
#3429 Base runtime image installs procps: every ECS service health check uses pgrep

### DIFF
--- a/docker-compose/app/Dockerfile
+++ b/docker-compose/app/Dockerfile
@@ -66,10 +66,12 @@ ARG user
 ARG uid
 
 # Runtime dependencies only (no -dev headers, no compilers).
-# - First line: CLI tooling used by the app / deploy scripts.
+# - First line: CLI tooling used by the app / deploy scripts. procps provides pgrep, which
+#   EVERY ECS container health check runs (php-fpm/swoole/reverb/queue-worker/cron in
+#   keystoneguru-infra) — removing it makes all services fail health checks and deploys hang.
 # - Second line: shared libraries the compiled PHP extensions link against.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl default-mysql-client gettext zip unzip sudo nano ca-certificates \
+    git curl default-mysql-client gettext zip unzip sudo nano ca-certificates procps \
     libpng16-16 libonig5 libxml2 libzip5 liblua5.3-0 libmagickwand-7.q16-10 \
     libfftw3-double3 liblcms2-2 liblqr-1-0 libfreetype6 libfontconfig1 \
  && rm -rf /var/lib/apt/lists/*

--- a/docker-compose/cron/Dockerfile
+++ b/docker-compose/cron/Dockerfile
@@ -2,9 +2,7 @@ FROM keystone.guru-app
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# procps provides pgrep, which the ECS container health check runs (`pgrep cron`). The lean
-# runtime image (#3320) no longer carries procps transitively, so install it explicitly.
-RUN apt-get update && apt-get -y install cron procps
+RUN apt-get update && apt-get -y install cron
 
 # Copy hello-cron file to the cron.d directory
 COPY etc/cron.d /etc/cron.d

--- a/docker-compose/cron/Dockerfile
+++ b/docker-compose/cron/Dockerfile
@@ -2,7 +2,9 @@ FROM keystone.guru-app
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get -y install cron
+# procps provides pgrep, which the ECS container health check runs (`pgrep cron`). The lean
+# runtime image (#3320) no longer carries procps transitively, so install it explicitly.
+RUN apt-get update && apt-get -y install cron procps
 
 # Copy hello-cron file to the cron.d directory
 COPY etc/cron.d /etc/cron.d


### PR DESCRIPTION
Closes #3429

The v15.2.8 staging deploy hung because ECS kept killing tasks with "failed container health checks" (exit 137) — first observed on cron, then on the web services. Root cause: **every first-party service's container health check in keystoneguru-infra uses `pgrep`** (`php-fpm`, `octane:start`, `reverb:start`, `queue:work`, `cron`), and the lean multi-stage runtime image from #3343 no longer carries `procps` — previously present only as a transitive dependency of the removed Chrome/GTK dev packages. Containers started fine; the probe binary itself was missing (exit 127 → 3 strikes → SIGKILL → CloudFormation never stabilized).

Fix: install `procps` in the **base runtime image** (`docker-compose/app/Dockerfile`), the single place all five service images inherit from, with a comment explaining why it must never be slimmed away. The earlier cron-only fix from this branch is reverted in favour of the base-image fix.

Verified locally:
- built the lean base from the v15.2.8 Dockerfile → `pgrep` confirmed **missing**
- built it with this fix → `pgrep` present at `/usr/bin/pgrep`
- built the cron image on the fixed base and ran the exact ECS probe (`pgrep cron`) in the running container → passes

Ships as v15.2.9; that tag's staging deploy stabilizing is the end-to-end proof.
