### PR TITLE
#3316 Bump bundler deps + webpack to mix-compatible 5.104.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,12 @@ updates:
     ignore:
       # laravel-mix 6 (unmaintained) is incompatible with newer webpack 5.x:
       # >=5.107 removed webpack/lib/SizeFormatHelpers which mix requires, and
-      # mix's webpackbar@5 fails strict ProgressPlugin option validation.
-      # Keep webpack at ~5.99.9 until the build tooling is migrated off mix.
+      # mix's webpackbar@5 fails strict ProgressPlugin option validation on >=5.106.
+      # 5.104.1 is the highest version verified to build with mix (npm run production),
+      # and it clears the buildHttp allowedUris advisories. Keep webpack pinned here
+      # until the build tooling is migrated off mix (Vite migration, #3449).
       - dependency-name: "webpack"
-        versions: [">5.99"]
+        versions: [">5.104"]
   - package-ecosystem: composer
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "depcheck",
+    "name": "3316-dependabot-bundler-bumps",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^5.15.4",
-                "@shopify/draggable": "^1.0.0-beta.12",
+                "@shopify/draggable": "^1.2.1",
                 "@simonwep/pickr": "^1.8.2",
                 "ajv": "^8.18.0",
                 "bootstrap": "^4.3.1",
@@ -16,7 +16,7 @@
                 "bootswatch": "^5.1.3",
                 "color-interpolate": "^1.0.4",
                 "d3": "7.4.4",
-                "datatables.net": "^2.3.2",
+                "datatables.net": "^2.3.8",
                 "datatables.net-dt": "^2.3.2",
                 "dotenv": "^16.0.1",
                 "geojson-utils": "^1.1.0",
@@ -68,11 +68,11 @@
                 "pusher-js": "^8.4.0",
                 "resolve-url-loader": "^5.0.0",
                 "sass": "^1.89.2",
-                "sass-loader": "^13.0.0",
+                "sass-loader": "^17.0.0",
                 "vitest": "^3.2.6",
                 "vue-template-compiler": "^2.6.14",
-                "webpack": "~5.99.9",
-                "webpack-shell-plugin-next": "^2.2.2"
+                "webpack": "~5.104.1",
+                "webpack-shell-plugin-next": "^2.3.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -3157,9 +3157,10 @@
             ]
         },
         "node_modules/@shopify/draggable": {
-            "version": "1.0.0-beta.12",
-            "resolved": "https://registry.npmjs.org/@shopify/draggable/-/draggable-1.0.0-beta.12.tgz",
-            "integrity": "sha512-Un/Dn61sv2er9yjDXLGWMauCOWBb0BMbm0yzmmrD+oUX2/x50yhNJASTsCRdndUCpWlqYfZH8jEfaOgTPsKc/g=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@shopify/draggable/-/draggable-1.2.1.tgz",
+            "integrity": "sha512-hYKhd99nl1mkO4ybA8i3rxvZgYS2A4Imcxpq7BoUu7h4LmFt997YxHLy8Mm5J7ST+G4DTQXqBsTx9mDid6piZg==",
+            "license": "MIT"
         },
         "node_modules/@simonwep/pickr": {
             "version": "1.8.2",
@@ -3829,6 +3830,18 @@
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
             }
         },
         "node_modules/adjust-sourcemap-loader": {
@@ -6118,9 +6131,9 @@
             }
         },
         "node_modules/datatables.net": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.3.2.tgz",
-            "integrity": "sha512-31TzwIQM0+pr2ZOEOEH6dsHd/WSAl5GDDGPezOHPI3mM2NK4lcDyOoG8xXeWmSbVfbi852LNK5C84fpp4Q+qxg==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.3.8.tgz",
+            "integrity": "sha512-uhViowhlDlheAuo5a8TrkQqADsjrtGeOyvrigvr4t0+K3MyAWqClORXWAYIcN9VLX6iIX0C8O9gwJNd01hITRg==",
             "license": "MIT",
             "dependencies": {
                 "jquery": ">=1.7"
@@ -6133,6 +6146,15 @@
             "license": "MIT",
             "dependencies": {
                 "datatables.net": "2.3.2",
+                "jquery": ">=1.7"
+            }
+        },
+        "node_modules/datatables.net-dt/node_modules/datatables.net": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.3.2.tgz",
+            "integrity": "sha512-31TzwIQM0+pr2ZOEOEH6dsHd/WSAl5GDDGPezOHPI3mM2NK4lcDyOoG8xXeWmSbVfbi852LNK5C84fpp4Q+qxg==",
+            "license": "MIT",
+            "dependencies": {
                 "jquery": ">=1.7"
             }
         },
