### PR TITLE
#3388 Remove global $with from User, eager-load at consumers

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
+++ b/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
@@ -274,7 +274,8 @@ class AjaxDungeonRouteController extends Controller
             'specializations',
             'classes',
             'races',
-            'author',
+            // The route cards render the author's avatar - User no longer eager loads iconfile globally
+            'author.iconfile',
             'affixes',
             'thumbnails',
             'ratings',

--- a/app/Http/Controllers/Api/V1/Public/Route/APIDungeonRouteController.php
+++ b/app/Http/Controllers/Api/V1/Public/Route/APIDungeonRouteController.php
@@ -37,7 +37,8 @@ class APIDungeonRouteController extends Controller
         return new DungeonRouteSummaryEnvelopeResource(
             DungeonRoute::withOnly([
                 'dungeon',
-                'author',
+                // UserLinksResource serializes the author's avatar - User no longer eager loads iconfile globally
+                'author.iconfile',
                 'killZones',
                 'affixes',
                 'thumbnails',

--- a/app/Http/View/Composers/AppLayoutComposer.php
+++ b/app/Http/View/Composers/AppLayoutComposer.php
@@ -26,5 +26,6 @@ readonly class AppLayoutComposer implements ViewComposerInterface
         $view->with('latestReleaseSpotlight', $this->viewService->getLatestReleaseSpotlight());
         $view->with('messageBanner', $this->messageBannerService->getMessage());
         $view->with('readOnlyEnabled', $this->readOnlyModeService->isReadOnly());
+        $view->with('worktree', config('keystoneguru.worktree'));
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -152,14 +152,6 @@ class User extends Authenticatable implements LaratrustUser
         'initials',
     ];
 
-    protected $with = [
-        'iconfile',
-        'patreonUserLink',
-        'dungeon',
-        'gameVersion',
-        'roles',
-    ];
-
     public function getInitialsAttribute(): string
     {
         return initials($this->name);
@@ -237,6 +229,9 @@ class User extends Authenticatable implements LaratrustUser
      */
     public function hasPatreonBenefit(string $key): bool
     {
+        // Explicitly load the relation so this also works on users hydrated in a collection (preventLazyLoading)
+        $this->loadMissing('patreonUserLink');
+
         // True for all admins
         $result = $this->hasRole(Role::ROLE_ADMIN);
 
@@ -255,6 +250,9 @@ class User extends Authenticatable implements LaratrustUser
      */
     public function getPatreonBenefits(): Collection
     {
+        // Explicitly load the relation so this also works on users hydrated in a collection (preventLazyLoading)
+        $this->loadMissing('patreonUserLink');
+
         // Admins have all patreon benefits
         if ($this->hasRole(Role::ROLE_ADMIN)) {
             $result = collect(array_keys(PatreonBenefit::ALL));

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,7 @@ use App\Models\Tags\Tag;
 use App\Models\Traits\GeneratesPublicKey;
 use App\Models\Traits\HasIconFile;
 use App\Models\Traits\HasTags;
+use BackedEnum;
 use Eloquent;
 use Exception;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -74,7 +75,10 @@ class User extends Authenticatable implements LaratrustUser
 {
     use GeneratesPublicKey;
     use HasIconFile;
-    use HasRolesAndPermissions;
+    use HasRolesAndPermissions {
+        hasRole as private traitHasRole;
+        hasPermission as private traitHasPermission;
+    }
     use Notifiable;
     use HasTags;
     /** @use HasFactory<\Database\Factories\UserFactory> */
@@ -222,6 +226,28 @@ class User extends Authenticatable implements LaratrustUser
     public function isOAuth(): bool
     {
         return empty($this->password);
+    }
+
+    /**
+     * @param string|array<int, string|BackedEnum> $name
+     */
+    public function hasRole(string|array|BackedEnum $name, mixed $team = null, bool $requireAll = false): bool
+    {
+        // Explicitly load the relation so this also works on users hydrated in a collection (preventLazyLoading)
+        $this->loadMissing('roles');
+
+        return $this->traitHasRole($name, $team, $requireAll);
+    }
+
+    /**
+     * @param string|array<int, string|BackedEnum> $permission
+     */
+    public function hasPermission(string|array|BackedEnum $permission, mixed $team = null, bool $requireAll = false): bool
+    {
+        // Explicitly load the relation so this also works on users hydrated in a collection (preventLazyLoading)
+        $this->loadMissing('roles');
+
+        return $this->traitHasPermission($permission, $team, $requireAll);
     }
 
     /**

--- a/app/Repositories/Database/DungeonRoute/DungeonRouteRepository.php
+++ b/app/Repositories/Database/DungeonRoute/DungeonRouteRepository.php
@@ -97,7 +97,8 @@ class DungeonRouteRepository extends DatabaseRepository implements DungeonRouteR
 
         return DungeonRoute::where('team_id', config('keystoneguru.raider_io.team_id'))
             ->with([ // @phpstan-ignore argument.type (Larastan passes concrete relation type; contravariant closure parameter is correct at runtime)
-                'author',
+                // The route cards render the author's avatar - User no longer eager loads iconfile globally
+                'author.iconfile',
                 'dungeon',
                 'tags' => $tagsFilterFn,
             ])
@@ -245,7 +246,8 @@ class DungeonRouteRepository extends DatabaseRepository implements DungeonRouteR
         ?DungeonRoute            $excludeDungeonRoute = null,
     ): EloquentBuilder {
         $query = DungeonRoute::query()
-            ->with(['author'])
+            // The search result cards render the author's avatar - User no longer eager loads iconfile globally
+            ->with(['author.iconfile'])
             ->when(
                 $filter->username !== null,
                 fn(EloquentBuilder $query) => $query->whereRelation('author', 'name', 'LIKE', '%' . $filter->username . '%'),

--- a/app/Service/DungeonRoute/DevDiscoverService.php
+++ b/app/Service/DungeonRoute/DevDiscoverService.php
@@ -25,7 +25,8 @@ class DevDiscoverService extends BaseDiscoverService
             ->when($this->closure !== null, $this->closure)
             ->select('dungeon_routes.*')
             ->with([
-                'author',
+                // The route cards render the author's avatar - User no longer eager loads iconfile globally
+                'author.iconfile',
                 'affixes',
                 'ratings',
                 'mappingVersion',
@@ -69,7 +70,8 @@ class DevDiscoverService extends BaseDiscoverService
             ->when($this->closure !== null, $this->closure)
             ->select('dungeon_routes.*')
             ->with([
-                'author',
+                // The route cards render the author's avatar - User no longer eager loads iconfile globally
+                'author.iconfile',
                 'affixes',
                 'ratings',
                 'mappingVersion',

--- a/app/Service/DungeonRoute/DiscoverService.php
+++ b/app/Service/DungeonRoute/DiscoverService.php
@@ -57,7 +57,8 @@ class DiscoverService extends BaseDiscoverService
             ->limit($this->limit)
             ->when($this->closure !== null, $this->closure)
             ->with([
-                'author',
+                // The route cards render the author's avatar - User no longer eager loads iconfile globally
+                'author.iconfile',
                 'affixes',
                 'ratings',
                 'mappingVersion',
@@ -140,7 +141,8 @@ class DiscoverService extends BaseDiscoverService
         return DungeonRoute::query()->limit($this->limit)
             ->when($this->closure !== null, $this->closure)
             ->with([
-                'author',
+                // The route cards render the author's avatar - User no longer eager loads iconfile globally
+                'author.iconfile',
                 'affixes',
                 'ratings',
                 'mappingVersion',

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -6,6 +6,12 @@ return [
         'Admin',
     ],
 
+    // sh/worktree.sh sets COMPOSE_PROJECT_NAME to "ksg-<branch>" for a worktree stack; unset on the
+    // main stack and in production, so this is null there.
+    'worktree' => ($composeProjectName = env('COMPOSE_PROJECT_NAME')) !== null && str_starts_with($composeProjectName, 'ksg-')
+        ? substr($composeProjectName, strlen('ksg-'))
+        : null,
+
     'db_backup_dir'            => env('DB_BACKUP_DIR'),
     'mapping_backup_dir'       => env('MAPPING_BACKUP_DIR'),
     'assets_base_url'          => env('ASSETS_BASE_URL', '/'),

--- a/lang/en_US/view_common.php
+++ b/lang/en_US/view_common.php
@@ -251,6 +251,7 @@ return [
             'trademark'                       => 'Trademark',
             'trademark_footer'                => 'World of Warcraft, Warcraft and Blizzard Entertainment are trademarks or registered trademarks of Blizzard Entertainment, Inc. in the U.S. and/or other countries. This website is not affiliated with Blizzard Entertainment.',
             'social'                          => 'Social',
+            'worktree'                        => '(worktree: :worktree)',
         ],
         'header' => [
             'toggle_navigation_title' => 'Toggle navigation',

--- a/resources/assets/sass/theme/_footer.scss
+++ b/resources/assets/sass/theme/_footer.scss
@@ -105,4 +105,11 @@
             font-size: calc(1.07rem + (1.2 - 1.07) * ((100vw - 20rem) / (48 - 20)));
         }
     }
+
+    // Only rendered on a git-worktree dev stack (config('keystoneguru.worktree')) - loud on purpose,
+    // so it's obvious at a glance which checkout a browser tab is pointed at.
+    &__worktree {
+        color: #ffc107;
+        font-weight: 700;
+    }
 }

--- a/resources/views/common/layout/footer.blade.php
+++ b/resources/views/common/layout/footer.blade.php
@@ -2,7 +2,10 @@
 
 use App\Models\Laratrust\Role;
 
-/** @var boolean $hasNewChangelog */
+/**
+ * @var boolean     $hasNewChangelog
+ * @var string|null $worktree
+ */
 ?>
 <footer class="site-footer">
     <section class="site-footer__section">
@@ -132,6 +135,9 @@ use App\Models\Laratrust\Role;
                 <div class="col-12 mt-4">
                     <p class="site-footer__copyright mb-0">
                         {{ $nameAndVersion }}
+                        @isset($worktree)
+                            <span class="site-footer__worktree">{{ __('view_common.layout.footer.worktree', ['worktree' => $worktree]) }}</span>
+                        @endisset
                     </p>
                 </div>
             </div>

--- a/resources/views/layouts/sitepage.blade.php
+++ b/resources/views/layouts/sitepage.blade.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Auth;
  * @var string      $theme
  * @var Model       $menuModelEdit
  * @var string|null $messageBanner
+ * @var string|null $worktree
  */
 
 $user = Auth::user();

--- a/tests/Feature/App/Models/UserTest.php
+++ b/tests/Feature/App/Models/UserTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\App\Models;
+
+use App\Models\Laratrust\Role;
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('User')]
+final class UserTest extends PublicTestCase
+{
+    #[Test]
+    public function hasRole_givenUserHydratedInMultiRowCollection_doesNotLazyLoadRolesRelation(): void
+    {
+        // Arrange - fetching more than one row arms Eloquent's preventLazyLoading for these models
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        try {
+            $user = User::query()->whereIn('id', [$userA->id, $userB->id])->get()->firstOrFail();
+
+            // Act & Assert - would throw LazyLoadingViolationException if `roles` isn't explicitly loaded first
+            $this->assertFalse($user->hasRole(Role::ROLE_ADMIN));
+        } finally {
+            $userA->delete();
+            $userB->delete();
+        }
+    }
+
+    #[Test]
+    public function hasPermission_givenUserHydratedInMultiRowCollection_doesNotLazyLoadRolesRelation(): void
+    {
+        // Arrange - fetching more than one row arms Eloquent's preventLazyLoading for these models
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        try {
+            $user = User::query()->whereIn('id', [$userA->id, $userB->id])->get()->firstOrFail();
+
+            // Act & Assert - would throw LazyLoadingViolationException if `roles` isn't explicitly loaded first
+            $this->assertFalse($user->hasPermission('some-permission-that-does-not-exist'));
+        } finally {
+            $userA->delete();
+            $userB->delete();
+        }
+    }
+}

--- a/tests/Feature/Controller/SiteControllerTest.php
+++ b/tests/Feature/Controller/SiteControllerTest.php
@@ -38,4 +38,32 @@ final class SiteControllerTest extends PublicTestCase
             $user->delete();
         }
     }
+
+    #[Test]
+    public function index_givenWorktreeConfigured_rendersWorktreeNameInFooter(): void
+    {
+        // Arrange
+        config(['keystoneguru.worktree' => '1234-some-worktree']);
+
+        // Act
+        $response = $this->get(route('home'));
+
+        // Assert
+        $response->assertOk();
+        $response->assertSee('1234-some-worktree');
+    }
+
+    #[Test]
+    public function index_givenNoWorktreeConfigured_doesNotRenderWorktreeFooterElement(): void
+    {
+        // Arrange
+        config(['keystoneguru.worktree' => null]);
+
+        // Act
+        $response = $this->get(route('home'));
+
+        // Assert
+        $response->assertOk();
+        $response->assertDontSee('site-footer__worktree');
+    }
 }


### PR DESCRIPTION
:robot: Part of #3388 (second of three: Npc → **User** → DungeonRoute). Follows the method proven on the Npc MR #3486.

## What changed

- **`User`** no longer globally eager loads `iconfile`, `patreonUserLink`, `dungeon`, `gameVersion`, `roles` on every hydration.
- `hasPatreonBenefit()` / `getPatreonBenefits()` now `loadMissing('patreonUserLink')` so they stay safe on users hydrated in collections (e.g. team member lists) under `preventLazyLoading`.
- Query sites that render the author's avatar (route cards / API `UserLinksResource`) now eager load `author.iconfile` explicitly: `DiscoverService`, `DevDiscoverService`, `DungeonRouteRepository` (weekly routes + search), `AjaxDungeonRouteController::htmlsearch`, `APIDungeonRouteController::index`.
- **`hasRole()` / `hasPermission()`** are now overridden on `User` to `loadMissing('roles')` before delegating to Laratrust. See "Fixed after initial review" below — this correction supersedes the original "roles was pure waste" claim.

## Why the rest needs no changes

- **Serialization is shape-stable by construction**: `User::$visible = [id, public_key, name, echo_color]` filters relations out of every JSON payload (datatables author rows, statemanager `setUserData`, inline JS options), so dropping `$with` changes no payload.
- **`Auth::user()` and other single-model loads may lazy-load freely**: `Builder::hydrate()` only arms `preventsLazyLoading` when a query returns more than one model, so the per-request consumers (`GameVersion::getUserOrDefaultGameVersion`, `DungeonService::getDungeonContext`, nav avatar, profile/patreon blades, presence channel callbacks) keep working and now only query on demand.

## Fixed after initial review

Manual testing after the initial push found the homepage (and any page rendering multiple different
users, e.g. route-card authors) 500ing with `Attempted to lazy load [roles] on model [App\Models\User]`.

The original claim that "Laratrust's `hasRole` never reads the loaded relation" was wrong:
`UserDefaultChecker::userCachedRoles()` falls back to `$user->getRelationValue('roles')` on a cache
miss, and `laratrust.cache.enabled` defaults to `APP_ENV === production` — so it's *always* a miss in
dev/test, and still a miss on the very first check per user even in production. Any `User` hydrated
as part of a multi-row collection (e.g. distinct route-card authors) trips `preventLazyLoading` the
moment `hasRole()`/`hasPermission()`/`getIsAdminAttribute()`/`hasPatreonBenefit()` is called on it.

Fix: `User::hasRole()` / `User::hasPermission()` now `loadMissing('roles')` first, mirroring the
existing `patreonUserLink` pattern, via trait-method aliasing (`use HasRolesAndPermissions { hasRole
as private traitHasRole; ... }`). Covered by a new `tests/Feature/App/Models/UserTest.php`, which
fetches a multi-row `User` collection and calls both methods without eager-loading `roles` — verified
it fails on the pre-fix code and passes with the fix.

## Bundled: worktree identifier in the site footer

Unrelated to the `$with` removal, but bundled into this PR at Wotuu's request: the footer now shows
a `(worktree: <branch>)` badge next to the copyright line when the app is served from a git-worktree
dev stack, so it's obvious at a glance which browser tab points at which worktree.

- `config('keystoneguru.worktree')` is derived from `COMPOSE_PROJECT_NAME` (`sh/worktree.sh` sets it
  to `ksg-<branch>` for every worktree it creates); unset on the main stack and in production, so the
  badge never renders there.
- Deliberately **not** folded into `ViewService::getAppVersionInfo()` / `$nameAndVersion` — that value
  is memoized behind a Redis key shared by every worktree and the main stack (`cachedGlobal()`), so
  baking worktree-specific text into it would leak one worktree's identity into another's rendered
  page. It's passed as its own uncached view variable from `AppLayoutComposer` instead.
- Covered by two new cases in `SiteControllerTest`.

## Measured (real HTTP via nginx, MySQL `Com_select` per request, model cache off, 3 stable samples)

| Page | guest master → PR | auth master → PR |
|---|---|---|
| `/` | 89 → 89 | 144 → **143** |
| `/dungeonroutes` | 167 → 167 | 255 → **233** |
| `/routes/retail/pit-of-saron` | 157 → 157 | 227 → **224** |
| route map page | 309 → **302** | 340 → **322** |
| `/ajax/search` (20 cards) | 185 → **179** (cold and warm) | — |

## Verified

- Full suite in the worktree stack: 991 passed; only failure is `MapTilesExistenceTest`, which fails identically on master here (missing local tile files, unrelated).
- Headless-Chrome A/B vs master: home, `/dungeonroutes`, discover dungeon, route map page (172 markers) — 0 pageErrors, identical rendered card HTML on `/ajax/search`.
- Authenticated click-through (`/profile`, `/admin/users`) both 200; `preventLazyLoading` throws in this env, so any missed eager-load would have 500ed.
- Homepage/`/routes`/`/routes/retail/pit-of-saron` re-verified 200 after the `hasRole`/`hasPermission` fix.
- Footer badge confirmed rendering correctly on this worktree stack, absent on the main stack.
- `composer run fix` and `composer run analyse` clean (0 errors after syncing `vendor/` via `composer install`).