### PR TITLE
#3462 Migrate vapor $body-bg shim to native bootswatch purple

### DIFF
--- a/resources/assets/sass/_variables.scss
+++ b/resources/assets/sass/_variables.scss
@@ -1,8 +1,11 @@
 // Body
 // NOTE: $body-bg must NOT be pre-set globally here. Bootstrap 5 derives --bs-body-bg from it and
 // feeds that variable into cards, modals, dropdowns and list-groups, so a global value would leak
-// the same background into every theme (light themes included). Each theme sets its own $body-bg
-// in its theme scss (darkly) or falls back to its bootswatch default (lux, vapor).
+// the same background into every theme (light themes included) — which is exactly what the old
+// global $body-bg: #2B3E50 navy did under Bootstrap 4. Each theme now owns its background:
+//   - darkly keeps that navy #2B3E50 as a deliberate permanent choice (see darkly.scss);
+//   - vapor sets its native bootswatch purple #1a0933 explicitly (see vapor.scss);
+//   - lux sets nothing here and inherits its bootswatch (light) default.
 
 // Typography
 $font-family-sans-serif: Salesforce Sans, Arial, sans-serif;

--- a/resources/assets/sass/theme/darkly/darkly.scss
+++ b/resources/assets/sass/theme/darkly/darkly.scss
@@ -4,11 +4,14 @@
   $link-decoration: none;
   $link-hover-decoration: underline;
 
+  // Permanent design choice (not a temporary shim): keep the navy #2B3E50 body background.
   // Bootstrap 4 compiled every theme with the global $body-bg: #2B3E50 from sass/_variables.scss
-  // (removed in this migration). The color is nearly invisible in darkly — the page background is
-  // forced to var(--theme-darker) elsewhere — but bootswatch derives a few component colors from
-  // $body-bg (e.g. the active nav-tab background in the map settings modal), so keep the same
-  // value to stay pixel-identical with the Bootstrap 4 output.
+  // (removed in this migration). This value is deliberately NOT bootswatch darkly's own default
+  // ($gray-900, a near-black): the navy is nearly invisible in darkly — the page background is
+  // forced to var(--theme-darker) elsewhere — but Bootstrap 5 derives component colors from
+  // $body-bg (e.g. the active nav-tab background in the map settings modal), so keeping it stays
+  // pixel-identical with the established Bootstrap 4 look. Unlike vapor (which adopted its native
+  // bootswatch bg), darkly is the flagship theme and this navy is part of its intended appearance.
   $body-bg: #2B3E50;
 
   // Bootstrap 5 dropped the default navbar x-padding ($navbar-padding-x is now null); restore the

--- a/resources/assets/sass/theme/vapor/vapor.scss
+++ b/resources/assets/sass/theme/vapor/vapor.scss
@@ -4,9 +4,12 @@
   $link-decoration: none;
   $link-hover-decoration: underline;
 
-  // Keep the pre-BS5 look: this theme always rendered with the navy body background (via the old
-  // global $body-bg), giving slate inputs/modals instead of bootswatch vapor's purple
-  $body-bg: #2B3E50;
+  // Use bootswatch vapor's native deep-purple body background (#1a0933). Under Bootstrap 4 this
+  // theme rendered with the global $body-bg: #2B3E50 (a navy pollution artifact that leaked into
+  // every theme), which gave slate inputs/modals instead of vapor's intended purple. That global
+  // is gone; falling back to the bootswatch default restores the theme's real palette, from which
+  // Bootstrap 5 also derives --bs-body-bg for cards, modals, dropdowns and list-groups.
+  $body-bg: #1a0933;
 
   @import "~bootswatch/dist/vapor/variables";
   @import "~bootstrap/scss/bootstrap";


### PR DESCRIPTION
:robot: Part of #3462 (Bootstrap-4-compat shim inventory). This is **shim 6: per-theme `$body-bg`**.

## What
The old global `$body-bg: #2B3E50` (navy) leaked the same background into every theme under BS4. It was removed during the BS5 migration and each theme now owns its background. This PR finalizes shim 6 by resolving the one open decision — the **vapor** theme's background:

- **vapor** → switched from the pinned navy `#2B3E50` to bootswatch vapor's own default **`#1a0933`** (deep purple). BS5 derives `--bs-body-bg`, input backgrounds (`$input-bg: lighten($body-bg, 10%)`) and the body gradient from it, so vapor now renders its intended purple palette instead of the historical navy artifact.
- **darkly** → keeps its navy `#2B3E50`, now documented as a **deliberate permanent choice** (it drives component colors like the active nav-tab bg in the map settings modal, and is nearly invisible behind `--theme-darker`; bootswatch darkly's own default `$gray-900` would visibly change it).
- **`_variables.scss`** → the removed-global rationale comment finalized to describe each theme owning its background.

Cards, modals, dropdowns and list-groups on vapor use `--theme-*` variables, so they are unaffected — only the body background/gradient and native input backgrounds shift.

## Verification
Headless-Chrome A/B (branch vs master) on the vapor theme, 1600×1000, zero `pageError`s:

- Home: body background navy → purple.
- Login (form inputs): inputs slate → dark purple, no layout change.

`composer run fix` clean (only an unrelated pre-existing file was reformatted; discarded). No PHP touched, so PhpStan is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)