### PR TITLE
Release v15.2.9 - Deployment pipeline improvements

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/php-coverage.yml
+++ b/.github/workflows/php-coverage.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout for local actions
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/php-coverage.yml
+++ b/.github/workflows/php-coverage.yml
@@ -46,7 +46,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage.xml

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout for local actions
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout for local actions
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'

--- a/database/seeders/releases/v15.2.9.json
+++ b/database/seeders/releases/v15.2.9.json
@@ -1,0 +1,47 @@
+{
+    "id": 369,
+    "release_changelog_id": 376,
+    "version": "v15.2.9",
+    "title": "Deployment pipeline improvements",
+    "backup_db": 0,
+    "silent": 1,
+    "spotlight": 0,
+    "released": 1,
+    "created_at": "2026-07-07T20:03:42+00:00",
+    "updated_at": "2026-07-07T20:03:42+00:00",
+    "changelog": {
+        "id": 376,
+        "release_id": 369,
+        "description": null,
+        "changes": [
+            {
+                "release_changelog_id": 376,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3320,
+                "is_public": 0,
+                "change": "Queue workers now run a dedicated image with Chrome for thumbnail generation; web-facing images no longer ship a browser."
+            },
+            {
+                "release_changelog_id": 376,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3320,
+                "is_public": 0,
+                "change": "Removed the legacy PHP-Deployer flow (deploy.php, php-deployer image and secrets)."
+            },
+            {
+                "release_changelog_id": 376,
+                "release_changelog_category_id": 1,
+                "ticket_id": 3415,
+                "is_public": 0,
+                "change": "Sped up the MR test pipeline: tests sharded by group, coverage dropped from PR runs, Lua build cached."
+            },
+            {
+                "release_changelog_id": 376,
+                "release_changelog_category_id": 5,
+                "ticket_id": 3429,
+                "is_public": 0,
+                "change": "The lean runtime image now includes procps: every ECS container health check runs pgrep, which was lost in the image slimming and made all services fail health checks."
+            }
+        ]
+    }
+}

--- a/docker-compose/app/Dockerfile
+++ b/docker-compose/app/Dockerfile
@@ -66,10 +66,12 @@ ARG user
 ARG uid
 
 # Runtime dependencies only (no -dev headers, no compilers).
-# - First line: CLI tooling used by the app / deploy scripts.
+# - First line: CLI tooling used by the app / deploy scripts. procps provides pgrep, which
+#   EVERY ECS container health check runs (php-fpm/swoole/reverb/queue-worker/cron in
+#   keystoneguru-infra) — removing it makes all services fail health checks and deploys hang.
 # - Second line: shared libraries the compiled PHP extensions link against.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl default-mysql-client gettext zip unzip sudo nano ca-certificates \
+    git curl default-mysql-client gettext zip unzip sudo nano ca-certificates procps \
     libpng16-16 libonig5 libxml2 libzip5 liblua5.3-0 libmagickwand-7.q16-10 \
     libfftw3-double3 liblcms2-2 liblqr-1-0 libfreetype6 libfontconfig1 \
  && rm -rf /var/lib/apt/lists/*

--- a/docker-compose/cron/Dockerfile
+++ b/docker-compose/cron/Dockerfile
@@ -2,9 +2,7 @@ FROM keystone.guru-app
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# procps provides pgrep, which the ECS container health check runs (`pgrep cron`). The lean
-# runtime image (#3320) no longer carries procps transitively, so install it explicitly.
-RUN apt-get update && apt-get -y install cron procps
+RUN apt-get update && apt-get -y install cron
 
 # Copy hello-cron file to the cron.d directory
 COPY etc/cron.d /etc/cron.d

--- a/docker-compose/cron/Dockerfile
+++ b/docker-compose/cron/Dockerfile
@@ -2,7 +2,9 @@ FROM keystone.guru-app
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get -y install cron
+# procps provides pgrep, which the ECS container health check runs (`pgrep cron`). The lean
+# runtime image (#3320) no longer carries procps transitively, so install it explicitly.
+RUN apt-get update && apt-get -y install cron procps
 
 # Copy hello-cron file to the cron.d directory
 COPY etc/cron.d /etc/cron.d


### PR DESCRIPTION
General changes:
  * #3320 Queue workers now run a dedicated image with Chrome for thumbnail generation; web-facing images no longer ship a browser.
  * #3320 Removed the legacy PHP-Deployer flow (deploy.php, php-deployer image and secrets).
  * #3415 Sped up the MR test pipeline: tests sharded by group, coverage dropped from PR runs, Lua build cached.

Bugfixes:
  * #3429 The lean runtime image now includes procps: every ECS container health check runs pgrep, which was lost in the image slimming and made all services fail health checks.

Closes #3320
Closes #3320
Closes #3415
Closes #3429