### PR TITLE
#3516 Parallelize release image builds into a matrix, add GHA layer caching

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -117,8 +117,45 @@ jobs:
             --cache-control "public,max-age=31536000,immutable" \
             --no-progress
 
+  # Builds app / worker / cron in parallel matrix legs (each a fresh runner).
+  #
+  # Only the app base image (docker-compose/app) gets buildx + GHA layer caching:
+  # it's the expensive, self-contained build (rust/PHP-extension toolchain, ~5.4min)
+  # and every FROM in it resolves to a public registry image, which the buildx
+  # docker-container driver (required for --cache-to type=gha) can reach.
+  #
+  # The worker/cron base images (docker-compose/app-worker, docker-compose/cron) and
+  # all three production images instead FROM a *locally* tagged image (keystone.guru-app,
+  # or that leg's own base) — the docker-container builder cannot see the host docker
+  # daemon's local image store, so those stay on the plain `docker build` (default
+  # driver, shares the daemon). They're cheap layers (apt-get + one binary / a git
+  # clone), so there's little to gain from caching them anyway.
   build-push-images:
-    name: Build & Push Release Images
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: app
+            base_tag: keystone.guru-app
+            needs_own_base_build: false
+            prod_context: docker-compose/app-aws
+            ecr_repos: "ksg-php-fpm ksg-reverb ksg-swoole"
+          # Puppeteer/Chrome live only in this image (docker-compose/app-worker), so the
+          # thumbnail-generation queue workers get a browser; the app image above doesn't.
+          - image: worker
+            base_tag: keystone.guru-worker
+            needs_own_base_build: true
+            base_context: docker-compose/app-worker
+            prod_context: docker-compose/app-worker-aws
+            ecr_repos: "ksg-queue-worker"
+          - image: cron
+            base_tag: keystone.guru-cron
+            needs_own_base_build: true
+            base_context: docker-compose/cron
+            prod_context: docker-compose/cron-aws
+            ecr_repos: "ksg-cron"
+
+    name: Build & Push Release Images (${{ matrix.image }})
     runs-on: ubuntu-latest
 
     steps:
@@ -134,66 +171,50 @@ jobs:
       - name: Log in to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # The base image build substitutes GIT_TOKEN into the composer auth.json.
       # All composer repositories are public, so the built-in token is sufficient.
       - name: Prepare base image build context
         run: echo "GIT_TOKEN=${{ secrets.GITHUB_TOKEN }}" > docker-compose/app/.env
 
-      - name: Build base app image
-        run: docker build -t keystone.guru-app docker-compose/app
+      # Built on every leg (not just the app leg): the worker/cron base Dockerfiles
+      # both FROM keystone.guru-app (see their Dockerfiles), so it has to exist
+      # locally on those runners too. Scoped "app-base" on all three legs so they
+      # share one GHA cache entry instead of each rebuilding it cold.
+      - name: Build app base image
+        run: |
+          docker buildx build \
+            --cache-from type=gha,scope=app-base \
+            --cache-to type=gha,mode=max,scope=app-base \
+            --load \
+            -t keystone.guru-app \
+            docker-compose/app
+
+      - name: Build base ${{ matrix.image }} image
+        if: matrix.needs_own_base_build
+        run: docker build -t ${{ matrix.base_tag }} ${{ matrix.base_context }}
 
       # GIT_REF pins the in-image checkout to the released tag for reproducibility.
-      - name: Build production app image
+      # No --no-cache here: on a fresh runner there's nothing to invalidate, and the
+      # Dockerfile's `git clone --depth 1 --branch <GIT_REF>` self-invalidates every
+      # release regardless.
+      - name: Build production ${{ matrix.image }} image
         run: |
-          docker build --no-cache \
+          docker build \
             --build-arg STAGE=production \
             --build-arg GIT_REF=${{ github.ref_name }} \
-            -t keystone.guru-app:${{ github.ref_name }} \
-            docker-compose/app-aws/
+            -t ${{ matrix.base_tag }}:${{ github.ref_name }} \
+            ${{ matrix.prod_context }}
 
-      - name: Tag & push app image to ECR
+      - name: Tag & push ${{ matrix.image }} image(s) to ECR
         run: |
