### PR TITLE
#3453 Render wrong-HTTP-method requests as 405 instead of 500

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -16,8 +16,10 @@ use Illuminate\Validation\ValidationException;
 use MarvinLabs\DiscordLogger\Discord\Exceptions\MessageCouldNotBeSent;
 use Override;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
@@ -102,6 +104,16 @@ class Handler extends ExceptionHandler
                 return response()->json(['message' => __('exceptions.handler.api_route_not_found')], StatusCode::NOT_FOUND);
             } elseif ($e instanceof ThrottleRequestsException) {
                 return response()->json(['message' => __('exceptions.handler.too_many_requests')], RFC6585::TOO_MANY_REQUESTS);
+            } elseif ($e instanceof HttpExceptionInterface) {
+                // Preserve the real HTTP status (e.g. 405 Method Not Allowed) and any headers (such as
+                // the Allow header on a 405) instead of collapsing every remaining HttpException to a 500.
+                $statusCode = $e->getStatusCode();
+
+                return response()->json(
+                    ['message' => SymfonyResponse::$statusTexts[$statusCode] ?? __('exceptions.handler.internal_server_error')],
+                    $statusCode,
+                    $e->getHeaders(),
+                );
             } elseif (!config('app.debug')) {
                 return response()->json(['message' => __('exceptions.handler.internal_server_error')], StatusCode::INTERNAL_SERVER_ERROR);
             } elseif (config('app.type') !== 'local') {

--- a/lang/en_US/view_errors.php
+++ b/lang/en_US/view_errors.php
@@ -18,6 +18,10 @@ return [
         'title'   => '404 Not Found',
         'message' => 'Sorry, the page you are looking for could not be found.',
     ],
+    '405' => [
+        'title'   => '405 Method Not Allowed',
+        'message' => 'Sorry, this page does not support that request method.',
+    ],
     '410' => [
         'title'   => '410 Page Expired',
         'message' => 'Sorry, the page you are looking for has expired.',

--- a/resources/views/errors/405.blade.php
+++ b/resources/views/errors/405.blade.php
@@ -1,0 +1,5 @@
+@extends('errors.error-layout', [
+    'title' => __('view_errors.405.title'),
+    'code' => 405,
+    'message' => __('view_errors.405.message')
+    ])

--- a/routes/web.php
+++ b/routes/web.php
@@ -99,6 +99,10 @@ use App\Http\Controllers\UserReportController;
 use App\Http\Controllers\Webhook\GithubWebhookController;
 use App\Http\Controllers\Webhook\WowheadWebhookController;
 use App\Http\Middleware\WowheadCors;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route as RoutingRoute;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
 // Webhooks
 Route::prefix('webhook')->group(static function () {
@@ -811,6 +815,23 @@ Route::middleware(['viewcachebuster', 'language', 'debugbarmessagelogger', 'read
 });
 
 Route::fallback(
-    // Render your 404 page, but now with web middleware (sessions) active
-    fn() => response()->view('errors.404', [], 500),
+    // Reaching the fallback means no route matched this request. The fallback itself is a GET/HEAD
+    // route, so it only ever fires for GET/HEAD requests; if the URI is served under other verbs the
+    // request is a 405 (advertising the allowed verbs), otherwise it is a genuine 404. Aborting - as
+    // opposed to rendering a view inline - keeps the response mapping in App\Exceptions\Handler, while
+    // the 'web' middleware keeps the session active so the rendered error page shows a logged-in nav.
+    static function (Request $request): void {
+        $otherVerbs = collect(Route::getRoutes()->getRoutes())
+            ->filter(static fn(RoutingRoute $route): bool => !$route->isFallback && $route->matches($request, false))
+            ->flatMap(static fn(RoutingRoute $route): array => $route->methods())
+            ->unique()
+            ->reject(static fn(string $method): bool => in_array($method, [Request::METHOD_GET, Request::METHOD_HEAD], true))
+            ->values();
+
+        if ($otherVerbs->isNotEmpty()) {
+            throw new MethodNotAllowedHttpException($otherVerbs->all());
+        }
+
+        abort(Response::HTTP_NOT_FOUND);
+    },
 )->middleware('web');

--- a/tests/Feature/Controller/ErrorResponseTest.php
+++ b/tests/Feature/Controller/ErrorResponseTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Controller;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Controller')]
+#[Group('ErrorResponse')]
+final class ErrorResponseTest extends PublicTestCase
+{
+    #[Test]
+    public function fallback_givenGetRequestToDeleteOnlyRoute_returns405HtmlPage(): void
+    {
+        // Act - /ajax/profile/adfree/{user} is registered for POST and DELETE, but not GET
+        $response = $this->get('/ajax/profile/adfree/1');
+
+        // Assert
+        $response->assertStatus(405);
+        $response->assertHeader('Allow', 'POST, DELETE');
+        $response->assertSee(__('view_errors.405.title'));
+    }
+
+    #[Test]
+    public function fallback_givenJsonGetRequestToDeleteOnlyRoute_returns405Json(): void
+    {
+        // Act
+        $response = $this->getJson('/ajax/profile/adfree/1');
+
+        // Assert
+        $response->assertStatus(405);
+        $response->assertHeader('Allow', 'POST, DELETE');
+        $response->assertJson(['message' => 'Method Not Allowed']);
+    }
+
+    #[Test]
+    public function fallback_givenGetRequestToUnmatchedRoute_returns404HtmlPage(): void
+    {
+        // Act
+        $response = $this->get('/admin/this-route-does-not-exist-xyz');
+
+        // Assert
+        $response->assertStatus(404);
+        $response->assertSee(__('view_errors.404.title'));
+    }
+
+    #[Test]
+    public function fallback_givenJsonGetRequestToUnmatchedRoute_returns404Json(): void
+    {
+        // Act
+        $response = $this->getJson('/ajax/this/route/does/not/exist/xyz');
+
+        // Assert
+        $response->assertStatus(404);
+        $response->assertJson(['message' => __('exceptions.handler.api_route_not_found')]);
+    }
+
+    #[Test]
+    public function render_givenJsonWrongMethodToExistingRoute_returns405JsonWithAllowHeader(): void
+    {
+        // Act - the home page is GET only, so a POST is a genuine method mismatch thrown by the router
+        $response = $this->postJson(route('home'));
+
+        // Assert
+        $response->assertStatus(405);
+        $response->assertHeader('Allow', 'GET, HEAD');
+        $response->assertJson(['message' => 'Method Not Allowed']);
+    }
+}


### PR DESCRIPTION
Closes #3453

## Problem

A GET to a DELETE-only route (e.g. `GET /ajax/profile/adfree/{key}`, or the admin delete routes from #3392) returned **HTTP 500** with a 404-titled error page instead of **405 Method Not Allowed**.

Root cause: the `Route::fallback` closure rendered `errors.404` with a **hardcoded 500** status. Because the fallback is a GET/HEAD catch-all (`.*`), it also *swallowed every GET method mismatch* before the router could raise a 405 — so those requests never reached the exception handler as a 405 at all.

A secondary mis-mapping lived in `Handler::render`: on JSON/API requests, every `HttpException` other than `NotFoundHttpException`/`ThrottleRequestsException` was collapsed to a generic 500, losing the real status code.

## Changes

- **`routes/web.php`** — the fallback now inspects the route table. If the URI is served under other verbs it throws `MethodNotAllowedHttpException` (which advertises the allowed verbs via the `Allow` header); otherwise it `abort(404)`s. Aborting (instead of rendering a view inline) routes the response through `App\Exceptions\Handler`, while the `web` middleware keeps the session active so the rendered HTML error page still shows a logged-in nav.
- **`app/Exceptions/Handler.php`** — JSON/API responses now preserve the real HTTP status code and headers for any `HttpException` (405, 403, 400, …) instead of returning 500.
- Added the missing **`errors/405`** view + `view_errors.405` translations.

## Verification

```
$ curl -s -o /dev/null -w '%{http_code}' -X GET http://…/ajax/profile/adfree/xyz -H 'X-Requested-With: XMLHttpRequest'
405
```

| Request | Before | After |
|---|---|---|
| GET a DELETE-only route (browser) | 500, 404-titled page | **405** HTML page, `Allow` header |
| GET a DELETE-only route (ajax/JSON) | 500 | **405** JSON, `Allow` header |
| GET a genuinely unmatched URI | 500 | **404** |
| POST a GET-only route (JSON) | 500 | **405** JSON, `Allow: GET, HEAD` |

## Tests

Added `tests/Feature/Controller/ErrorResponseTest.php` covering the 405/404 HTML and JSON paths (both the fallback-thrown and router-thrown 405s). Existing Ajax/API/Site controller suites (144 tests) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)