### PR TITLE
#3390 Fix rector.php paths and add composer rector script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,6 +159,7 @@
         ],
         "fix": "php-cs-fixer fix",
         "analyse": "phpstan analyse -c phpstan.neon",
+        "rector": "rector process --dry-run",
         "dev": [
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 
 return RectorConfig::configure()
@@ -11,8 +10,6 @@ return RectorConfig::configure()
         __DIR__ . '/app',
         __DIR__ . '/bootstrap',
         __DIR__ . '/config',
-        __DIR__ . '/node_modules',
-        __DIR__ . '/public',
         __DIR__ . '/resources',
         __DIR__ . '/routes',
         __DIR__ . '/tests',
@@ -20,5 +17,4 @@ return RectorConfig::configure()
     // uncomment to reach your current PHP version
     ->withPhpSets(php84: true)
     ->withSets([\RectorLaravel\Set\LaravelSetList::LARAVEL_120])
-    ->withRules([AddVoidReturnTypeWhereNoReturnRector::class])
-    ->withSkip([RemoveUselessParamTagRector::class]);
+    ->withRules([AddVoidReturnTypeWhereNoReturnRector::class]);


### PR DESCRIPTION
Closes #3390

## What

1. **Removed `node_modules` and `public` from `rector.php` `withPaths()`.** `node_modules` is third-party dependency code and `public` is compiled/published output — neither is project source, so Rector must never rewrite them. Running `vendor/bin/rector process` (not `--dry-run`) would previously have attempted to rewrite vendored/generated files.
2. **Added a `composer run rector` script** (`rector process --dry-run`), mirroring the `analyse` script pattern, so Rector provides an on-demand signal like PHP-CS-Fixer and PHPStan.
3. **Dropped the `RemoveUselessParamTagRector` `withSkip()` entry** (and its now-unused import). Rector reported it as *"This skipped rule is never registered"* — the active rule set never enables it, so the skip was dead config emitting a warning on every run.

## Verification

- `composer run rector` runs cleanly over **source only** (no `node_modules`/`public` in the scan) and no longer emits the "never registered" warning.
- It exits `2` because there is a **pending change set** (see below) — this is Rector's expected behaviour when a dry-run finds changes, not a failure.
- `composer run analyse` reports the same 43 pre-existing errors with and without this change — this PR introduces none.

## Deliberately deferred (needs follow-up)

**The advisory CI workflow is intentionally NOT added in this PR.** A dry-run over source surfaces a **large one-time change set (68 files)** from the active `AddVoidReturnTypeWhereNoReturnRector` + `LARAVEL_120` + php84 rule sets — mostly `#[\Override]` attribute and void return-type additions.

Wiring an advisory (`continue-on-error`) workflow now would emit 68 annotations on **every** PR until that backlog lands — permanent noise that defeats the point of an advisory check. The correct sequencing (per the issue's own Risks section) is:

1. **This PR** — path fix + composer script.
2. **Follow-up PR** — land the 68-file Rector change set as its own reviewed diff.
3. **Then, optionally** — add the advisory `rector.yml` workflow (mirroring `phpstan.yml`), starting from a clean baseline where it actually signals new drift.

The composer script alone already satisfies the issue's Definition of Done ("wired in as advisory CI/composer script **or** documented as manual").

> Note: this MR targets `development`, so it will not populate the issue's linked-PR "Development" panel or auto-close #3390 automatically — that must be done manually in the GitHub UI if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)