### PR TITLE
#3504 Fix map settings range sliders full width + filled track

### DIFF
--- a/resources/assets/css/map.css
+++ b/resources/assets/css/map.css
@@ -1250,3 +1250,11 @@ html, body, #map, #app, .wrapper {
 #heatmap_search_sidebar.embed #heatmap_search_options_current_filters {
     height: 106px;
 }
+
+/* Map settings range sliders: full width with a themed filled track.
+   Bootstrap 5's .form-range sets appearance:none, which removes the native
+   left-fill; native rendering + accent-color restores it (adapts per theme). */
+.map_settings_range {
+    width: 100%;
+    accent-color: var(--bs-primary);
+}

--- a/resources/views/common/forms/mapsettings.blade.php
+++ b/resources/views/common/forms/mapsettings.blade.php
@@ -31,7 +31,7 @@ $mapEnemyDangerousBorder          = $_COOKIE['map_enemy_dangerous_border'] ?? 0;
         </div>
         <div class="row">
             <div class="col">
-                <input id="map_settings_zoom_speed" class="form-control-range" type="range" min="0"
+                <input id="map_settings_zoom_speed" class="map_settings_range" type="range" min="0"
                        max="100" value="{{ $mapZoomSpeed }}">
             </div>
             <div class="col-auto value">
@@ -101,7 +101,7 @@ $mapEnemyDangerousBorder          = $_COOKIE['map_enemy_dangerous_border'] ?? 0;
         </div>
         <div class="row">
             <div class="col">
-                <input id="map_settings_unkilled_enemy_opacity" class="form-control-range" type="range" min="0"
+                <input id="map_settings_unkilled_enemy_opacity" class="map_settings_range" type="range" min="0"
                        max="100" value="{{ $mapUnkilledEnemyOpacity }}">
             </div>
             <div class="col-auto value">
@@ -123,7 +123,7 @@ $mapEnemyDangerousBorder          = $_COOKIE['map_enemy_dangerous_border'] ?? 0;
         </div>
         <div class="row">
             <div class="col">
-                <input id="map_settings_unkilled_important_enemy_opacity" class="form-control-range" type="range"
+                <input id="map_settings_unkilled_important_enemy_opacity" class="map_settings_range" type="range"
                        min="0" max="100" value="{{ $mapUnkilledImportantEnemyOpacity }}">
             </div>
             <div class="col-auto value">
@@ -187,7 +187,7 @@ $mapEnemyDangerousBorder          = $_COOKIE['map_enemy_dangerous_border'] ?? 0;
         </div>
         <div class="row">
             <div class="col">
-                <input id="map_settings_kill_zone_path_weight" class="form-control-range" type="range" min="1"
+                <input id="map_settings_kill_zone_path_weight" class="map_settings_range" type="range" min="1"
                        max="5" value="{{ $killzonePathWeight }}">
             </div>
             <div class="col-auto value">


### PR DESCRIPTION
:robot: Closes #3504

## Problem
The range sliders in the map settings modal (zoom speed, unkilled enemy opacity, unkilled important enemy opacity, kill zone path stroke width) regressed in the Bootstrap 4 → 5 upgrade (#3397):

- BS4's `form-control-range` class was **removed** in BS5, so the sliders fell back to the browser's intrinsic (~130px) width instead of filling the column.
- BS5's replacement `.form-range` renders a flat track with **no filled portion** — the slider became "a dot on a white line", losing the filled-left track that showed the current value.

## Fix
Render the ranges **natively** (no `appearance: none`) under a dedicated `.map_settings_range` class:

```css
.map_settings_range {
    width: 100%;
    accent-color: var(--bs-primary);
}
```

`accent-color` restores the native filled-left track, and using the BS5 `--bs-primary` CSS variable means the fill colour adapts to each bootswatch theme automatically. No JS required.

## Verification
Verified in a real headless Chrome against the map settings modal (darkly theme) with the actual blade markup + the exact CSS rule. All four sliders are full-width with a themed filled track proportional to their value (zoom 50 → half, pull-path 5/max → full).

**Before** (`.form-range` — dot on a line):

![before](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3504-before.png)

**After** (`.map_settings_range` — filled themed track):

![after](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3504-after.png)

_Assets are compiled by CI on deploy; `map.css` is already covered by the existing `resources/assets/css/**/*.css` mix glob._

🤖 Generated with [Claude Code](https://claude.com/claude-code)