### PR TITLE
#3462 Document vendored vapor bootswatch as a permanent design choice

### DIFF
--- a/resources/assets/sass/theme/vapor/dist/_bootswatch.scss
+++ b/resources/assets/sass/theme/vapor/dist/_bootswatch.scss
@@ -1,5 +1,22 @@
-// Vapor 5.2.2
-// Bootswatch
+// Vapor 5.2.2 — Bootswatch, VENDORED + HAND-MODIFIED. Do NOT replace with the upstream import.
+//
+// This is a deliberate, permanent fork of bootswatch's vapor `_bootswatch.scss` (imported by
+// ../vapor.scss), not a stale copy waiting to be updated. The Midnight / Xalatath theme
+// (User::THEME_XALATATH = 'vapor') intentionally strips vapor's signature neon-glow look: the four
+// glow mixins below (text-shadow, text-shadow-sm, box-shadow, box-shadow-lg) have their bodies
+// commented out, so every `@include` of them throughout this file emits nothing.
+//
+// That customization CANNOT be achieved by importing the node_modules copy: bootswatch defines AND
+// consumes these mixins within this same file, so there is no seam to inject empty overrides from
+// vapor.scss — importing the upstream file would re-enable glowing text and boxes site-wide on this
+// theme. Hence the vendored copy is load-bearing, and BS5 renames are patched here by hand as well
+// (e.g. `.arrow` -> `.tooltip-arrow` in the .tooltip block near the bottom). Note upstream
+// bootswatch (5.3.8 at time of writing) still ships `.arrow` there, so tracking node_modules would
+// not fix that rename anyway.
+//
+// To pull upstream fixes later: re-vendor from the target bootswatch version, re-comment the four
+// glow mixin bodies, re-apply the `.tooltip-arrow` rename, then re-run the vapor visual sweep.
+// Never point vapor.scss at `~bootswatch/dist/vapor/bootswatch`.
 
 
 // Variables

--- a/resources/assets/sass/theme/vapor/vapor.scss
+++ b/resources/assets/sass/theme/vapor/vapor.scss
@@ -10,8 +10,9 @@
 
   @import "~bootswatch/dist/vapor/variables";
   @import "~bootstrap/scss/bootstrap";
+  // Vendored + hand-modified bootswatch: strips vapor's neon glow for the Midnight theme and can
+  // NOT be swapped for the upstream `~bootswatch/dist/vapor/bootswatch`. See that file's header.
   @import "dist/_bootswatch";
-  //@import "~bootswatch/dist/vapor/bootswatch";
 
   body, .btn {
     color: #fff;


### PR DESCRIPTION
:robot: Part of #3462 (Bootstrap-4-compat shim inventory). This is **shim 10: the hand-patched vendored vapor bootswatch**.

## Finding
The issue's suggested native fix — *"figure out why vapor needs the vendored copy and switch back to the node_modules import if possible"* — turns out **not to be possible**, and the `.arrow`→`.tooltip-arrow` rename is only an incidental hand-edit, not the real reason for vendoring.

The real reason: `resources/assets/sass/theme/vapor/dist/_bootswatch.scss` deliberately **guts vapor's four neon-glow mixins** (`text-shadow`, `text-shadow-sm`, `box-shadow`, `box-shadow-lg` — bodies commented out). Bootswatch vapor is a synthwave theme with glowing text/boxes everywhere; the Midnight / Xalatath theme (`User::THEME_XALATATH = 'vapor'`) strips that glow. Because bootswatch **defines and consumes those mixins within the same file**, there's no seam to inject empty overrides from `vapor.scss` — importing the upstream copy would re-enable glowing text and boxes site-wide on this theme.

Two extra notes:
- Upstream bootswatch **5.3.8 still ships `.arrow`** in that tooltip block, so tracking node_modules wouldn't even fix the rename this shim is named after.
- With the glow mixins empty, most of this file's `@include`s emit nothing; the CSS it actually produces (body gradient, outline-button styling, alert colors, transparent card bg, etc.) is genuinely needed.

## Resolution
Per the issue DoD (*"explicitly re-documented as a permanent design choice in the file itself"*):
- Header comment on the vendored file explaining **why** it's vendored, why the upstream import can't replace it, that the `.arrow`→`.tooltip-arrow` patch is part of maintaining it, and how to re-vendor if upstream fixes are ever needed.
- Pointer comment on the `@import "dist/_bootswatch"` line in `vapor.scss`, and removal of the misleading commented-out `//@import "~bootswatch/dist/vapor/bootswatch"` that invited re-enabling it.

## Verification
**Comment-only change** — SCSS comments are stripped at compile time and the removed line was already commented out, so the compiled CSS is byte-identical. No visual change, nothing to sweep. No PHP touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)