### PR TITLE
#3388 Remove global $with from DungeonRoute, eager-load at consumers

### DIFF
--- a/app/Http/Controllers/AdminTools/AdminToolsEnemyForcesController.php
+++ b/app/Http/Controllers/AdminTools/AdminToolsEnemyForcesController.php
@@ -58,13 +58,7 @@ class AdminToolsEnemyForcesController extends Controller
     {
         $dungeonId = (int)$request->get('dungeon_id');
 
-        $builder = DungeonRoute::without([
-            'faction',
-            'specializations',
-            'classes',
-            'races',
-            'affixes',
-        ])
+        $builder = DungeonRoute::query()
             ->select('id')
             ->when($dungeonId !== -1, static fn(Builder $builder) => $builder->where('dungeon_id', $dungeonId));
 

--- a/app/Http/Controllers/AdminTools/AdminToolsThumbnailsController.php
+++ b/app/Http/Controllers/AdminTools/AdminToolsThumbnailsController.php
@@ -24,14 +24,8 @@ class AdminToolsThumbnailsController extends Controller
         $dungeonId   = (int)$request->get('dungeon_id');
         $onlyMissing = (int)$request->get('only_missing');
 
-        $builder = DungeonRoute::without([
-            'faction',
-            'specializations',
-            'classes',
-            'races',
-            'affixes',
-        ])
-            ->with('dungeon')
+        // ThumbnailService::queueThumbnailRefresh() reads dungeon and mappingVersion on every route
+        $builder = DungeonRoute::with(['dungeon', 'mappingVersion'])
             ->when($dungeonId !== -1, static fn(Builder $builder) => $builder->where('dungeon_id', $dungeonId))
             ->orderByDesc('created_at');
 

--- a/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
+++ b/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
@@ -100,7 +100,6 @@ class AjaxDungeonRouteController extends Controller
         }
 
         $routes = DungeonRoute::with($withRelations)
-            ->without(['season'])
             // Specific selection of dungeon columns; if we don't do it somehow the Affixes and Attributes of the result is cleared.
             // Probably selecting similar named columns leading Laravel to believe the relation is already satisfied.
             ->selectRaw('dungeon_routes.*, mapping_versions.enemy_forces_required_teeming, mapping_versions.enemy_forces_required, MAX(mapping_versions.id) as dungeon_latest_mapping_version_id')
@@ -269,11 +268,8 @@ class AjaxDungeonRouteController extends Controller
             $season = Season::find($request->get('season'));
         }
 
+        // Everything the rendered route cards read - DungeonRoute no longer eager loads relations globally
         $query = DungeonRoute::with([
-            'faction',
-            'specializations',
-            'classes',
-            'races',
             // The route cards render the author's avatar - User no longer eager loads iconfile globally
             'author.iconfile',
             'affixes',
@@ -283,6 +279,7 @@ class AjaxDungeonRouteController extends Controller
             'dungeon',
             'dungeon.activeFloors',
             'mappingVersion',
+            'season.expansion',
         ])
             ->join('dungeons', 'dungeon_routes.dungeon_id', 'dungeons.id')
             ->join('mapping_versions', 'mapping_versions.dungeon_id', 'dungeons.id')

--- a/app/Models/DungeonRoute/DungeonRoute.php
+++ b/app/Models/DungeonRoute/DungeonRoute.php
@@ -236,18 +236,6 @@ class DungeonRoute extends Model implements TracksPageViewInterface
         'thumbnail_updated_at',
     ];
 
