### PR TITLE
#3462 Migrate navbar-padding & link-underline shims to native BS5 (shim 5/7)

### DIFF
--- a/resources/assets/sass/_variables.scss
+++ b/resources/assets/sass/_variables.scss
@@ -7,3 +7,11 @@
 // Typography
 $font-family-sans-serif: Salesforce Sans, Arial, sans-serif;
 $line-height-base: 1.6;
+
+// Links
+// Bootstrap 4 did not underline links (hover only); Bootstrap 5 underlines them by default. Set
+// once here (before the theme imports in app.scss) instead of repeating it in every theme scss.
+// Safe to set globally: no bootswatch theme overrides these vars, and the value is identical across
+// all themes.
+$link-decoration: none;
+$link-hover-decoration: underline;

--- a/resources/assets/sass/theme/darkly/darkly.scss
+++ b/resources/assets/sass/theme/darkly/darkly.scss
@@ -1,9 +1,5 @@
 // Bootstrap theme (bootstrap should be between these)
 .darkly {
-  // Bootstrap 4 did not underline links (hover only); Bootstrap 5 underlines them by default
-  $link-decoration: none;
-  $link-hover-decoration: underline;
-
   // Bootstrap 4 compiled every theme with the global $body-bg: #2B3E50 from sass/_variables.scss
   // (removed in this migration). The color is nearly invisible in darkly — the page background is
   // forced to var(--theme-darker) elsewhere — but bootswatch derives a few component colors from
@@ -12,8 +8,8 @@
   $body-bg: #2B3E50;
 
   // Bootstrap 5 dropped the default navbar x-padding ($navbar-padding-x is now null); restore the
-  // Bootstrap 4 default so the navbar keeps its edge inset on mobile (lux/vapor override .navbar
-  // padding directly and are unaffected)
+  // 1rem inset so the navbar keeps its edge padding on mobile (lux/vapor set the same var too;
+  // darkly's y-padding already comes out at 1rem via bootswatch's own $spacer)
   $navbar-padding-x: 1rem;
 
   @import "~bootswatch/dist/darkly/variables";

--- a/resources/assets/sass/theme/lux/lux.scss
+++ b/resources/assets/sass/theme/lux/lux.scss
@@ -1,8 +1,9 @@
 // Bootstrap theme (bootstrap should be between these)
 .lux {
-  // Bootstrap 4 did not underline links (hover only); Bootstrap 5 underlines them by default
-  $link-decoration: none;
-  $link-hover-decoration: underline;
+  // Match darkly's navbar height: Bootstrap 5 defaults navbar padding to (null x, 0.5rem y); set
+  // the 1rem inset via SCSS vars instead of a separate .navbar { padding } CSS override
+  $navbar-padding-x: 1rem;
+  $navbar-padding-y: 1rem;
 
   @import "~bootswatch/dist/lux/variables";
   @import "~bootstrap/scss/bootstrap";
@@ -10,11 +11,6 @@
 
   body {
     font-size: 0.9375rem;
-  }
-
-  /** Lux special - make sure the top header has the same height as the one in Darkly */
-  .navbar {
-    padding: 1rem 1rem;
   }
 
   .form-control {

--- a/resources/assets/sass/theme/vapor/vapor.scss
+++ b/resources/assets/sass/theme/vapor/vapor.scss
@@ -1,8 +1,9 @@
 // Bootstrap theme (bootstrap should be between these)
 .vapor {
-  // Bootstrap 4 did not underline links (hover only); Bootstrap 5 underlines them by default
-  $link-decoration: none;
-  $link-hover-decoration: underline;
+  // Match darkly's navbar height: Bootstrap 5 defaults navbar padding to (null x, 0.5rem y); set
+  // the 1rem inset via SCSS vars instead of a separate .navbar { padding } CSS override
+  $navbar-padding-x: 1rem;
+  $navbar-padding-y: 1rem;
 
   // Keep the pre-BS5 look: this theme always rendered with the navy body background (via the old
   // global $body-bg), giving slate inputs/modals instead of bootswatch vapor's purple
@@ -40,10 +41,6 @@
 
   .dropdown-menu {
     background-color: var(--theme-darker);
-  }
-
-  .navbar {
-    padding: 1rem 1rem !important;
   }
 
   .nav-tabs .nav-link.active {


### PR DESCRIPTION
:robot: Part of #3462 — removes shims **5** (navbar padding) and **7** (link underlines), the next PR in the issue's recommended order (`5/7`).

## Shim 5 — navbar `$navbar-padding-x` restore
The 1rem navbar inset lived in three different forms across the themes:
- **darkly**: `$navbar-padding-x: 1rem` SCSS var
- **lux**: `.navbar { padding: 1rem 1rem }` plain CSS override
- **vapor**: `.navbar { padding: 1rem 1rem !important }` CSS override

Unified onto the single BS5-native mechanism: lux and vapor now set `$navbar-padding-x`/`$navbar-padding-y` SCSS vars (like darkly) and the CSS overrides — including vapor's `!important` — are deleted. Bootswatch never sets `.navbar` padding itself, so the variable mechanism is the sole source and the `!important` was purely defensive.

## Shim 7 — link underlines
`$link-decoration: none` / `$link-hover-decoration: underline` were repeated in all three theme files. Moved to the global `sass/_variables.scss` (imported before the themes in `app.scss`), so a fourth theme can't silently regress to BS5's default underlines. No bootswatch theme overrides these vars, so a single global definition is safe.

## Verification — rule-level diff of the compiled production CSS
Built `npm run production` on master and on this branch, normalised both `app-*.css` to one rule per line, and diffed. The **entire** delta is:

- `.lux .navbar` and `.vapor .navbar` rule bodies only.
- Both resolve to the **same effective padding as before** (1rem all sides):
  - lux before: bootstrap `1.5rem 0` **overridden** by `padding:1rem` → 1rem. After: `--bs-navbar-padding-x/y:1rem` → 1rem. Identical.
  - vapor before: bootstrap `0.5rem 0` **overridden** by `padding:1rem!important` → 1rem. After: 1rem/1rem via vars. Identical.
- darkly navbar: no diff (already 1rem/1rem).
- **link decoration: zero diff** — centralising the vars is byte-identical output.

So the render is provably unchanged on every theme; this is a pure mechanism cleanup. `composer run analyse` (PhpStan) is green. No PHP/JS/Blade touched, so there is no PHPUnit surface.