### PR TITLE
#3445 Make discord log channel a safe no-op when webhook is unset

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -2,6 +2,7 @@
 
 use App\Logging\Handlers\ColoredLineFormatter;
 use App\Logging\Handlers\DeduplicateHandlers;
+use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
 
@@ -67,7 +68,13 @@ return [
             'stream'     => 'php://stderr',
         ],
 
-        'discord' => empty(env('APP_LOG_DISCORD_WEBHOOK')) ? [] : [
+        // When no webhook is configured (e.g. local/testing) discord must still resolve to a
+        // valid channel, otherwise any stack that includes it (like 'scheduler') fails to build
+        // and falls back to the emergency logger. A NullHandler makes discord logging a safe no-op.
+        'discord' => empty(env('APP_LOG_DISCORD_WEBHOOK')) ? [
+            'driver'  => 'monolog',
+            'handler' => NullHandler::class,
+        ] : [
             'driver' => 'custom',
             'url'    => env('APP_LOG_DISCORD_WEBHOOK'),
             'via'    => MarvinLabs\DiscordLogger\Logger::class,

--- a/tests/Unit/App/Logging/SchedulerLogChannelTest.php
+++ b/tests/Unit/App/Logging/SchedulerLogChannelTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\App\Logging;
+
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Regression coverage for #3445: when APP_LOG_DISCORD_WEBHOOK is empty (the local/testing default),
+ * the 'discord' channel must still resolve to a valid channel so the 'scheduler' stack that includes
+ * it can be built without emitting "Undefined array key \"driver\"" warnings or falling back to the
+ * emergency logger.
+ */
+#[Group('Logging')]
+final class SchedulerLogChannelTest extends PublicTestCase
+{
+    #[Test]
+    public function discordChannel_givenEmptyWebhook_resolvesToValidChannel(): void
+    {
+        // Arrange - a configured 'url' means a webhook is set, which is not the case this test guards
+        $discordConfig = config('logging.channels.discord');
+        if (array_key_exists('url', $discordConfig)) {
+            self::markTestSkipped('A discord webhook is configured; this test covers the empty-webhook default.');
+        }
+
+        // Act & Assert
+        self::assertArrayHasKey('driver', $discordConfig, 'discord must be a valid channel even without a webhook.');
+    }
+
+    #[Test]
+    public function schedulerChannel_givenEmptyWebhook_logsWithoutEmittingPhpErrors(): void
+    {
+        // Arrange - force a fresh resolution so channel resolution (and any warning) actually happens
+        Log::forgetChannel('scheduler');
+        Log::forgetChannel('discord');
+
+        $capturedErrors = [];
+        set_error_handler(static function (int $severity, string $message) use (&$capturedErrors): bool {
+            $capturedErrors[] = $message;
+
+            return true;
+        });
+
+        try {
+            // Act
+            Log::channel('scheduler')->info('Regression check for #3445 - scheduler channel must be a safe no-op.');
+        } finally {
+            restore_error_handler();
+        }
+
+        // Assert
+        self::assertSame(
+            [],
+            array_values(array_unique($capturedErrors)),
+            'Logging to the scheduler channel must not emit PHP warnings when the discord webhook is empty.',
+        );
+    }
+}


### PR DESCRIPTION
Closes #3445

## Problem

The `scheduler` log stack unconditionally includes the `discord` channel, but `discord` resolved to an empty array (`[]`) whenever `APP_LOG_DISCORD_WEBHOOK` is empty — the local/testing default. Building the stack then read `$config['driver']` on that empty array, emitting `Undefined array key "driver"` warnings.

## Fix

`discord` now resolves to a valid monolog `NullHandler` channel when no webhook is configured, so any stack that includes it (like `scheduler`) builds cleanly and discord logging becomes a genuine no-op. When a webhook is set, behaviour is unchanged.

## Note on the reported 404

The literal 404 in the issue **no longer reproduces on Laravel 12**: framework `LogManager::get()` now wraps channel resolution in `try/catch (Throwable)` and swallows the failure into the *emergency logger*, so the arrow-delete test was already green before this change — it does not discriminate the bug on v12.

The underlying defect is still real and matches the issue's Definition of Done, and this fix has a positive side effect: because the broken `discord` channel previously fell back to the emergency logger (a `StreamHandler` → `laravel.log`), **every** scheduler log line was leaking into `laravel.log` plus emitting an "Unable to create configured logger" line on every call. With the `NullHandler`, scheduler logs now go only to `scheduler.log`.

## Tests

New `tests/Unit/App/Logging/SchedulerLogChannelTest.php`:
- `discordChannel_givenEmptyWebhook_resolvesToValidChannel` — the resolved `discord` channel config has a `driver` key.
- `schedulerChannel_givenEmptyWebhook_logsWithoutEmittingPhpErrors` — logging to the `scheduler` channel emits no PHP warnings.

Both were verified red before the change and green after. `AjaxArrowControllerTest` and the full `Logging` group pass; `composer run analyse` remains at its pre-existing baseline and `composer run fix` is clean.

## Deferred (optional, follow-up)

The issue's secondary suggestion — narrowing `AjaxArrowController::delete()`'s blanket `catch (Exception) => 404` — was intentionally left out to keep this PR focused. Note `store()` has the identical pattern, so any change there should cover both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)