-    protected $with = [
-        'mappingVersion',
-        'dungeon',
-        'season',
-        'faction',
-        'specializations',
-        'classes',
-        'races',
-        'affixes',
-        'thumbnails',
-    ];
-
     protected function casts(): array
     {
         return [
@@ -279,8 +267,9 @@ class DungeonRoute extends Model implements TracksPageViewInterface
      */
     public function getSetupAttribute(): array
     {
-        // Telescope has an issue where somehow it doesn't have these relations loaded and causes crashes
-        $this->load([
+        // Telescope has an issue where somehow it doesn't have these relations loaded and causes crashes.
+        // loadMissing keeps that guarantee without re-querying when the relations were already eager loaded.
+        $this->loadMissing([
             'faction',
             'specializations',
             'classes',
@@ -749,6 +738,10 @@ class DungeonRoute extends Model implements TracksPageViewInterface
 
     public function getHasThumbnailAttribute(): bool
     {
+        // Explicitly load the relation so this appended attribute also works on routes hydrated
+        // in a collection (preventLazyLoading)
+        $this->loadMissing('thumbnails');
+
         return $this->thumbnails->isNotEmpty();
     }
 

--- a/app/Repositories/Database/DungeonRoute/DungeonRouteRepository.php
+++ b/app/Repositories/Database/DungeonRoute/DungeonRouteRepository.php
@@ -44,7 +44,9 @@ class DungeonRouteRepository extends DatabaseRepository implements DungeonRouteR
      */
     public function getDungeonRoutesWithExpiredThumbnails(?Collection $dungeonRoutes = null): Collection
     {
-        return DungeonRoute::where('author_id', '>', '0')
+        // ThumbnailService::queueThumbnailRefresh() reads dungeon and mappingVersion on every returned route
+        return DungeonRoute::with(['dungeon', 'mappingVersion'])
+            ->where('author_id', '>', '0')
             // Check if in queue, if so skip, unless the queue age is longer than keystoneguru.thumbnail.refresh_requeue_hours
             ->where(static function (EloquentBuilder $builder) {
                 $builder->whereColumn('thumbnail_refresh_queued_at', '<', 'thumbnail_updated_at')
@@ -97,9 +99,14 @@ class DungeonRouteRepository extends DatabaseRepository implements DungeonRouteR
 
         return DungeonRoute::where('team_id', config('keystoneguru.raider_io.team_id'))
             ->with([ // @phpstan-ignore argument.type (Larastan passes concrete relation type; contravariant closure parameter is correct at runtime)
-                // The route cards render the author's avatar - User no longer eager loads iconfile globally
+                // Everything the rendered route cards read - DungeonRoute no longer eager loads relations globally
                 'author.iconfile',
                 'dungeon',
+                'affixes',
+                'mappingVersion',
+                'season.expansion',
+                'thumbnails',
+                'ratings',
                 'tags' => $tagsFilterFn,
             ])
             ->when($dungeon, fn(EloquentBuilder $query) => $query->where('dungeon_id', $dungeon->id))
@@ -246,8 +253,16 @@ class DungeonRouteRepository extends DatabaseRepository implements DungeonRouteR
         ?DungeonRoute            $excludeDungeonRoute = null,
     ): EloquentBuilder {
         $query = DungeonRoute::query()
-            // The search result cards render the author's avatar - User no longer eager loads iconfile globally
-            ->with(['author.iconfile'])
+            // Everything the rendered search result cards read - DungeonRoute no longer eager loads relations globally
+            ->with([
+                'author.iconfile',
+                'dungeon',
+                'affixes',
+                'mappingVersion',
+                'season.expansion',
+                'thumbnails',
+                'ratings',
+            ])
             ->when(
                 $filter->username !== null,
                 fn(EloquentBuilder $query) => $query->whereRelation('author', 'name', 'LIKE', '%' . $filter->username . '%'),

--- a/app/Service/DungeonRoute/DevDiscoverService.php
+++ b/app/Service/DungeonRoute/DevDiscoverService.php
@@ -7,7 +7,6 @@ use App\Models\Dungeon;
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Season;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Collection;
 
 class DevDiscoverService extends BaseDiscoverService
@@ -31,17 +30,8 @@ class DevDiscoverService extends BaseDiscoverService
                 'ratings',
                 'mappingVersion',
                 'thumbnails',
-                'dungeon' => fn(BelongsTo $query) => $query->without(['gameVersion']),
-                'season'  => fn(BelongsTo $query) => $query->without([
-                    'affixGroups',
-                    'dungeons',
-                ])->with('expansion'),
-            ])
-            ->without([
-                'faction',
-                'specializations',
-                'classes',
-                'races',
+                'dungeon',
+                'season.expansion',
             ])
             ->join('dungeons', 'dungeon_routes.dungeon_id', '=', 'dungeons.id')
             ->join('mapping_versions', 'mapping_versions.id', 'dungeon_routes.mapping_version_id')
@@ -76,17 +66,8 @@ class DevDiscoverService extends BaseDiscoverService
                 'ratings',
                 'mappingVersion',
                 'thumbnails',
-                'dungeon' => fn(BelongsTo $query) => $query->without(['gameVersion']),
-                'season'  => fn(BelongsTo $query) => $query->without([
-                    'affixGroups',
-                    'dungeons',
-                ])->with('expansion'),
-            ])
-            ->without([
-                'faction',
-                'specializations',
-                'classes',
-                'races',
+                'dungeon',
+                'season.expansion',
             ])
             ->join('dungeons', 'dungeon_routes.dungeon_id', '=', 'dungeons.id')
             ->join('mapping_versions', 'mapping_versions.id', 'dungeon_routes.mapping_version_id')

--- a/app/Service/DungeonRoute/DiscoverService.php
+++ b/app/Service/DungeonRoute/DiscoverService.php
@@ -9,7 +9,6 @@ use App\Models\PublishedState;
 use App\Models\Season;
 use App\Service\Cache\Traits\RemembersToFile;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Collection;
 
 class DiscoverService extends BaseDiscoverService
@@ -63,17 +62,8 @@ class DiscoverService extends BaseDiscoverService
                 'ratings',
                 'mappingVersion',
                 'thumbnails',
-                'dungeon' => fn(BelongsTo $query) => $query->without(['gameVersion']),
-                'season'  => fn(BelongsTo $query) => $query->without([
-                    'affixGroups',
-                    'dungeons',
-                ])->with('expansion'),
-            ])
-            ->without([
-                'faction',
-                'specializations',
-                'classes',
-                'races',
+                'dungeon',
+                'season.expansion',
             ])
             // This query makes sure that routes which are 'catch all' for affixes drop down since they aren't as specific
             // as routes who only have say 1 or 2 affixes assigned to them.
@@ -147,17 +137,8 @@ class DiscoverService extends BaseDiscoverService
                 'ratings',
                 'mappingVersion',
                 'thumbnails',
-                'dungeon' => fn(BelongsTo $query) => $query->without(['gameVersion']),
-                'season'  => fn(BelongsTo $query) => $query->without([
-                    'affixGroups',
-                    'dungeons',
-                ])->with('expansion'),
-            ])
-            ->without([
-                'faction',
-                'specializations',
-                'classes',
-                'races',
+                'dungeon',
+                'season.expansion',
             ])
             ->select('dungeon_routes.*')
             ->join('dungeons', 'dungeons.id', 'dungeon_routes.dungeon_id')

--- a/app/Service/View/ViewService.php
+++ b/app/Service/View/ViewService.php
@@ -91,7 +91,6 @@ class ViewService implements ViewServiceInterface
         return $this->cachedGlobal('demo_routes', static fn() => DungeonRoute::where('demo', true)
             ->join('mapping_versions', 'mapping_versions.id', '=', 'dungeon_routes.mapping_version_id')
             ->where('mapping_versions.game_version_id', GameVersion::getDefaultGameVersion()->id)
-            ->without(['thumbnails'])
             ->where('published_state_id', PublishedState::ALL[PublishedState::WORLD_WITH_LINK])
             ->orderBy('dungeon_routes.dungeon_id')
             ->get());

--- a/resources/views/common/maps/map.blade.php
+++ b/resources/views/common/maps/map.blade.php
@@ -63,6 +63,8 @@ $embedStyle          ??= '';
 $edit                = isset($edit) && $edit;
 $mapClasses          ??= '';
 $dungeonroute        ??= null;
+// The inline map JS reads affixes (and the setup/has_thumbnail appends) off the serialized route
+$dungeonroute?->loadMissing(['affixes']);
 $liveSession         ??= null;
 $mapBackgroundColor  ??= null;
 $controlOptions      ??= [];


### PR DESCRIPTION
:robot: Closes #3388 — third and final part (Npc #3486 → User #3495 → **DungeonRoute**). Stacked on #3495 (base branch), so this diff shows only the DungeonRoute work; GitHub will retarget to `master` when #3495 merges.

## What changed

- **`DungeonRoute`** no longer globally eager loads its 9 relations (`mappingVersion`, `dungeon`, `season`, `faction`, `specializations`, `classes`, `races`, `affixes`, `thumbnails`).
- `getSetupAttribute()` switched from `load()` to `loadMissing()` — the old code **re-queried faction/specs/classes/races on every serialization even when eager loaded**; now it only queries when missing.
- `getHasThumbnailAttribute()` now `loadMissing('thumbnails')` so the appended attribute is safe on collection-hydrated routes.
- Card-rendering query sites got the full card relation set (`author.iconfile`, `dungeon`, `affixes`, `mappingVersion`, `season.expansion`, `thumbnails`, `ratings`): weekly routes + route search in `DungeonRouteRepository`, `htmlsearch` in `AjaxDungeonRouteController`.
- `DungeonRouteRepository::getDungeonRoutesWithExpiredThumbnails()` now eager loads `dungeon`+`mappingVersion` — `ThumbnailService::queueThumbnailRefresh()` reads both on every returned route (this method re-queries bare models, so callers' eager loads never helped).
- `AdminToolsThumbnailsController` same fix; `AdminToolsEnemyForcesController` builder reads only `id` — no relations at all now.
- `map.blade.php` explicitly `loadMissing(['affixes'])` on the route — the inline map JS reads `affixes`/`setup` off the serialized route options.
- Dead code removed: every `->without([...])` on DungeonRoute (`AjaxDungeonRouteController`, `DiscoverService`, `DevDiscoverService`, `ViewService` demo routes, both AdminTools controllers) plus the `dungeon`/`season` sub-`without()` closures in the discover services, which referred to `Dungeon`/`Season` `$with` entries that #3302 already removed.

## Why the rest needs no changes

- `mapping:save` demo-route export calls `unsetRelations()` + `setAppends([])` + explicit `load()` — seeder JSON is byte-shape independent of `$with`.
- `DungeonRoutePolicy`, map context, MDT/SimulationCraft exports, and all single-route pages operate on route-bound/`find()` models, which may lazy-load freely (`preventLazyLoading` only arms on >1-row hydrations).
- The datatables JS reads `dungeon.name`/`dungeon.expansion.shortname`/`affixes`/`setup`/`author.name` — all still in that endpoint's explicit `with`; `mappingVersion`/`season` objects were serialized but never read, so the rows just got smaller.
- The delete cascade explicitly loads everything it touches.

## Measured (authed, per-request dev query log — deterministic, no cross-traffic)

| Page | master | after User #3495 | after this PR |
|---|---|---|---|
| `/` | 220 | 212 | 212 |
| `/dungeonroutes` | 342 | 313 | 313 |
| discover dungeon | 308 | 298 | 298 |
| **route map page** | 386 | 361 | **340** |
| **`/ajax/search` (20 cards)** | 467 | 450 | **437** |
| **single `DungeonRoute` hydration** | 14 | 14 | **1** |

The last row is the big one: every route-model binding (all `/ajax/route/{route}` PATCH/PUT/DELETE ops, API `show`, ratings, favorites, thumbnail jobs, ...) used to drag 13 relation queries.

## Verified

- Full suite: 987 passed; only failure is `MapTilesExistenceTest` (env-only, fails identically on master on this machine).
- Headless-Chrome vs master: home, discover, search, route map page (172 markers) — 0 pageErrors; `/ajax/search` rendered card HTML byte-identical (class histogram + route set).
- Serialized map options A/B: `dungeonroute.affixes` and `.setup` present and equal on both sides.
- `composer run fix` / `composer run analyse` clean.