### PR TITLE
#3462 Migrate .dismiss-close to BS5 .btn-close (shim 4)

### DIFF
--- a/resources/assets/css/general.css
+++ b/resources/assets/css/general.css
@@ -96,18 +96,18 @@ select.form-control {
     }
 }
 
-.modal .modal-content .dismiss-close {
+/* The generic modal component places .btn-close as a direct child of .modal-content (no .modal-header),
+   so position it in the top-right corner. Scoped to the direct child so modals that do use a
+   .modal-header keep Bootstrap's native placement. */
+.modal .modal-content > .btn-close {
     position: absolute;
     top: 10px;
     right: 10px;
     z-index: 100;
-    font-size: 26px;
-    /* Theme-dependent: white on the dark themes, near-black on lux (white was invisible on lux modals) */
-    color: var(--theme-text-contrast);
 }
 
 @media screen and (max-width: 480px) {
-    .modal .modal-content .dismiss-close {
+    .modal .modal-content > .btn-close {
         top: 20px;
         right: 20px;
     }

--- a/resources/assets/js/custom/inline/layouts/app.js
+++ b/resources/assets/js/custom/inline/layouts/app.js
@@ -29,7 +29,7 @@ class LayoutsApp extends InlineCode {
             this._newPassword('#modal-register_password');
         }
 
-        $('.dismiss-close,.close_alternative').unbind('click').bind('click', function () {
+        $('[data-alert-dismiss-id]').unbind('click').bind('click', function () {
             let dismissId = $(this).data('alert-dismiss-id');
             // Cookie is now set to dismiss this alert permanently
             Cookies.set(`alert-dismiss-${dismissId}`, true, $.extend({expires: 30}, cookieDefaultAttributes));

--- a/resources/assets/sass/theme/theme.scss
+++ b/resources/assets/sass/theme/theme.scss
@@ -16,6 +16,14 @@
   @include spread-map($theme-map-vapor);
 }
 
+/* Bootstrap 5's .btn-close is a dark SVG intended for light backgrounds (lux). On our dark themes
+   the modal/alert backgrounds are dark, so invert it to white - the same filter BS5 itself applies
+   under [data-bs-theme="dark"], keyed here to our root theme classes instead. */
+:root.darkly .btn-close,
+:root.vapor .btn-close {
+  filter: invert(1) grayscale(100%) brightness(200%);
+}
+
 body {
   font-family: Salesforce Sans, Arial, sans-serif;
   background-color: var($--theme-darker) !important;
@@ -25,25 +33,6 @@ body {
 .theme {
   .nav-item-divider {
     margin: 0 0.75em;
-  }
-
-  /* Project-owned close button for modals/alerts (Bootstrap 5 removed .close; we keep the FontAwesome icon design) */
-  .dismiss-close {
-    float: right;
-    padding: 0;
-    background-color: transparent;
-    border: 0;
-    font-size: 1.5rem;
-    font-weight: 700;
-    line-height: 1;
-    color: var($--theme-text-contrast);
-    opacity: .5;
-
-    &:hover, &:focus {
-      color: var($--theme-text-contrast);
-      text-decoration: none;
-      opacity: .75;
-    }
   }
 
   /** Tom Select (the .selectpicker selects) **/

--- a/resources/views/admin/tools/combatlog/parsefailures.blade.php
+++ b/resources/views/admin/tools/combatlog/parsefailures.blade.php
@@ -80,9 +80,7 @@
                         {{ __('view_admin.tools.combatlog.parsefailures.segments_modal_title') }}
                         <span id="parsefailures_segments_run_id"></span>
                     </h5>
-                    <button type="button" class="dismiss-close" data-bs-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <p class="text-muted small">

--- a/resources/views/common/general/alert.blade.php
+++ b/resources/views/common/general/alert.blade.php
@@ -10,12 +10,10 @@ $rootClass ??= '';
 $align     ??= 'start';
 ?>
 @if(!isAlertDismissed($name))
-    <div class="alert alert-{{ $type }} text-{{$align}} mt-4 {{ $dismiss ? 'alert-dismissable' : '' }} {{ $rootClass }}"
+    <div class="alert alert-{{ $type }} text-{{$align}} mt-4 {{ $dismiss ? 'alert-dismissible' : '' }} {{ $rootClass }}"
          role="alert">
         @if($dismiss)
-            <a href="#" class="dismiss-close" data-bs-dismiss="alert" aria-label="close" data-alert-dismiss-id="{{ $name }}">
-                <i class="fas fa-times"></i>
-            </a>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="close" data-alert-dismiss-id="{{ $name }}"></button>
         @endif
 
         @if($type === 'info')

--- a/resources/views/common/general/modal.blade.php
+++ b/resources/views/common/general/modal.blade.php
@@ -18,9 +18,7 @@ $showClose ??= true;
     <div class="{{ $class }} modal-dialog modal-{{$size}} vertical-align-center">
         <div class="modal-content">
             @if($showClose)
-                <button type="button" class="dismiss-close" data-bs-dismiss="modal" aria-hidden="true">
-                    <i class="fas fa-times"></i>
-                </button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             @endif
             <div class="probootstrap-modal-flex">
                 <div class="probootstrap-modal-content">


### PR DESCRIPTION
:robot: Closes #3462 (shim 4 of the inventory — one shim per PR)

## What

Removes the project-owned **`.dismiss-close`** BS4-compat shim (issue #3462, item 4) in favour of Bootstrap 5's native **`.btn-close`**. BS5 removed BS4's `.close`; we had kept a FontAwesome × renamed to `.dismiss-close`, styled in both `theme.scss` and `general.css` and coloured with `--theme-text-contrast`.

- Delete the `.dismiss-close` styling from `theme.scss` and `general.css`.
- Modal / alert / parsefailures markup now uses `<button class="btn-close">` (the FA `<i class="fas fa-times">` is dropped — BS5 renders its own SVG).
- **Theming:** instead of `--theme-text-contrast`, the close button is themed per root theme class — `darkly`/`vapor` get the exact white filter BS5 itself applies under `[data-bs-theme="dark"]`; `lux` keeps the default dark SVG (visible on its light modals). One small rule replaces the whole `.dismiss-close` block.
- The generic modal component positions `.btn-close` top-right via a **direct-child** selector (`.modal .modal-content > .btn-close`) so modals that use a `.modal-header` (parsefailures) keep BS5's native placement.
- Fix the BS4 `alert-dismissable` typo → BS5 `alert-dismissible`, so the alert positions its close button natively (it previously relied on the shim's `float: right`).
- Narrow the dismiss-cookie click handler from `.dismiss-close` to `[data-alert-dismiss-id]` — only alerts set the cookie; this also stops modal closes writing an `alert-dismiss-undefined` cookie.

## Verification

- `npm run production` builds clean; `.btn-close` + the white filter compile into the theme CSS.
- Headless-Chrome A/B vs master on the login modal: **darkly** → white × top-right (`filter: invert(1)…`), **lux** → dark × top-right (`filter: none`) — matches the old `--theme-text-contrast` behaviour. Injected `alert-dismissible` confirmed the close button sits top-right inside the alert.
- `npm test` (134 JS tests) green; `SiteControllerTest` + `ViewComposerSmokeTest` green (homepage renders the modal component); `composer run fix` / `analyse` clean.

> Note: `npm run production` is currently failing on `master` for an **unrelated** reason (a co-located `*.test.js` file swept into the production bundle by commit 776966c7b); that is being fixed separately on `master`. It is not part of this MR.