@@ -6693,6 +6715,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
             "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
@@ -11529,39 +11552,35 @@
             }
         },
         "node_modules/sass-loader": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.1.0.tgz",
-            "integrity": "sha512-tZS1RJQ2n2+QNyf3CCAo1H562WjL/5AM6Gi8YcPVVoNxQX8d19mx8E+8fRrMWsyc93ZL6Q8vZDSM0FHVTJaVnQ==",
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-17.0.0.tgz",
+            "integrity": "sha512-0Ybm8ohBQ9LcrycVrFQp/KQBNX5a3Wda9/smS0mE/xLffzEnwvV8nykOzrbiSWNzTE3IB/jiXx8O4QmDPG2+Gw==",
             "dev": true,
-            "dependencies": {
-                "klona": "^2.0.4",
-                "neo-async": "^2.6.2"
-            },
+            "license": "MIT",
             "engines": {
-                "node": ">= 14.15.0"
+                "node": ">= 22.11.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "fibers": ">= 3.1.0",
-                "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+                "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
                 "sass": "^1.3.0",
                 "sass-embedded": "*",
                 "webpack": "^5.0.0"
             },
             "peerDependenciesMeta": {
-                "fibers": {
-                    "optional": true
-                },
-                "node-sass": {
+                "@rspack/core": {
                     "optional": true
                 },
                 "sass": {
                     "optional": true
                 },
                 "sass-embedded": {
+                    "optional": true
+                },
+                "webpack": {
                     "optional": true
                 }
             }
@@ -13406,23 +13425,6 @@
                 }
             }
         },
-        "node_modules/vite-node/node_modules/yaml": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
-            }
-        },
         "node_modules/vitest": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
@@ -13649,23 +13651,6 @@
                 }
             }
         },
-        "node_modules/vitest/node_modules/yaml": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
-            }
-        },
         "node_modules/vm-browserify": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -13760,35 +13745,36 @@
             "license": "Apache-2.0"
         },
         "node_modules/webpack": {
-            "version": "5.99.9",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
-            "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
+            "version": "5.104.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
+            "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
             "license": "MIT",
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
+                "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.14.0",
-                "browserslist": "^4.24.0",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
+                "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
-                "es-module-lexer": "^1.2.1",
+                "enhanced-resolve": "^5.17.4",
+                "es-module-lexer": "^2.0.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
                 "json-parse-even-better-errors": "^2.3.1",
-                "loader-runner": "^4.2.0",
+                "loader-runner": "^4.3.1",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.2",
-                "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.11",
-                "watchpack": "^2.4.1",
-                "webpack-sources": "^3.2.3"
+                "schema-utils": "^4.3.3",
+                "tapable": "^2.3.0",
+                "terser-webpack-plugin": "^5.3.16",
+                "watchpack": "^2.4.4",
+                "webpack-sources": "^3.3.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -14032,10 +14018,11 @@
             }
         },
         "node_modules/webpack-shell-plugin-next": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/webpack-shell-plugin-next/-/webpack-shell-plugin-next-2.2.2.tgz",
-            "integrity": "sha512-2HeC1e0cCvTgA3SD4XPAD69DnILM92mCschrtKdlLRORHCR+oG7xnibQMkVySxTAYWTQOcBRHlqa88x4syWwhQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/webpack-shell-plugin-next/-/webpack-shell-plugin-next-2.3.3.tgz",
+            "integrity": "sha512-3TMY32HKeEiaKqv6o6MSM3sN/G2HgtPWldINI5YkTyY31XB7I/awarZICBoSusbCYwW13oowG+Xrw9zg3mfT7w==",
             "dev": true,
+            "license": "MIT",
             "peerDependencies": {
                 "webpack": "^5.18.0"
             }
@@ -14049,6 +14036,12 @@
                 "source-list-map": "^2.0.0",
                 "source-map": "~0.6.1"
             }
