### PR TITLE
#3474 Vendor headless-browser-verify skill + screenshot-to-PR helper

### DIFF
--- a/.claude/skills/headless-browser-verify/SKILL.md
+++ b/.claude/skills/headless-browser-verify/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: headless-browser-verify
+description: Verify keystone.guru pages in a real headless Chrome - reproduce rendering/JS issues, measure layout, catch page errors, and take screenshots you can view with the Read tool (and post onto a PR). Use when curl/static reasoning is not enough (JS-driven UI, bootstrap-select menus, layout/sizing bugs, "does this actually render" questions). Works from the main checkout or any worktree via its Docker stack.
+---
+
+# Headless browser verification (keystone.guru)
+
+Drive the site in a real Chrome via the `chrome` compose service (chromedp/headless-shell, defined
+in `docker-compose.worktree.yml` behind the `chrome` profile). The driver script runs inside the
+`app` container, where the site is `http://nginx`; screenshots land in the bind-mounted checkout so
+they can be viewed with the Read tool. Proven useful for: bootstrap-select sizing bugs, JS crashes
+on specific pages, layout verification after CSS changes.
+
+## Spin up (per stack, from the worktree/checkout root)
+
+```sh
+docker compose --profile chrome up -d chrome   # profile-gated: normal stack is unaffected
+mkdir -p .chrome-tmp && cp .claude/skills/headless-browser-verify/browse.js .chrome-tmp/
+```
+
+No published ports, so every worktree stack can run its own chrome simultaneously.
+
+## Running
+
+```sh
+docker compose exec -T app sh -c 'cd /var/www && node .chrome-tmp/browse.js http://nginx/search \
+    --screenshot /var/www/.chrome-tmp/shot.png \
+    --click ".affixselect.bootstrap-select button" \
+    --eval "document.querySelectorAll(\".dropdown-menu.show li\").length"'
+```
+
+- Output is JSON: `status`, `chrome` (should say `service`), `pageErrors` (uncaught JS),
+  `consoleErrors`, `evalResult`. Exit 1 on HTTP >= 400 or any page error - a bare run doubles as a
+  smoke test.
+- View the screenshot with the Read tool at `<worktree>/.chrome-tmp/shot.png`.
+- `--eval` takes a JS expression evaluated in the page (JSON-serializable result). For complex
+  measurements/flows write a bespoke script next to browse.js (require puppeteer, copy the
+  `connectToService` helper from browse.js).
+- `--mobile` switches to an iPhone viewport/UA; the site renders a different (sidebar-less) layout
+  for mobile UAs - and curl without a desktop UA is treated as mobile too (a trap when grepping for
+  sidebar markup).
+- `puppeteer` resolves from `/var/www/node_modules` (run with cwd `/var/www`).
+
+## Post the screenshot to a GitHub PR/issue
+
+To make the browser output visible to reviewers, embed the screenshot in the PR body. GitHub has no
+image-upload API, but on this **public** repo an image renders in markdown from any raw URL. The
+`post-screenshot.sh` helper hosts the PNG on a dedicated orphan branch (`verification-screenshots`)
+that carries no code and is never merged, then prints the raw URL:
+
+```sh
+URL=$(.claude/skills/headless-browser-verify/post-screenshot.sh .chrome-tmp/shot.png pr/3471-search.png)
+# then embed in the PR body / a comment:
+#   ![verification](<URL>)
+gh pr comment <pr> --repo RaiderIO/keystone.guru --body "$(printf '![verification](%s)' "$URL")"
+```
+
+- The first call creates the orphan branch; later calls append to it (one file per PR, e.g.
+  `pr/<n>-<page>.png`). The branch accumulates artifacts and is never merged into `master`, so the
+  PR's own diff stays clean.
+- Requires `gh` (authenticated), `jq`, `base64`. Public repo only — private-repo raw URLs do not
+  render in GitHub markdown.
+- Verify it landed: `curl -s -o /dev/null -w '%{http_code}' <URL>` should print `200`.
+
+## How the connection works (for bespoke scripts)
+
+Chrome's DevTools endpoint rejects `Host:` headers that are not an IP or localhost. browse.js
+resolves the `chrome` service name to its IP, fetches `/json/version` from the IP, rewrites the
+`webSocketDebuggerUrl` to that IP, and uses `puppeteer.connect`. Disconnect (do not close) so the
+browser stays warm for the next run.
+
+## Gotchas
+
+- **Auth**: guest pages only, unless you inject a session cookie via a bespoke script
+  (`page.setCookie(...)` with a value taken from a logged-in browser).
+- **Cleanup**: `rm -rf .chrome-tmp` before finishing a task; it must never be committed
+  (untracked, but `git add -A` would grab it). Files written by the container are root-owned, so
+  remove them from inside the container first
+  (`docker compose exec -T -u root app rm -rf /var/www/.chrome-tmp`). Stop chrome with
+  `docker compose --profile chrome stop chrome` if you want it gone.
+- `shm_size: 1gb` on the service is required - with the compose default 64MB /dev/shm, image-heavy
+  pages fail with `net::ERR_INSUFFICIENT_RESOURCES`.
+- The main checkout's docker-compose.yml has no chrome service (only docker-compose.worktree.yml);
+  for the main stack either add one locally or run a worktree.
+- The compose service arrived with the Bootstrap 5 migration branch (#3397 / MR #3419); on branches
+  that predate it, worktree.sh copies docker-compose.worktree.yml from the main repo checkout only
+  if the branch lacks the file entirely - otherwise use the launch fallback: download
+  chrome-headless-shell into `.chrome-tmp/` and apt-install its deps in the app container
+  (libnspr4 libnss3 libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64 libatspi2.0-0t64 libcairo2
+  libcups2t64 libdbus-1-3 libexpat1 libgbm1 libglib2.0-0t64 libpango-1.0-0 libvulkan1
+  libxcomposite1 libxdamage1 libxfixes3 libxkbcommon0 libxrandr2 fonts-liberation); browse.js falls
+  back to `/var/www/.chrome-tmp/chrome-headless-shell-linux64/chrome-headless-shell` automatically.
+  (On Debian 13 / trixie the `t64` package names above apply; older releases use the non-`t64`
+  names.)

--- a/.claude/skills/headless-browser-verify/browse.js
+++ b/.claude/skills/headless-browser-verify/browse.js
@@ -1,0 +1,140 @@
+/**
+ * Generic headless-Chrome driver for verifying keystone.guru pages in a real browser.
+ * Runs INSIDE the app container (node + mounted node_modules), against http://nginx.
+ *
+ * Connects to the compose `chrome` service (CDP on chrome:9222, started with
+ * `docker compose --profile chrome up -d chrome`); falls back to launching a local
+ * chrome-headless-shell binary if the service is unreachable.
+ *
+ * Usage (from the worktree/checkout root on the host):
+ *   docker compose exec -T app sh -c 'cd /var/www && node .chrome-tmp/browse.js <url> [options]'
+ *
+ * Options:
+ *   --screenshot <path>   Save a full-page PNG (use a /var/www/.chrome-tmp/... path so the host can Read it)
+ *   --click <selector>    Click an element after load (repeatable)
+ *   --wait <ms>           Extra wait after load/click (default 1500)
+ *   --eval <js>           Evaluate an expression in the page after everything; JSON result is printed
+ *   --viewport <WxH>      Viewport size (default 1600x1000)
+ *   --mobile              Use a mobile viewport + user agent instead
+ *
+ * Output: JSON on stdout: { url, status, chrome, pageErrors, consoleErrors, evalResult }
+ * Exit code 1 when the HTTP status is >= 400 or a page (JS) error occurred.
+ */
+const puppeteer = require('puppeteer');
+const http = require('http');
+const dns = require('dns').promises;
+
+function arg(name, fallback = null) {
+    const i = process.argv.indexOf('--' + name);
+    return i === -1 ? fallback : process.argv[i + 1];
+}
+
+function args(name) {
+    const result = [];
+    for (let i = 0; i < process.argv.length; i++) {
+        if (process.argv[i] === '--' + name) result.push(process.argv[i + 1]);
+    }
+    return result;
+}
+
+/**
+ * Connect to the compose chrome service. Chrome's DevTools endpoint rejects Host headers that are
+ * not an IP or localhost, so resolve the service name to an IP first and connect through that.
+ */
+async function connectToService(host, port) {
+    const {address} = await dns.lookup(host);
+    const version = await new Promise((resolve, reject) => {
+        const req = http.get({host: address, port, path: '/json/version', timeout: 3000}, res => {
+            let body = '';
+            res.on('data', chunk => body += chunk);
+            res.on('end', () => resolve(JSON.parse(body)));
+        });
+        req.on('error', reject);
+        req.on('timeout', () => req.destroy(new Error('timeout')));
+    });
+    const wsEndpoint = version.webSocketDebuggerUrl.replace(/ws:\/\/[^/]+/, `ws://${address}:${port}`);
+
+    return await puppeteer.connect({browserWSEndpoint: wsEndpoint, defaultViewport: null});
+}
+
+(async () => {
+    const url = process.argv[2];
+    if (!url || url.startsWith('--')) {
+        console.error('usage: node browse.js <url> [--screenshot p] [--click sel] [--wait ms] [--eval js] [--viewport WxH] [--mobile]');
+        process.exit(2);
+    }
+
+    let browser;
+    let chromeSource;
+    try {
+        browser = await connectToService(process.env.CHROME_HOST || 'chrome', parseInt(process.env.CHROME_PORT || '9222', 10));
+        chromeSource = 'service';
+    } catch (e) {
+        // Fallback: local binary (needs the container apt deps - see SKILL.md)
+        browser = await puppeteer.launch({
+            headless: 'new',
+            executablePath: process.env.CHROME_BIN || '/var/www/.chrome-tmp/chrome-headless-shell-linux64/chrome-headless-shell',
+            args: ['--no-sandbox', '--disable-dev-shm-usage'],
+        });
+        chromeSource = 'local launch (service unreachable: ' + e.message + ')';
+    }
+
+    const page = await browser.newPage();
+
+    if (process.argv.includes('--mobile')) {
+        await page.setViewport({width: 390, height: 844, isMobile: true, hasTouch: true});
+        await page.setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1');
+    } else {
+        const [w, h] = (arg('viewport', '1600x1000')).split('x').map(Number);
+        await page.setViewport({width: w, height: h});
+        await page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36');
+    }
+
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on('pageerror', e => pageErrors.push(e.message));
+    page.on('console', msg => {
+        if (msg.type() === 'error') consoleErrors.push(msg.text().substring(0, 300));
+    });
+
+    const response = await page.goto(url, {waitUntil: 'networkidle2', timeout: 60000});
+    const waitMs = parseInt(arg('wait', '1500'), 10);
+    await new Promise(r => setTimeout(r, waitMs));
+
+    for (const selector of args('click')) {
+        const clicked = await page.evaluate(sel => {
+            const el = document.querySelector(sel);
+            if (el) el.click();
+            return !!el;
+        }, selector);
+        if (!clicked) consoleErrors.push(`--click: no element matched ${selector}`);
+        await new Promise(r => setTimeout(r, waitMs));
+    }
+
+    let evalResult;
+    const expression = arg('eval');
+    if (expression) {
+        try {
+            evalResult = await page.evaluate(expression);
+        } catch (e) {
+            evalResult = {evalError: e.message};
+        }
+    }
+
+    const screenshot = arg('screenshot');
+    if (screenshot) {
+        await page.screenshot({path: screenshot, fullPage: !arg('viewport')});
+    }
+
+    const status = response ? response.status() : 0;
+    console.log(JSON.stringify({url, status, chrome: chromeSource, pageErrors, consoleErrors: consoleErrors.slice(0, 10), evalResult}, null, 2));
+
+    // Close the page but keep a shared service browser running for the next invocation
+    await page.close();
+    if (chromeSource === 'service') {
+        browser.disconnect();
+    } else {
+        await browser.close();
+    }
+    process.exit(status >= 400 || pageErrors.length ? 1 : 0);
+})();

--- a/.claude/skills/headless-browser-verify/post-screenshot.sh
+++ b/.claude/skills/headless-browser-verify/post-screenshot.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+# Post a verification screenshot onto a GitHub PR/issue.
+#
+# GitHub has no image-upload API, but on a *public* repo an image renders in
+# markdown from any raw URL. This hosts the PNG on a dedicated orphan branch
+# (`verification-screenshots` by default) that carries no code and is never
+# merged, then prints the raw.githubusercontent.com URL to embed in the PR body:
+#
+#   ![verification](<printed url>)
+#
+# Usage:
+#   post-screenshot.sh <local-png> <dest-path-on-branch>
+#   e.g. post-screenshot.sh .chrome-tmp/shot.png pr/3471-search.png
+#
+# First call creates the orphan branch; later calls append to it.
+#
+# Requires: gh (authenticated), jq, base64. Public repo only — private-repo raw
+# URLs do not render in GitHub markdown.
+set -eu
+
+REPO="${KSG_REPO:-RaiderIO/keystone.guru}"
+BRANCH="${KSG_SCREENSHOT_BRANCH:-verification-screenshots}"
+
+if [ $# -ne 2 ]; then
+    echo "usage: post-screenshot.sh <local-png> <dest-path-on-branch>" >&2
+    exit 2
+fi
+PNG="$1"
+DEST="$2"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Upload the PNG as a git blob (base64; avoids the shell arg-length limit).
+base64 -w0 "$PNG" > "$tmp/b64"
+jq -n --rawfile c "$tmp/b64" '{content:$c, encoding:"base64"}' > "$tmp/blob.json"
+blob="$(gh api -X POST "repos/$REPO/git/blobs" --input "$tmp/blob.json" --jq .sha)"
+
+if parent="$(gh api "repos/$REPO/git/ref/heads/$BRANCH" --jq .object.sha 2>/dev/null)"; then
+    # Branch exists: append the file on top of the current commit/tree.
+    base_tree="$(gh api "repos/$REPO/git/commits/$parent" --jq .tree.sha)"
+    jq -n --arg sha "$blob" --arg dest "$DEST" --arg bt "$base_tree" \
+        '{base_tree:$bt, tree:[{path:$dest, mode:"100644", type:"blob", sha:$sha}]}' > "$tmp/tree.json"
+    tree="$(gh api -X POST "repos/$REPO/git/trees" --input "$tmp/tree.json" --jq .sha)"
+    jq -n --arg t "$tree" --arg p "$parent" \
+        '{message:"Add verification screenshot", tree:$t, parents:[$p]}' > "$tmp/commit.json"
+    commit="$(gh api -X POST "repos/$REPO/git/commits" --input "$tmp/commit.json" --jq .sha)"
+    gh api -X PATCH "repos/$REPO/git/refs/heads/$BRANCH" -f sha="$commit" >/dev/null
+else
+    # First screenshot: create a parentless (orphan) branch with only this file.
+    jq -n --arg sha "$blob" --arg dest "$DEST" \
+        '{tree:[{path:$dest, mode:"100644", type:"blob", sha:$sha}]}' > "$tmp/tree.json"
+    tree="$(gh api -X POST "repos/$REPO/git/trees" --input "$tmp/tree.json" --jq .sha)"
+    jq -n --arg t "$tree" \
+        '{message:"Verification screenshots (orphan asset branch, never merged)", tree:$t, parents:[]}' > "$tmp/commit.json"
+    commit="$(gh api -X POST "repos/$REPO/git/commits" --input "$tmp/commit.json" --jq .sha)"
+    gh api -X POST "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" -f sha="$commit" >/dev/null
+fi
+
+echo "https://raw.githubusercontent.com/$REPO/$BRANCH/$DEST"


### PR DESCRIPTION
Closes #3474

Moves the `headless-browser-verify` dev skill out of a personal `~/.claude/skills` dir and into `.claude/skills/headless-browser-verify/` so it's checked in alongside the other project skills (it's only ever used for this project).

**New capability — post the screenshot onto a PR.** `post-screenshot.sh` hosts a verification screenshot on a dedicated orphan `verification-screenshots` branch (carries no code, never merged, so PR diffs stay clean) and prints a `raw.githubusercontent.com` URL to embed in a PR body/comment. GitHub has no image-upload API, but this renders on a public repo. Verified end-to-end (orphan create + append + raw 200 + delete).

The screenshot on #3473 was posted with exactly this method as the first real use.

### Files
- `SKILL.md` — runbook (adds a "Post the screenshot to a GitHub PR/issue" section)
- `browse.js` — the Chrome driver (unchanged)
- `post-screenshot.sh` — the new helper

### Note
The `chrome` compose service the skill prefers lives on the soon-to-merge Bootstrap 5 branch (#3397 / MR #3419); until then the skill's documented local-launch fallback covers it.