-          for repo in ksg-php-fpm ksg-reverb ksg-swoole; do
-            docker tag keystone.guru-app:${{ github.ref_name }} \
+          for repo in ${{ matrix.ecr_repos }}; do
+            docker tag ${{ matrix.base_tag }}:${{ github.ref_name }} \
               "${ECR_REGISTRY}/${repo}:${{ github.ref_name }}"
             docker push "${ECR_REGISTRY}/${repo}:${{ github.ref_name }}"
           done
-
-      # Puppeteer/Chrome live only in this image (docker-compose/app-worker), so the
-      # thumbnail-generation queue workers get a browser; the web-facing images above don't.
-      - name: Build base worker image
-        run: docker build -t keystone.guru-worker docker-compose/app-worker
-
-      - name: Build production worker image
-        run: |
-          docker build --no-cache \
-            --build-arg STAGE=production \
-            --build-arg GIT_REF=${{ github.ref_name }} \
-            -t keystone.guru-worker:${{ github.ref_name }} \
-            docker-compose/app-worker-aws/
-
-      - name: Tag & push worker image to ECR
-        run: |
-          docker tag keystone.guru-worker:${{ github.ref_name }} \
-            "${ECR_REGISTRY}/ksg-queue-worker:${{ github.ref_name }}"
-          docker push "${ECR_REGISTRY}/ksg-queue-worker:${{ github.ref_name }}"
-
-      - name: Build base cron image
-        run: docker build -t keystone.guru-cron docker-compose/cron
-
-      - name: Build production cron image
-        run: |
-          docker build --no-cache \
-            --build-arg STAGE=production \
-            --build-arg GIT_REF=${{ github.ref_name }} \
-            -t keystone.guru-cron:${{ github.ref_name }} \
-            docker-compose/cron-aws/
-
-      - name: Tag & push cron image to ECR
-        run: |
-          docker tag keystone.guru-cron:${{ github.ref_name }} \
-            "${ECR_REGISTRY}/ksg-cron:${{ github.ref_name }}"
-          docker push "${ECR_REGISTRY}/ksg-cron:${{ github.ref_name }}"
 
   # Staging deploys automatically once the release images, frontend assets and
   # map context all exist for the tag (gated via `needs` below). The

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -181,16 +181,26 @@ jobs:
 
       # Built on every leg (not just the app leg): the worker/cron base Dockerfiles
       # both FROM keystone.guru-app (see their Dockerfiles), so it has to exist
-      # locally on those runners too. Scoped "app-base" on all three legs so they
-      # share one GHA cache entry instead of each rebuilding it cold.
+      # locally on those runners too, all reading the one "app-base" GHA cache scope.
+      #
+      # This must be build-push-action rather than a raw `docker buildx build` run
+      # step: the type=gha cache backend needs the Actions runtime token/URL, which
+      # GitHub only injects into actions — a shell step never sees them, so the
+      # cache export would fail on the first real tag push.
+      #
+      # Only the app leg exports the cache (cache-to); worker/cron only read it.
+      # mode=max blobs are hundreds of MB, and three identical uploads per release
+      # would burn time and the repo's 10GB cache budget for nothing. An empty
+      # cache-to input is treated as "not set" by build-push-action.
       - name: Build app base image
-        run: |
-          docker buildx build \
-            --cache-from type=gha,scope=app-base \
-            --cache-to type=gha,mode=max,scope=app-base \
-            --load \
-            -t keystone.guru-app \
-            docker-compose/app
+        uses: docker/build-push-action@v6
+        with:
+          context: docker-compose/app
+          tags: keystone.guru-app
+          load: true
+          push: false
+          cache-from: type=gha,scope=app-base
+          cache-to: ${{ matrix.image == 'app' && 'type=gha,mode=max,scope=app-base' || '' }}
 
       - name: Build base ${{ matrix.image }} image
         if: matrix.needs_own_base_build


### PR DESCRIPTION
:robot: Closes #3516

## Summary

