### PR TITLE
#3388 Remove global $with from Npc, eager-load at consumers

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxEnemyController.php
+++ b/app/Http/Controllers/Ajax/AjaxEnemyController.php
@@ -81,6 +81,12 @@ class AjaxEnemyController extends AjaxMappingModelBaseController
             $enemy->load([
                 'npc',
                 'npc.enemyForces',
+                // The admin map re-assigns the enemy's npc from this response - include what the visuals/tooltips read
+                'npc.type',
+                'npc.class',
+                'npc.npcbolsteringwhitelists',
+                'npc.npcHealths',
+                'npc.spells',
                 'floor',
             ])->makeHidden(['floor']);
             // Perform floor change and move enemy to the correct location on the new floor

--- a/app/Http/Controllers/Compendium/NpcCompendiumController.php
+++ b/app/Http/Controllers/Compendium/NpcCompendiumController.php
@@ -36,7 +36,7 @@ class NpcCompendiumController extends Controller
             return redirect(route('npc.compendium.show', $npc), 301);
         }
 
-        $npc->load(['classification', 'dungeons.expansion', 'npcSpells']);
+        $npc->load(['classification', 'type', 'dungeons.expansion', 'npcSpells', 'npcHealths', 'characteristics', 'spells']);
 
         $currentGameVersion = GameVersion::getUserOrDefaultGameVersion();
 
@@ -116,6 +116,8 @@ class NpcCompendiumController extends Controller
         $mappingVersion = $request->dungeon()->getCurrentMappingVersion();
 
         $npcs = Npc::query()
+            // The datatable renders the spells column off the serialized spells relation
+            ->with(['spells'])
             ->selectRaw('npcs.*, npc_name_translations.translation as name, GROUP_CONCAT(DISTINCT dungeon_translations.translation SEPARATOR ", ") AS dungeon_names')
             ->join('enemies', 'enemies.npc_id', '=', 'npcs.id')
             ->join('mapping_versions', 'enemies.mapping_version_id', '=', 'mapping_versions.id')

