### PR TITLE
#3462 Migrate the global column compat shim to targeted BS5-native rules (shim 1)

### DIFF
--- a/resources/assets/css/custom.css
+++ b/resources/assets/css/custom.css
@@ -1,15 +1,26 @@
 /** BOOTSTRAP 5 COMPAT */
 /*
- * Bootstrap 4 gave every column `position: relative` and its gutter padding; Bootstrap 5 removed the
- * former entirely and only pads columns that are direct children of a .row (via `.row > *`). That
- * breaks absolutely positioned overlays anchoring to their column (e.g. the dungeon card titles over
- * their images) and makes rows spill out of standalone columns (e.g. the affix list). Restore the
- * Bootstrap 4 behavior; inside a .row this padding computes to the same value `.row > *` already sets.
+ * Bootstrap 4 gave every column `position: relative` and its gutter padding; Bootstrap 5 dropped the
+ * former entirely and only pads columns that are direct children of a .row (via `.row > *`). We used
+ * to restore the Bootstrap 4 behavior globally, but that global `[class^="col-"]` selector fought the
+ * framework and leaked onto any (future / third-party) `col-*` markup. The handful of elements that
+ * actually relied on it are now handled explicitly:
+ *  - absolutely positioned overlays anchoring to their column -> `position: relative` on that
+ *    specific column below (and the `position-relative` utility on the search results column in
+ *    dungeonroute/discover/search.blade.php);
+ *  - standalone columns used as padded containers (not a direct child of a .row, so `.row > *` never
+ *    pads them) -> gutter padding restored below. Inside a .row this computes to the same value
+ *    `.row > *` already sets, so it stays correct there too.
  */
-.col,
-[class^="col-"],
-[class*=" col-"] {
+
+/* Dungeon grid card: the dungeon-name overlay (.card-img-caption .card-text, position: absolute)
+   anchors to this column as its offset parent (see the .discover .card-img-caption .card-text rules) */
+.grid_dungeon {
     position: relative;
+}
+
+/* Standalone column: the affix picker list sits in a plain .mb-3, not a .row */
+.affix_list {
     padding-right: calc(var(--bs-gutter-x, 1.5rem) * .5);
     padding-left: calc(var(--bs-gutter-x, 1.5rem) * .5);
 }

--- a/resources/views/dungeonroute/discover/search.blade.php
+++ b/resources/views/dungeonroute/discover/search.blade.php
@@ -137,7 +137,7 @@ use Illuminate\Support\Collection;
                 {{ html()->text('user', request('user'))->id('user')->class('form-control')->placeholder(__('view_dungeonroute.discover.search.user_placeholder'))->attribute('autocomplete', 'off') }}
             @endcomponent
         </div>
-        <div class="col-xl-9">
+        <div class="col-xl-9 position-relative">
             <div id="route_list">
 
             </div>


### PR DESCRIPTION
:robot: Part of #3462 — removes shim **1**, the global column shim (the biggest-blast-radius item on the list).

## What was removed
The blanket compat rule in `resources/assets/css/custom.css`:
```css
.col, [class^="col-"], [class*=" col-"] {
    position: relative;
    padding-right: calc(var(--bs-gutter-x, 1.5rem) * .5);
    padding-left:  calc(var(--bs-gutter-x, 1.5rem) * .5);
}
```
This matched *every* `col-*` element (including any future/third-party markup) and forced `position: relative` + gutters on columns even outside a `.row`. Both behaviors are now restored only where genuinely needed.

## position: relative
The only column-anchored absolute overlay is the dungeon-name `.card-img-caption .card-text` on the discover dungeon grid, whose offset parent is the `.grid_dungeon` column (the `.discover .tab-content … .card-text { width: calc(100% - 1rem) }` compensation rule proves it anchors to the *col*, not the caption). Restored with `position: relative` on `.grid_dungeon` only, and an explicit `position-relative` utility on the `.col-xl-9` that holds `#route_list_overlay`.

- `gridcards`/`griddiscover` wrap the caption in a `.card`, which is `position: relative` in BS5 — never col-dependent.
- tom-select `::after` and the toggle switches anchor to their own relative parents (`theme.scss`), not columns.

## padding
Columns inside a `.row` already get identical gutter padding from BS5's `.row > *`; only *standalone* columns lost it. The affix picker list (`.affix_list`, a column sitting in a plain `.mb-3`) restores it explicitly.

## Verification
A/B headless screenshots (master `:8008` vs this branch), same viewport:
- `/search`, `/`, and the dungeon-routes grid render **pixel-identical**.
- The `.grid_dungeon` overlay's `offsetParent` **and** bounding box are numerically identical before/after (`offsetParent = .grid_dungeon col-lg-3 …`, text top 6px / left 8px / width 242px in both).

`composer run analyse` (PhpStan) is green. No PHP logic changed (CSS + one Blade class). Before/after screenshots posted below for a quick eyeball.