+        },
+        "node_modules/webpack/node_modules/es-module-lexer": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "license": "MIT"
         },
         "node_modules/webpack/node_modules/schema-utils": {
             "version": "4.3.3",
@@ -16217,9 +16210,9 @@
             "optional": true
         },
         "@shopify/draggable": {
-            "version": "1.0.0-beta.12",
-            "resolved": "https://registry.npmjs.org/@shopify/draggable/-/draggable-1.0.0-beta.12.tgz",
-            "integrity": "sha512-Un/Dn61sv2er9yjDXLGWMauCOWBb0BMbm0yzmmrD+oUX2/x50yhNJASTsCRdndUCpWlqYfZH8jEfaOgTPsKc/g=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@shopify/draggable/-/draggable-1.2.1.tgz",
+            "integrity": "sha512-hYKhd99nl1mkO4ybA8i3rxvZgYS2A4Imcxpq7BoUu7h4LmFt997YxHLy8Mm5J7ST+G4DTQXqBsTx9mDid6piZg=="
         },
         "@simonwep/pickr": {
             "version": "1.8.2",
@@ -16823,6 +16816,12 @@
             "version": "8.17.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="
+        },
+        "acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "requires": {}
         },
         "adjust-sourcemap-loader": {
             "version": "4.0.0",
@@ -18487,9 +18486,9 @@
             }
         },
         "datatables.net": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.3.2.tgz",
-            "integrity": "sha512-31TzwIQM0+pr2ZOEOEH6dsHd/WSAl5GDDGPezOHPI3mM2NK4lcDyOoG8xXeWmSbVfbi852LNK5C84fpp4Q+qxg==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.3.8.tgz",
+            "integrity": "sha512-uhViowhlDlheAuo5a8TrkQqADsjrtGeOyvrigvr4t0+K3MyAWqClORXWAYIcN9VLX6iIX0C8O9gwJNd01hITRg==",
             "requires": {
                 "jquery": ">=1.7"
             }
@@ -18501,6 +18500,16 @@
             "requires": {
                 "datatables.net": "2.3.2",
                 "jquery": ">=1.7"
+            },
+            "dependencies": {
+                "datatables.net": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.3.2.tgz",
+                    "integrity": "sha512-31TzwIQM0+pr2ZOEOEH6dsHd/WSAl5GDDGPezOHPI3mM2NK4lcDyOoG8xXeWmSbVfbi852LNK5C84fpp4Q+qxg==",
+                    "requires": {
+                        "jquery": ">=1.7"
+                    }
+                }
             }
         },
         "de-indent": {
@@ -18916,7 +18925,8 @@
         "es-module-lexer": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true
         },
         "es-object-atoms": {
             "version": "1.1.1",
@@ -22398,14 +22408,11 @@
             }
         },
         "sass-loader": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.1.0.tgz",
-            "integrity": "sha512-tZS1RJQ2n2+QNyf3CCAo1H562WjL/5AM6Gi8YcPVVoNxQX8d19mx8E+8fRrMWsyc93ZL6Q8vZDSM0FHVTJaVnQ==",
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-17.0.0.tgz",
+            "integrity": "sha512-0Ybm8ohBQ9LcrycVrFQp/KQBNX5a3Wda9/smS0mE/xLffzEnwvV8nykOzrbiSWNzTE3IB/jiXx8O4QmDPG2+Gw==",
             "dev": true,
-            "requires": {
-                "klona": "^2.0.4",
-                "neo-async": "^2.6.2"
-            }
+            "requires": {}
         },
         "sax": {
             "version": "1.6.0",
@@ -23677,14 +23684,6 @@
                         "rollup": "^4.43.0",
                         "tinyglobby": "^0.2.15"
                     }
-                },
-                "yaml": {
-                    "version": "2.9.0",
-                    "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-                    "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
                 }
             }
         },
@@ -23772,14 +23771,6 @@
                         "rollup": "^4.43.0",
                         "tinyglobby": "^0.2.15"
                     }
-                },
-                "yaml": {
-                    "version": "2.9.0",
-                    "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-                    "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
                 }
             }
         },