- Split the `build-push-images` job into a **job matrix** with three parallel legs: `app`, `worker`, `cron`. Each leg builds its own base + production image and pushes to the same ECR repos as before (app → `ksg-php-fpm`/`ksg-reverb`/`ksg-swoole`, worker → `ksg-queue-worker`, cron → `ksg-cron`). `deploy-staging` still `needs: build-push-images` — `needs` on a matrix job id waits for all combinations, so no change was needed there.
- Added **GHA layer caching** for the app base image build (`docker-compose/app`) — the expensive, self-contained ~5.4min build (rust + PHP-extension toolchain). The build uses `docker/build-push-action@v6` (with `setup-buildx-action`), `cache-from: type=gha,scope=app-base`, `load: true`/`push: false` so the image lands in the local daemon. This step runs on **all three** matrix legs, not just `app`, because the worker and cron base Dockerfiles both `FROM keystone.guru-app`, so a fresh matrix runner for those legs needs a local copy too — all reading the same `app-base` cache scope.
- **Why build-push-action instead of a raw `docker buildx build` run step**: the `type=gha` cache backend authenticates with the Actions runtime token/URL (`ACTIONS_RUNTIME_TOKEN`/`ACTIONS_RESULTS_URL`), which GitHub injects **only into actions, never into shell steps** — a raw buildx invocation in `run:` would fail to configure the gha cache on the first real tag push. build-push-action wires the runtime token into buildx automatically.
- **Single cache writer**: only the `app` leg exports the cache (`cache-to: type=gha,mode=max,scope=app-base` via a conditional expression); worker/cron only read it via `cache-from`. `mode=max` blobs are hundreds of MB — three identical uploads per release would waste time and the repo's 10GB Actions cache budget. The conditional emits an empty `cache-to` on worker/cron, which build-push-action treats as unset (verified against the v6 source: `Util.getInputList` returns `[]` for an empty string, so no `--cache-to` flag is emitted).
- Dropped `--no-cache` from the production image builds — on fresh runners it was a no-op, and the production Dockerfiles `git clone --depth 1 --branch <GIT_REF>`, so that layer self-invalidates every release regardless.

**Example matrix entry** (worker leg):
```yaml
- image: worker
  base_tag: keystone.guru-worker
  needs_own_base_build: true
  base_context: docker-compose/app-worker
  prod_context: docker-compose/app-worker-aws
  ecr_repos: "ksg-queue-worker"
```

## Deviation from the original plan

The plan called for buildx + `type=gha` caching on **each** matrix leg's base image, scoped per image (`<image>-base`). That doesn't hold together for the worker/cron legs: their base Dockerfiles `FROM` a *locally tagged* image (`keystone.guru-app`, built moments earlier in the same leg), and buildx's `docker-container` driver — required for `--cache-to type=gha` — cannot see images sitting only in the host docker daemon's local store (only the classic `docker` driver can, and it doesn't support cache exporters). This is the same constraint the issue already calls out for production images.

So the split actually implemented is:
- **App base image**: build-push-action + GHA cache (`scope=app-base`), loaded into the local daemon. Built on every leg, since worker/cron need it locally too; only the app leg writes the cache.
- **Worker/cron's own extra base layer** (`docker-compose/app-worker`, `docker-compose/cron`) and **all three production images**: plain `docker build` against the local daemon, no cache flags — same reasoning the issue gives for production images applies here too, and these are cheap layers (a handful of `apt-get` lines / one binary download / a git clone) where caching wouldn't buy much anyway.

This means the "layer caching" win is concentrated on the one build that actually costs 5+ minutes, while the cheap downstream layers stay simple. Same ECR repos, same `<tag>` image tags, same `version`-file semantics (`GIT_REF` build arg) as before — nothing about what gets pushed changed.

## Verification

- YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-deploy.yml'))"`) — OK.
- `actionlint` was not available in this environment and was not installed (per instructions); instead I re-read the diff line by line checking matrix syntax, `needs` references, `${{ matrix.* }}` usage, and secret/env references — all unchanged/consistent.
- Empty-`cache-to` tolerance verified against the docker/build-push-action v6 source (see above).
- **This workflow only triggers on `v*` tag pushes, so CI on this MR will NOT exercise it.** The first real validation will be the next actual release (or a throwaway `-rc` tag — maintainer's call, since that also auto-deploys staging).
- Expected effect: ~10.6 min → ~3-5 min on the **second consecutive release** once the `app-base` GHA cache is warm (the first release after this merges will still build the app base from scratch, since there's nothing to prime the cache with yet).
