### PR TITLE
#3467 Fix cron container building on stale PHP 8.2 base image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,14 @@ services:
     build:
       context: docker-compose/cron
       dockerfile: Dockerfile
+      args:
+        BASE_IMAGE: keystone.guru
+      # The cron Dockerfile builds FROM the app image. `depends_on` does not order *builds*,
+      # so on a cold machine a parallel `docker compose build` would fail before the app image
+      # exists. This named context makes compose build the app service first and resolves
+      # `FROM keystone.guru` to its result (mirrors the horizon/worker service above).
+      additional_contexts:
+        keystone.guru: service:app
     image: keystone.guru-cron
     container_name: keystone.guru-cron
     depends_on:

--- a/docker-compose/cron/Dockerfile
+++ b/docker-compose/cron/Dockerfile
@@ -1,4 +1,5 @@
-FROM keystone.guru-app
+ARG BASE_IMAGE=keystone.guru-app
+FROM ${BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Closes #3467

## Problem

`keystone.guru-cron` crashed on startup after a local image rebuild:

```
Composer detected issues in your platform: Your Composer dependencies require a
PHP version ">= 8.4.1". You are running 8.2.29.
```

## Root cause

`docker-compose/cron/Dockerfile` hardcoded `FROM keystone.guru-app`, but the local `app` service tags its freshly built image as `keystone.guru`. So cron re-stacked on a stale pre-8.4-migration `keystone.guru-app` (v13.12, PHP 8.2) image instead of the current 8.4 one. It only surfaced now because `composer.json` was bumped to require PHP `>= 8.4.1`.

`horizon`/worker already avoids this via `ARG BASE_IMAGE` + a compose override; cron never got the same treatment.

## Fix

- `docker-compose/cron/Dockerfile`: `ARG BASE_IMAGE=keystone.guru-app` + `FROM ${BASE_IMAGE}` (CI/prod default preserved — `release-deploy.yml` builds with no build-arg).
- `docker-compose.yml` cron `build:`: add `args: BASE_IMAGE: keystone.guru` + `additional_contexts: keystone.guru: service:app`, mirroring the `horizon` service.

CI/production is untouched: there the app image is tagged `keystone.guru-app`, which the preserved default resolves to.

## Verification

- `docker compose build cron` builds the fresh `keystone.guru` app image first, then cron.
- `docker compose exec cron php -v` → PHP 8.4.22.
- `docker compose exec cron php artisan schedule:list` runs with no platform_check fatal.

Stale PHP 8.2 images (`keystone.guru-app:latest`, `keystone.guru-app:v13.12`, `keystone.guru-php-deployer:latest`) were also removed from the affected machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)