@@ -23863,36 +23854,42 @@
             "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="
         },
         "webpack": {
-            "version": "5.99.9",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
-            "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
+            "version": "5.104.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
+            "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
             "requires": {
                 "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
+                "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.14.0",
-                "browserslist": "^4.24.0",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
+                "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
-                "es-module-lexer": "^1.2.1",
+                "enhanced-resolve": "^5.17.4",
+                "es-module-lexer": "^2.0.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
                 "json-parse-even-better-errors": "^2.3.1",
-                "loader-runner": "^4.2.0",
+                "loader-runner": "^4.3.1",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.2",
-                "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.11",
-                "watchpack": "^2.4.1",
-                "webpack-sources": "^3.2.3"
+                "schema-utils": "^4.3.3",
+                "tapable": "^2.3.0",
+                "terser-webpack-plugin": "^5.3.16",
+                "watchpack": "^2.4.4",
+                "webpack-sources": "^3.3.3"
             },
             "dependencies": {
+                "es-module-lexer": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+                    "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw=="
+                },
                 "schema-utils": {
                     "version": "4.3.3",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -24046,9 +24043,9 @@
             }
         },
         "webpack-shell-plugin-next": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/webpack-shell-plugin-next/-/webpack-shell-plugin-next-2.2.2.tgz",
-            "integrity": "sha512-2HeC1e0cCvTgA3SD4XPAD69DnILM92mCschrtKdlLRORHCR+oG7xnibQMkVySxTAYWTQOcBRHlqa88x4syWwhQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/webpack-shell-plugin-next/-/webpack-shell-plugin-next-2.3.3.tgz",
+            "integrity": "sha512-3TMY32HKeEiaKqv6o6MSM3sN/G2HgtPWldINI5YkTyY31XB7I/awarZICBoSusbCYwW13oowG+Xrw9zg3mfT7w==",
             "dev": true,
             "requires": {}
         },

--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
         "pusher-js": "^8.4.0",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.89.2",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^17.0.0",
         "vitest": "^3.2.6",
         "vue-template-compiler": "^2.6.14",
-        "webpack": "~5.99.9",
-        "webpack-shell-plugin-next": "^2.2.2"
+        "webpack": "~5.104.1",
+        "webpack-shell-plugin-next": "^2.3.3"
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
-        "@shopify/draggable": "^1.0.0-beta.12",
+        "@shopify/draggable": "^1.2.1",
         "@simonwep/pickr": "^1.8.2",
         "ajv": "^8.18.0",
         "bootstrap": "^4.3.1",
@@ -47,7 +47,7 @@
         "bootswatch": "^5.1.3",
         "color-interpolate": "^1.0.4",
         "d3": "7.4.4",
-        "datatables.net": "^2.3.2",
+        "datatables.net": "^2.3.8",
         "datatables.net-dt": "^2.3.2",
         "dotenv": "^16.0.1",
         "geojson-utils": "^1.1.0",


### PR DESCRIPTION
Follow-up to #3316. Combines four Dependabot **security** bumps that all touch the webpack build, verified together with a single local `npm run production` (MR CI never runs the webpack build, so green CI alone does not prove the build):

- sass-loader 13 → 17
- webpack-shell-plugin-next 2.2.2 → 2.3.3
- datatables.net 2.3.2 → 2.3.8
- @shopify/draggable 1.0.0-beta.12 → 1.2.1

**Also bumps webpack 5.99.9 → 5.104.1.** 5.104.1 is the highest version that still builds with laravel-mix 6 (≥5.106 breaks it: webpackbar ProgressPlugin validation; ≥5.107 removes `SizeFormatHelpers`), and it clears the two low-severity webpack `buildHttp`/`allowedUris` advisories. The `.github/dependabot.yml` ignore rule moves from `>5.99` to `>5.104` accordingly. Full pin removal is tracked by the Vite migration (#3449).

### Verification
- ✅ `npm run production` compiles clean with all five bumps (52s, only pre-existing child-compilation warnings).
- ✅ @shopify/draggable 1.2.1: the killzones-sidebar reorder handler binds `drag:out`/`drag:stop` with `draggable`/`classes`/`distance` options and checks `draggable-mirror`/`draggable--original` classes — all confirmed present in the 1.2.1 dist.

Supersedes/closes Dependabot PRs #3401, #3406, #3435, #3436 (their bumps are included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)