--- a/app/Http/Controllers/Compendium/SpellCompendiumController.php
+++ b/app/Http/Controllers/Compendium/SpellCompendiumController.php
@@ -55,7 +55,7 @@ class SpellCompendiumController extends Controller
         $spells = Spell::query()
             ->selectRaw('spells.*, spell_name_translations.translation as name,
                 GROUP_CONCAT(DISTINCT dungeon_translations.translation ORDER BY dungeon_translations.translation SEPARATOR ", ") AS dungeon_names')
-            ->with(['npcs' => static fn($query) => $query->without(['type', 'class', 'npcbolsteringwhitelists', 'npcHealths', 'characteristics', 'spells'])])
+            ->with(['npcs'])
             ->leftJoin('spell_dungeons', 'spell_dungeons.spell_id', '=', 'spells.id')
             ->leftJoin('dungeons', 'spell_dungeons.dungeon_id', '=', 'dungeons.id')
             ->leftJoin('translations as dungeon_translations', static function (JoinClause $clause) {

--- a/app/Http/Controllers/NpcController.php
+++ b/app/Http/Controllers/NpcController.php
@@ -147,6 +147,18 @@ class NpcController extends Controller
                 }
             }
 
+            // Re-load the relations so we're echoing/broadcasting back a fully updated npc - the front-end
+            // re-assigns enemy npcs from these payloads and reads these relations in the visuals/tooltips
+            $npcRelationsToEcho = [
+                'type',
+                'class',
+                'npcbolsteringwhitelists',
+                'npcHealths',
+                'spells',
+            ];
+            $npc->load($npcRelationsToEcho);
+            $npcBefore->load($npcRelationsToEcho);
+
             /** @var User $user */
             $user = Auth::user();
             foreach ($npc->dungeons as $dungeon) {
@@ -156,12 +168,6 @@ class NpcController extends Controller
             foreach ($npcBefore->dungeons as $dungeon) {
                 broadcast(new NpcChangedEvent($dungeon, $user, $npcBefore));
             }
-
-            // Re-load the relations so we're echoing back a fully updated npc
-            $npc->load([
-                'npcbolsteringwhitelists',
-                'spells',
-            ]);
 
             // Trigger mapping changed event so the mapping gets saved across all environments
             $this->mappingChanged($npcBefore, $npc);

--- a/app/Logic/MDT/Data/MDTDungeon.php
+++ b/app/Logic/MDT/Data/MDTDungeon.php
@@ -237,16 +237,10 @@ class MDTDungeon
                         $enemy->enemy_id      = -1;
 
                         $enemy->setRelation('floor', $floors->get($floorId));
+                        // We don't care for the npc's relationships here - just want to know if the NPC exists or not
                         $enemy->setRelation(
                             'npc',
-                            $this->dungeon->npcs->firstWhere('id', $enemy->npc_id)?->makeHidden([
-                                // We don't care for the relationships here - just want to know if the NPC exists or not
-                                'type',
-                                'class',
-                                'npcbolsteringwhitelists',
-                                'characteristics',
-                                'spells',
-                            ]) ??
+                            $this->dungeon->npcs->firstWhere('id', $enemy->npc_id) ??
                             new Npc([
                                 'name' => 'UNABLE TO FIND NPC!',
                                 'id'   => $npcId,

--- a/app/Logic/MapContext/MapContextDungeonData.php
+++ b/app/Logic/MapContext/MapContextDungeonData.php
@@ -45,6 +45,11 @@ class MapContextDungeonData implements Arrayable
                         ->on('translations.locale', '=', DB::raw(sprintf('"%s"', $this->locale)));
                 })
                 ->with([
+                    // The front-end reads these relations off the npc objects in this payload (enemy visuals + tooltips)
+                    'type',
+                    'class',
+                    'npcbolsteringwhitelists',
+                    'npcHealths',
                     // Return only spell IDs for each NPC
                     'spells:id',
                 ])
@@ -63,7 +68,6 @@ class MapContextDungeonData implements Arrayable
                     'level',
                     'mdt_scale',
                     'pivot',
-                    'characteristics',
                 ])
                 ->values(),
             config('keystoneguru.cache.dungeonData.ttl'),

--- a/app/Models/Npc/Npc.php
+++ b/app/Models/Npc/Npc.php
@@ -83,15 +83,6 @@ class Npc extends CacheModel implements MappingModelInterface
 
     public $timestamps = false;
 
-    protected $with = [
-        'type',
-        'class',
-        'npcbolsteringwhitelists',
-        'npcHealths',
-        'characteristics',
-        'spells',
-    ];
-
     protected $fillable = [
         'id',
         'dungeon_id',

--- a/app/Service/MDT/MDTMappingExportService.php
+++ b/app/Service/MDT/MDTMappingExportService.php
@@ -247,7 +247,7 @@ MDT.mapPOIs[dungeonIndex] = {};
         $dungeonEnemies = [];
 
         /** @var Collection<int, Npc> $npcs */
-        $npcs = Npc::with('npcEnemyForces')
+        $npcs = Npc::with(['npcEnemyForces', 'type', 'characteristics', 'spells', 'npcHealths'])
             ->join('npc_dungeons', 'npc_dungeons.npc_id', '=', 'npcs.id')
             ->select('npcs.*')
             ->where('npc_dungeons.dungeon_id', $mappingVersion->dungeon_id)

--- a/app/Service/Mapping/MappingExportService.php
+++ b/app/Service/Mapping/MappingExportService.php
@@ -33,25 +33,20 @@ class MappingExportService implements MappingExportServiceInterface
      */
     public function serializeNpcs(): array
     {
-        // Save all NPCs which aren't directly tied to a dungeon. npcbolsteringwhitelists is eager loaded
-        // here (rather than lazily accessed) so this also works under preventLazyLoading on the HTTP path.
-        $npcs = Npc::without([
-            'characteristics',
-            'spells',
-            'enemyForces',
+        // Save all NPCs which aren't directly tied to a dungeon. The relations below are eager loaded
+        // (rather than lazily accessed) so they are serialized into the npcs.json output.
+        // Note: the order of these relations determines the key order in npcs.json - keep it stable.
+        $npcs = Npc::with([
+            'npcbolsteringwhitelists',
+            'npcHealths',
+            'npcEnemyForces',
+            'npcDungeons',
         ])
-            ->with([
-                'npcEnemyForces',
-                'npcDungeons',
-                'npcbolsteringwhitelists',
-            ])
             ->get()
             ->values();
 
         foreach ($npcs as $npc) {
             $npc->makeHidden([
-                'type',
-                'class',
                 'enemy_portrait_url',
             ]);
             $npc->npcbolsteringwhitelists->makeHidden(['whitelistnpc']);

--- a/resources/views/common/dungeonroute/cardvertical.blade.php
+++ b/resources/views/common/dungeonroute/cardvertical.blade.php
@@ -6,7 +6,6 @@ use App\Models\Affix;
 use App\Models\AffixGroup\AffixGroup;
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Laratrust\Role;
-use App\Models\User;
 use App\Service\Cache\CacheServiceInterface;
 
 /**
@@ -249,9 +248,7 @@ use (
 };
 
 if ($cache) {
-    /** @var User|null $authUser */
-    $authUser          = Auth::user();
-    $currentUserLocale = Auth::check() ? $authUser->locale : 'en_US';
+    $currentUserLocale = app()->getLocale();
 // Echo the result of this function
     echo $cacheService->remember(
         DungeonRoute::getCardCacheKey($dungeonroute->id, 'vertical', $currentUserLocale, $showAffixes, $showDungeonImage, (int)$isAdmin),


### PR DESCRIPTION
Part of #3388 (PR 1 of 3 — Npc; User and DungeonRoute follow in separate PRs).

## What

Removes the global `$with = [type, class, npcbolsteringwhitelists, npcHealths, characteristics, spells]` from `Npc` and adds explicit eager-loads at the query sites that actually serialize or render those relations. With `automaticallyEagerLoadRelationships()` enabled, collection-iteration paths need no changes — the work here is preserving **serialized payload shapes**, since unloaded relations silently vanish from JSON.

## Consumer changes

- **MapContextDungeonData** (`dungeonNpcs` payload — the canonical npc source for all map JS): explicitly loads `type`, `class`, `npcbolsteringwhitelists`, `npcHealths` alongside the existing `spells:id`. Payload key set verified identical to master; the nested `whitelistnpc` no longer drags its own 5 cascaded relations along (JS only reads its `name`).
- **MappingExportService::serializeNpcs**: adds `npcHealths` to the explicit loads (was implicit via `$with`); relation order chosen so `npcs.json` stays **byte-identical** (verified with `mapping:save` + git diff). Dead `without()`/`makeHidden(type/class)` removed.
- **NpcController::store**: the relation reload now happens *before* the `NpcChangedEvent` broadcasts (the front-end re-assigns `enemy.npc` from that payload and reads type/class/npc_healths/whitelists in visuals/tooltips), and includes the full set.
- **AjaxEnemyController::store**: response npc keeps the relation set the admin map re-assigns on `save:success`.
- **NpcCompendiumController**: `get()` loads `spells` (the datatable renders that column from the serialized relation); `show()` loads what the view reads.
- **MDTMappingExportService**: explicit `type/characteristics/spells/npcHealths` for the MDT mapping export.
- **MDTDungeon / SpellCompendiumController**: removed now-dead `makeHidden`/`without` of npc relations.

## Incidental fix

`tests/Feature/Controller/SiteControllerTest` failed on master: `cardvertical.blade.php` passed a null authenticated-user locale into `DungeonRoute::getCardCacheKey()`. It now uses `app()->getLocale()`, consistent with `cardhorizontal` / `cardhorizontalrow`.

## Measured

- `Npc::all()` (5953 rows): **13 queries → 1** — and every `Enemy` load (`Enemy::$with = ['npc']`, i.e. every map render/combat-log path) stops cascading the 6 npc relation loads.
- `dungeonNpcs` map-context build: 9 → 8 queries, and the cached payload shrinks (no more nested whitelistnpc relation trees).

## Verified

- Full test suite green in the worktree stack.
- `mapping:save` → `npcs.json` byte-identical.
- Headless Chrome: route map page (96 enemies rendered, npc payload complete, 0 JS errors), NPC compendium table (spells column renders), NPC detail page (health/characteristics/spells sections) — all 200, no page errors.
- `composer run analyse`: same 35 pre-existing errors as master (local env skew), none in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)