### PR TITLE
#3441 CI: drop unused Microsoft apt repos before apt-get update

### DIFF
--- a/.github/actions/php-ci-setup/action.yml
+++ b/.github/actions/php-ci-setup/action.yml
@@ -31,6 +31,10 @@ runs:
 
     - name: Install system clients (mysql + redis CLI)
       run: |
+        # Drop the Microsoft apt repos preinstalled on the runner image (azure-cli, microsoft-prod);
+        # nothing here installs from them, and their recurring CDN outages fail `apt-get update`
+        # with "Clearsigned file isn't valid, got 'NOSPLIT'" (#3441).
+        grep -lr "packages.microsoft.com" /etc/apt/sources.list.d/ | xargs -r sudo rm -f
         sudo apt-get update
         sudo apt-get install -y default-mysql-client redis-tools lua5.3 liblua5.3-dev
       shell: bash


### PR DESCRIPTION
Closes #3441

PR CI shards intermittently fail in `php-ci-setup`'s `Install system clients` step because `apt-get update` refreshes the Microsoft apt repos preinstalled on GitHub's runner image (`azure-cli`, `microsoft-prod`), and packages.microsoft.com recurringly serves invalid clearsigned `InRelease` files (`got 'NOSPLIT'`), exiting with code 100. Example: https://github.com/RaiderIO/keystone.guru/actions/runs/28898246847/job/85728266761

We install nothing from those repos — the step only needs `default-mysql-client redis-tools lua5.3 liblua5.3-dev` from the Ubuntu archive. This removes the Microsoft sources before `apt-get update`, making CI immune to their CDN outages. Exposure grew with the #3415 sharding (6-7 apt-get update calls per PR run instead of 1), which is why the flake suddenly became frequent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
