### PR TITLE
#3517 Season-first map context: --scope option + split release job

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -72,11 +72,12 @@ jobs:
   # Map context JS is generated from the DB/seeders and is also keyed by the
   # `version` file. We override that file with the release tag so the output
   # lands at compiled/<tag>/mapcontext/... matching the image. Runs in parallel.
-  # Split into a priority job (current-season dungeons, the ~99% of traffic) that
+  # Split into a priority job (current + next season dungeons, the ~99% of traffic - the
+  # next season is included because it starts receiving traffic before it's active) that
   # deploy-staging waits on, and a rest job (remaining dungeons) that streams into
   # S3 while the infra deploy runs — see #3517.
   build-map-context-priority:
-    name: Map Context (current season)
+    name: Map Context (priority)
     runs-on: ubuntu-latest
 
     steps:
@@ -98,8 +99,8 @@ jobs:
         run: |
           mkdir -p storage/mapcontext
           php artisan make:mapcontextstatic --output=storage/mapcontext
-          php artisan make:mapcontextdungeon --output=storage/mapcontext --scope=current-season
-          php artisan make:mapcontextmappingversion --output=storage/mapcontext --scope=current-season
+          php artisan make:mapcontextdungeon --output=storage/mapcontext --scope=priority
+          php artisan make:mapcontextmappingversion --output=storage/mapcontext --scope=priority
           ls -la storage/mapcontext
 
       - name: Configure AWS (OIDC)
@@ -120,9 +121,9 @@ jobs:
             --cache-control "public,max-age=31536000,immutable" \
             --no-progress
 
-  # Remaining (non-current-season) dungeons. Intentionally NOT in deploy-staging's
-  # or deploy-production's `needs` — it finishes uploading while the infra deploy
-  # (8-15 min) runs, so a non-current-season route's map context can briefly 404
+  # Remaining (non-priority) dungeons. Intentionally NOT in deploy-staging's or
+  # deploy-production's `needs` — it finishes uploading while the infra deploy
+  # (8-15 min) runs, so a non-priority route's map context can briefly 404
   # right after the staging flip until this job lands.
   build-map-context-rest:
     name: Map Context (remaining dungeons)

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -72,8 +72,11 @@ jobs:
   # Map context JS is generated from the DB/seeders and is also keyed by the
   # `version` file. We override that file with the release tag so the output
   # lands at compiled/<tag>/mapcontext/... matching the image. Runs in parallel.
-  build-map-context:
-    name: Generate & Upload Map Context
+  # Split into a priority job (current-season dungeons, the ~99% of traffic) that
+  # deploy-staging waits on, and a rest job (remaining dungeons) that streams into
+  # S3 while the infra deploy runs — see #3517.
+  build-map-context-priority:
+    name: Map Context (current season)
     runs-on: ubuntu-latest
 
     steps:
@@ -95,8 +98,56 @@ jobs:
         run: |
           mkdir -p storage/mapcontext
           php artisan make:mapcontextstatic --output=storage/mapcontext
-          php artisan make:mapcontextdungeon --output=storage/mapcontext
-          php artisan make:mapcontextmappingversion --output=storage/mapcontext
+          php artisan make:mapcontextdungeon --output=storage/mapcontext --scope=current-season
+          php artisan make:mapcontextmappingversion --output=storage/mapcontext --scope=current-season
+          ls -la storage/mapcontext
+
+      - name: Configure AWS (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::868970774940:role/ksg-github-actions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install AWS CLI
+        uses: unfor19/install-aws-cli-action@v1
+
+      - name: Upload Map Context JS files
+        env:
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+        run: |
+          aws s3 cp storage/mapcontext "s3://${S3_BUCKET}/compiled" \
+            --recursive \
+            --cache-control "public,max-age=31536000,immutable" \
+            --no-progress
+
+  # Remaining (non-current-season) dungeons. Intentionally NOT in deploy-staging's
+  # or deploy-production's `needs` — it finishes uploading while the infra deploy
+  # (8-15 min) runs, so a non-current-season route's map context can briefly 404
+  # right after the staging flip until this job lands.
+  build-map-context-rest:
+    name: Map Context (remaining dungeons)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout for local actions
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Start services
+        run: docker compose -f docker-compose.ci.yml up -d --wait
+
+      - name: Common PHP/Laravel setup
+        uses: ./.github/actions/php-ci-setup
+
+      - name: Key map context by the release tag
+        run: printf '%s' "${{ github.ref_name }}" > version
+
+      - name: Generate Map Context JS
+        run: |
+          mkdir -p storage/mapcontext
+          php artisan make:mapcontextdungeon --output=storage/mapcontext --scope=rest
+          php artisan make:mapcontextmappingversion --output=storage/mapcontext --scope=rest
           ls -la storage/mapcontext
 
       - name: Configure AWS (OIDC)
@@ -204,7 +255,7 @@ jobs:
   # cross-repo).
   deploy-staging:
     name: Deploy to Staging
-    needs: [build-push-images, build-assets, build-map-context]
+    needs: [build-push-images, build-assets, build-map-context-priority]
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch staging deploy to keystoneguru-infra

--- a/app/Console/Commands/MapContext/Enums/MapContextScope.php
+++ b/app/Console/Commands/MapContext/Enums/MapContextScope.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Console\Commands\MapContext\Enums;
+
+/**
+ * The `--scope` option shared by the map context generator commands.
+ */
+enum MapContextScope: string
+{
+    case Priority = 'priority';
+    case Rest     = 'rest';
+    case All      = 'all';
+}

--- a/app/Console/Commands/MapContext/MakeMapContextDungeon.php
+++ b/app/Console/Commands/MapContext/MakeMapContextDungeon.php
@@ -2,14 +2,17 @@
 
 namespace App\Console\Commands\MapContext;
 
+use App\Console\Commands\MapContext\Traits\ResolvesMapContextScope;
 use App\Console\Commands\MapContext\Traits\SavesToFile;
 use App\Models\Dungeon;
 use App\Service\MapContext\MapContextServiceInterface;
+use App\Service\Season\SeasonServiceInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 
 class MakeMapContextDungeon extends Command
 {
+    use ResolvesMapContextScope;
     use SavesToFile;
 
     /**
@@ -17,7 +20,9 @@ class MakeMapContextDungeon extends Command
      *
      * @var string
      */
-    protected $signature = 'make:mapcontextdungeon {--output= : The output folder to place the generated map context in}';
+    protected $signature = 'make:mapcontextdungeon
+        {--output= : The output folder to place the generated map context in}
+        {--scope=all : Which dungeons to generate map context for (current-season, rest, all)}';
 
     /**
      * The console command description.
@@ -31,11 +36,17 @@ class MakeMapContextDungeon extends Command
      */
     public function handle(
         MapContextServiceInterface $mapContextService,
+        SeasonServiceInterface     $seasonService,
     ): int {
         $output = $this->option('output') ?? storage_path('mapcontext');
 
+        $dungeonIds = $this->resolveDungeonIdsForScope((string)$this->option('scope'), $seasonService);
+        if ($dungeonIds === null) {
+            return self::FAILURE;
+        }
+
         /** @var Collection<int, Dungeon> $dungeonsById */
-        $dungeonsById     = Dungeon::all()->keyBy('id');
+        $dungeonsById     = Dungeon::whereIn('id', $dungeonIds)->get()->keyBy('id');
         $allowedLanguages = language()->allowed();
 
         $bar = $this->output->createProgressBar($dungeonsById->count() * count($allowedLanguages));

--- a/app/Console/Commands/MapContext/MakeMapContextDungeon.php
+++ b/app/Console/Commands/MapContext/MakeMapContextDungeon.php
@@ -22,7 +22,7 @@ class MakeMapContextDungeon extends Command
      */
     protected $signature = 'make:mapcontextdungeon
         {--output= : The output folder to place the generated map context in}
-        {--scope=all : Which dungeons to generate map context for (current-season, rest, all)}';
+        {--scope=all : Which dungeons to generate map context for (priority, rest, all)}';
 
     /**
      * The console command description.

--- a/app/Console/Commands/MapContext/MakeMapContextMappingVersion.php
+++ b/app/Console/Commands/MapContext/MakeMapContextMappingVersion.php
@@ -2,16 +2,19 @@
 
 namespace App\Console\Commands\MapContext;
 
+use App\Console\Commands\MapContext\Traits\ResolvesMapContextScope;
 use App\Console\Commands\MapContext\Traits\SavesToFile;
 use App\Models\Dungeon;
 use App\Models\Mapping\MappingVersion;
 use App\Models\User;
 use App\Service\MapContext\MapContextServiceInterface;
+use App\Service\Season\SeasonServiceInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 
 class MakeMapContextMappingVersion extends Command
 {
+    use ResolvesMapContextScope;
     use SavesToFile;
 
     /**
@@ -19,7 +22,9 @@ class MakeMapContextMappingVersion extends Command
      *
      * @var string
      */
-    protected $signature = 'make:mapcontextmappingversion {--output= : The output folder to place the generated map context in}';
+    protected $signature = 'make:mapcontextmappingversion
+        {--output= : The output folder to place the generated map context in}
+        {--scope=all : Which mapping versions to generate map context for, scoped by their dungeon (current-season, rest, all)}';
 
     /**
      * The console command description.
@@ -33,13 +38,19 @@ class MakeMapContextMappingVersion extends Command
      */
     public function handle(
         MapContextServiceInterface $mapContextService,
+        SeasonServiceInterface     $seasonService,
     ): int {
         $output = $this->option('output') ?? storage_path('mapcontext');
 
+        $dungeonIds = $this->resolveDungeonIdsForScope((string)$this->option('scope'), $seasonService);
+        if ($dungeonIds === null) {
+            return self::FAILURE;
+        }
+
         /** @var Collection<int, Dungeon> $dungeonsById */
-        $dungeonsById = Dungeon::all()->keyBy('id');
+        $dungeonsById = Dungeon::whereIn('id', $dungeonIds)->get()->keyBy('id');
         /** @var Collection<int, MappingVersion> $mappingVersions */
-        $mappingVersions = MappingVersion::all();
+        $mappingVersions = MappingVersion::whereIn('dungeon_id', $dungeonIds)->get();
         $mapFacadeStyles = User::MAP_FACADE_STYLE_ALL;
 
         $bar = $this->output->createProgressBar($mappingVersions->count() * count($mapFacadeStyles));

--- a/app/Console/Commands/MapContext/MakeMapContextMappingVersion.php
+++ b/app/Console/Commands/MapContext/MakeMapContextMappingVersion.php
@@ -24,7 +24,7 @@ class MakeMapContextMappingVersion extends Command
      */
     protected $signature = 'make:mapcontextmappingversion
         {--output= : The output folder to place the generated map context in}
-        {--scope=all : Which mapping versions to generate map context for, scoped by their dungeon (current-season, rest, all)}';
+        {--scope=all : Which mapping versions to generate map context for, scoped by their dungeon (priority, rest, all)}';
 
     /**
      * The console command description.

--- a/app/Console/Commands/MapContext/Traits/ResolvesMapContextScope.php
+++ b/app/Console/Commands/MapContext/Traits/ResolvesMapContextScope.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Console\Commands\MapContext\Traits;
+
+use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
+use App\Service\Season\SeasonServiceInterface;
+use Illuminate\Support\Collection;
+
+/**
+ * Resolves the `--scope` option shared by the map context generator commands into the set of
+ * dungeon IDs that should be processed.
+ */
+trait ResolvesMapContextScope
+{
+    private const string SCOPE_CURRENT_SEASON = 'current-season';
+
+    private const string SCOPE_REST = 'rest';
+
+    private const string SCOPE_ALL = 'all';
+
+    /** @var array<int, string> */
+    private const array VALID_SCOPES = [
+        self::SCOPE_CURRENT_SEASON,
+        self::SCOPE_REST,
+        self::SCOPE_ALL,
+    ];
+
+    /**
+     * Resolves the given `--scope` option value to the set of dungeon IDs it covers.
+     *
+     * Writes an error to the command's output and returns null if the scope value is not recognized.
+     *
+     * @return Collection<int, int>|null
+     */
+    protected function resolveDungeonIdsForScope(string $scope, SeasonServiceInterface $seasonService): ?Collection
+    {
+        if (!in_array($scope, self::VALID_SCOPES, true)) {
+            $this->error(sprintf(
+                'Invalid --scope value "%s", expected one of: %s',
+                $scope,
+                implode(', ', self::VALID_SCOPES),
+            ));
+
+            return null;
+        }
+
+        $allDungeonIds = Dungeon::query()->pluck('id');
+
+        return match ($scope) {
+            self::SCOPE_ALL  => $allDungeonIds,
+            self::SCOPE_REST => $allDungeonIds
+                ->diff($this->currentSeasonDungeonIds($seasonService))
+                ->values(),
+            default => $this->currentSeasonDungeonIds($seasonService),
+        };
+    }
+
+    /**
+     * Dungeon IDs belonging to the current season of every expansion that currently has an active
+     * season - this includes non-retail game versions (e.g. Classic-era) whenever they have one.
+     *
+     * @return Collection<int, int>
+     */
+    private function currentSeasonDungeonIds(SeasonServiceInterface $seasonService): Collection
+    {
+        $dungeonIds = collect();
+
+        foreach (GameVersion::active()->get() as $gameVersion) {
+            if (!$gameVersion->has_seasons) {
+                continue;
+            }
+
+            $currentSeason = $seasonService->getCurrentSeason($gameVersion->expansion);
+
+            if ($currentSeason === null) {
+                continue;
+            }
+
+            $dungeonIds = $dungeonIds->merge($currentSeason->dungeons()->pluck('dungeons.id'));
+        }
+
+        return $dungeonIds->unique()->values();
+    }
+}

--- a/app/Console/Commands/MapContext/Traits/ResolvesMapContextScope.php
+++ b/app/Console/Commands/MapContext/Traits/ResolvesMapContextScope.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands\MapContext\Traits;
 
+use App\Console\Commands\MapContext\Enums\MapContextScope;
 use App\Models\Dungeon;
 use App\Models\GameVersion\GameVersion;
 use App\Service\Season\SeasonServiceInterface;
@@ -13,19 +14,6 @@ use Illuminate\Support\Collection;
  */
 trait ResolvesMapContextScope
 {
-    private const string SCOPE_CURRENT_SEASON = 'current-season';
-
-    private const string SCOPE_REST = 'rest';
-
-    private const string SCOPE_ALL = 'all';
-
-    /** @var array<int, string> */
-    private const array VALID_SCOPES = [
-        self::SCOPE_CURRENT_SEASON,
-        self::SCOPE_REST,
-        self::SCOPE_ALL,
-    ];
-
     /**
      * Resolves the given `--scope` option value to the set of dungeon IDs it covers.
      *
@@ -35,11 +23,13 @@ trait ResolvesMapContextScope
      */
     protected function resolveDungeonIdsForScope(string $scope, SeasonServiceInterface $seasonService): ?Collection
     {
-        if (!in_array($scope, self::VALID_SCOPES, true)) {
+        $scopeEnum = MapContextScope::tryFrom($scope);
+
+        if ($scopeEnum === null) {
             $this->error(sprintf(
                 'Invalid --scope value "%s", expected one of: %s',
                 $scope,
-                implode(', ', self::VALID_SCOPES),
+                implode(', ', array_column(MapContextScope::cases(), 'value')),
             ));
 
             return null;
@@ -47,22 +37,24 @@ trait ResolvesMapContextScope
 
         $allDungeonIds = Dungeon::query()->pluck('id');
 
-        return match ($scope) {
-            self::SCOPE_ALL  => $allDungeonIds,
-            self::SCOPE_REST => $allDungeonIds
-                ->diff($this->currentSeasonDungeonIds($seasonService))
+        return match ($scopeEnum) {
+            MapContextScope::All  => $allDungeonIds,
+            MapContextScope::Rest => $allDungeonIds
+                ->diff($this->priorityDungeonIds($seasonService))
                 ->values(),
-            default => $this->currentSeasonDungeonIds($seasonService),
+            MapContextScope::Priority => $this->priorityDungeonIds($seasonService),
         };
     }
 
     /**
-     * Dungeon IDs belonging to the current season of every expansion that currently has an active
-     * season - this includes non-retail game versions (e.g. Classic-era) whenever they have one.
+     * Dungeon IDs belonging to the current and next season of every expansion that currently has
+     * an active season line - this includes non-retail game versions (e.g. Classic-era) whenever
+     * they have one. The next season is included alongside the current one because it starts
+     * receiving traffic before it goes live (e.g. previews, early route creation).
      *
      * @return Collection<int, int>
      */
-    private function currentSeasonDungeonIds(SeasonServiceInterface $seasonService): Collection
+    private function priorityDungeonIds(SeasonServiceInterface $seasonService): Collection
     {
         $dungeonIds = collect();
 
@@ -72,12 +64,14 @@ trait ResolvesMapContextScope
             }
 
             $currentSeason = $seasonService->getCurrentSeason($gameVersion->expansion);
-
-            if ($currentSeason === null) {
-                continue;
+            if ($currentSeason !== null) {
+                $dungeonIds = $dungeonIds->merge($currentSeason->dungeons()->pluck('dungeons.id'));
             }
 
-            $dungeonIds = $dungeonIds->merge($currentSeason->dungeons()->pluck('dungeons.id'));
+            $nextSeason = $seasonService->getNextSeasonOfExpansion($gameVersion->expansion);
+            if ($nextSeason !== null) {
+                $dungeonIds = $dungeonIds->merge($nextSeason->dungeons()->pluck('dungeons.id'));
+            }
         }
 
         return $dungeonIds->unique()->values();

--- a/tests/Feature/Console/Commands/MapContext/ResolvesMapContextScopeTest.php
+++ b/tests/Feature/Console/Commands/MapContext/ResolvesMapContextScopeTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\Console\Commands\MapContext;
+
+use App\Console\Commands\MapContext\MakeMapContextDungeon;
+use App\Models\Dungeon;
+use App\Service\Season\SeasonServiceInterface;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Console')]
+#[Group('MapContext')]
+final class ResolvesMapContextScopeTest extends PublicTestCase
+{
+    #[Test]
+    public function resolveDungeonIdsForScope_givenCurrentSeason_returnsNonEmptyStrictSubsetOfAllDungeons(): void
+    {
+        // Arrange
+        $seasonService = app(SeasonServiceInterface::class);
+        $allDungeonIds = Dungeon::query()->pluck('id');
+
+        // Act
+        $result = $this->resolveScope('current-season', $seasonService);
+
+        // Assert
+        $this->assertNotNull($result);
+        $this->assertNotEmpty($result);
+        $this->assertTrue($result->diff($allDungeonIds)->isEmpty(), 'Every current-season dungeon must be part of all dungeons');
+        $this->assertLessThan($allDungeonIds->count(), $result->count(), 'current-season must be a strict subset of all dungeons');
+    }
+
+    #[Test]
+    public function resolveDungeonIdsForScope_givenRest_returnsExactComplementOfCurrentSeason(): void
+    {
+        // Arrange
+        $seasonService = app(SeasonServiceInterface::class);
+        $allDungeonIds = Dungeon::query()->pluck('id');
+
+        // Act
+        $currentSeasonDungeonIds = $this->resolveScope('current-season', $seasonService);
+        $restDungeonIds          = $this->resolveScope('rest', $seasonService);
+
+        // Assert
+        $this->assertNotNull($currentSeasonDungeonIds);
+        $this->assertNotNull($restDungeonIds);
+        $this->assertEqualsCanonicalizing(
+            $allDungeonIds->diff($currentSeasonDungeonIds)->values()->all(),
+            $restDungeonIds->values()->all(),
+        );
+        $this->assertTrue($restDungeonIds->intersect($currentSeasonDungeonIds)->isEmpty(), 'rest and current-season must not overlap');
+        $this->assertEqualsCanonicalizing(
+            $allDungeonIds->values()->all(),
+            $restDungeonIds->merge($currentSeasonDungeonIds)->unique()->values()->all(),
+            'The union of rest and current-season must equal all dungeons',
+        );
+    }
+
+    #[Test]
+    public function resolveDungeonIdsForScope_givenAll_returnsAllDungeons(): void
+    {
+        // Arrange
+        $seasonService = app(SeasonServiceInterface::class);
+        $allDungeonIds = Dungeon::query()->pluck('id');
+
+        // Act
+        $result = $this->resolveScope('all', $seasonService);
+
+        // Assert
+        $this->assertNotNull($result);
+        $this->assertEqualsCanonicalizing($allDungeonIds->values()->all(), $result->values()->all());
+    }
+
+    #[Test]
+    public function resolveDungeonIdsForScope_givenInvalidScope_returnsNull(): void
+    {
+        // Arrange
+        $seasonService = app(SeasonServiceInterface::class);
+
+        // Act
+        $result = $this->resolveScope('not-a-real-scope', $seasonService);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function handle_givenInvalidScopeOption_failsWithNonZeroExitCode(): void
+    {
+        // Act + Assert
+        $this->artisan('make:mapcontextdungeon', [
+            '--output' => sys_get_temp_dir(),
+            '--scope'  => 'not-a-real-scope',
+        ])->assertFailed();
+    }
+
+    /**
+     * Invokes the protected trait method shared by the map context generator commands, using the
+     * real command class rather than a test double so the behavior under test matches production.
+     *
+     * @return Collection<int, int>|null
+     */
+    private function resolveScope(string $scope, SeasonServiceInterface $seasonService): ?Collection
+    {
+        $command = new MakeMapContextDungeon();
+
+        // The trait writes to the command's output when the scope is invalid, so it needs one even
+        // though this command is never actually run through the console kernel here.
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new NullOutput()));
+
+        $method = new ReflectionMethod($command, 'resolveDungeonIdsForScope');
+
+        /** @var Collection<int, int>|null $result */
+        $result = $method->invoke($command, $scope, $seasonService);
+
+        return $result;
+    }
+}

--- a/tests/Feature/Console/Commands/MapContext/ResolvesMapContextScopeTest.php
+++ b/tests/Feature/Console/Commands/MapContext/ResolvesMapContextScopeTest.php
@@ -4,9 +4,11 @@ namespace Tests\Feature\Console\Commands\MapContext;
 
 use App\Console\Commands\MapContext\MakeMapContextDungeon;
 use App\Models\Dungeon;
+use App\Models\Season;
 use App\Service\Season\SeasonServiceInterface;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Support\Collection;
+use Mockery;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionMethod;
@@ -19,45 +21,78 @@ use Tests\TestCases\PublicTestCase;
 final class ResolvesMapContextScopeTest extends PublicTestCase
 {
     #[Test]
-    public function resolveDungeonIdsForScope_givenCurrentSeason_returnsNonEmptyStrictSubsetOfAllDungeons(): void
+    public function resolveDungeonIdsForScope_givenPriority_returnsNonEmptyStrictSubsetOfAllDungeons(): void
     {
         // Arrange
         $seasonService = app(SeasonServiceInterface::class);
         $allDungeonIds = Dungeon::query()->pluck('id');
 
         // Act
-        $result = $this->resolveScope('current-season', $seasonService);
+        $result = $this->resolveScope('priority', $seasonService);
 
         // Assert
         $this->assertNotNull($result);
         $this->assertNotEmpty($result);
-        $this->assertTrue($result->diff($allDungeonIds)->isEmpty(), 'Every current-season dungeon must be part of all dungeons');
-        $this->assertLessThan($allDungeonIds->count(), $result->count(), 'current-season must be a strict subset of all dungeons');
+        $this->assertTrue($result->diff($allDungeonIds)->isEmpty(), 'Every priority dungeon must be part of all dungeons');
+        $this->assertLessThan($allDungeonIds->count(), $result->count(), 'priority must be a strict subset of all dungeons');
     }
 
     #[Test]
-    public function resolveDungeonIdsForScope_givenRest_returnsExactComplementOfCurrentSeason(): void
+    public function resolveDungeonIdsForScope_givenPriorityAndNextSeasonKnown_includesNextSeasonDungeons(): void
+    {
+        // Arrange - stub the season service so this doesn't depend on which season line is
+        // currently live in the seeded data. TWW S1/S2 have disjoint dungeon rosters, which
+        // is used here to prove both get merged into "priority" (review on #3520: the next
+        // season already receives traffic before it goes fully active, so it must be
+        // included alongside the current one).
+        $currentSeason = Season::find(Season::SEASON_TWW_S1);
+        $nextSeason    = Season::find(Season::SEASON_TWW_S2);
+
+        $seasonServiceMock = Mockery::mock(SeasonServiceInterface::class);
+        $seasonServiceMock->shouldReceive('getCurrentSeason')->andReturn($currentSeason);
+        $seasonServiceMock->shouldReceive('getNextSeasonOfExpansion')->andReturn($nextSeason);
+
+        /** @var SeasonServiceInterface $seasonService */
+        $seasonService = $seasonServiceMock;
+
+        // Act
+        $result = $this->resolveScope('priority', $seasonService);
+
+        // Assert
+        $this->assertNotNull($result);
+        $this->assertEqualsCanonicalizing(
+            $currentSeason->dungeons()->pluck('dungeons.id')
+                ->merge($nextSeason->dungeons()->pluck('dungeons.id'))
+                ->unique()
+                ->values()
+                ->all(),
+            $result->values()->all(),
+        );
+    }
+
+    #[Test]
+    public function resolveDungeonIdsForScope_givenRest_returnsExactComplementOfPriority(): void
     {
         // Arrange
         $seasonService = app(SeasonServiceInterface::class);
         $allDungeonIds = Dungeon::query()->pluck('id');
 
         // Act
-        $currentSeasonDungeonIds = $this->resolveScope('current-season', $seasonService);
-        $restDungeonIds          = $this->resolveScope('rest', $seasonService);
+        $priorityDungeonIds = $this->resolveScope('priority', $seasonService);
+        $restDungeonIds     = $this->resolveScope('rest', $seasonService);
 
         // Assert
-        $this->assertNotNull($currentSeasonDungeonIds);
+        $this->assertNotNull($priorityDungeonIds);
         $this->assertNotNull($restDungeonIds);
         $this->assertEqualsCanonicalizing(
-            $allDungeonIds->diff($currentSeasonDungeonIds)->values()->all(),
+            $allDungeonIds->diff($priorityDungeonIds)->values()->all(),
             $restDungeonIds->values()->all(),
         );
-        $this->assertTrue($restDungeonIds->intersect($currentSeasonDungeonIds)->isEmpty(), 'rest and current-season must not overlap');
+        $this->assertTrue($restDungeonIds->intersect($priorityDungeonIds)->isEmpty(), 'rest and priority must not overlap');
         $this->assertEqualsCanonicalizing(
             $allDungeonIds->values()->all(),
-            $restDungeonIds->merge($currentSeasonDungeonIds)->unique()->values()->all(),
-            'The union of rest and current-season must equal all dungeons',
+            $restDungeonIds->merge($priorityDungeonIds)->unique()->values()->all(),
+            'The union of rest and priority must equal all dungeons',
         );
     }
 


### PR DESCRIPTION
:robot: Closes #3517

## Summary

- Adds a `--scope=priority|rest|all` option (default `all`, existing behavior unchanged) to `make:mapcontextdungeon` and `make:mapcontextmappingversion`. `make:mapcontextstatic` is untouched (stays global/priority).
- `priority` resolves via `GameVersion::active()->get()` filtered to `has_seasons`, then both `SeasonServiceInterface::getCurrentSeason($gameVersion->expansion)` and `getNextSeasonOfExpansion($gameVersion->expansion)` per matching game version — so it naturally covers non-retail game versions too (e.g. Classic-era) the moment they get a `has_seasons` flag and a current/next season, without any hardcoded expansion/dungeon list. Today only `retail` (→ expansion `midnight`) qualifies. The next season is included alongside the current one because it starts receiving traffic (previews, early route creation) before it's the fully active season.
- `rest` is the exact complement of `priority` over `Dungeon::all()`. Mapping versions are scoped by their dungeon's id (`MappingVersion::whereIn('dungeon_id', $dungeonIds)`), so **all** mapping versions of an in-scope dungeon are included, not just the latest.
- The resolution logic is factored into one shared trait, `app/Console/Commands/MapContext/Traits/ResolvesMapContextScope.php`, used by both commands (no duplication). The valid scope values are a native backed enum, `App\Console\Commands\MapContext\Enums\MapContextScope`. Invalid `--scope` values print an error and return a non-zero exit code.
- Splits the `build-map-context` job in `.github/workflows/release-deploy.yml` into `build-map-context-priority` (static + `--scope=priority`; `deploy-staging`'s `needs` now points here) and `build-map-context-rest` (`--scope=rest`; deliberately **not** in `deploy-staging`'s or `deploy-production`'s `needs`, so it uploads while the infra deploy runs). The diff is kept surgical — `build-push-images` (touched by #3516) is untouched.

## How priority resolution works

Investigated `SeasonServiceInterface`/`SeasonService`, the `Season` model's `dungeons()` relation, and `GameVersion`/`Expansion`. The front page (`DungeonRouteDiscoverController::discoverCurrentGameVersion`) already does exactly this for the current season: check `$gameVersion->has_seasons`, then `$seasonService->getCurrentSeason($gameVersion->expansion)`. Reused that pattern instead of `Expansion::active()` directly, because `active` on `Expansion` just means "released/supported" (true for almost every past expansion, including long-retired ones like Legion/BfA/Shadowlands) — it does not mean "currently the active season line". `GameVersion.has_seasons` is the actual signal for "this game version currently has an ongoing season", and correctly yields only `retail` today.

`getNextSeasonOfExpansion($expansion)` is merged in alongside `getCurrentSeason($expansion)` — per review, there's a period where a next season is known (and already receiving some traffic) but not active yet, so both need to land in "priority" mode.

## Verification

- Tests: `tests/Feature/Console/Commands/MapContext/ResolvesMapContextScopeTest.php` — 7 tests, all green (`php artisan test --compact --filter=ResolvesMapContextScopeTest`): priority is a non-empty strict subset of all dungeons, priority merges in the next season's dungeons when known (mocked `SeasonServiceInterface` with TWW S1/S2, which have disjoint dungeon rosters, since Midnight doesn't have a season 2 in the DB yet to exercise this for real), rest is the exact complement (and their union recombines to all), `all` matches `Dungeon::all()`, invalid scope fails.
- End-to-end equivalence check in the worktree container (`--scope=priority` + `--scope=rest` vs. unscoped `all`, both commands):
  - **all**: 2493 files
  - **priority**: 208 files (8 dungeons: Algeth'ar Academy, Magister's Terrace, Maisara Caverns, Nexus-Point: Xenas, Pit of Saron, Seat of the Triumvirate, Skyreach, Windrunner Spire — Midnight Season 1; no Midnight S2 seeded yet, so priority == current season only in practice today)
  - **rest**: 2285 files
  - union(priority, rest) == all exactly (byte-identical sorted file list diff); intersection is empty. 208 + 2285 = 2493. ✓
- `.github/workflows/release-deploy.yml` parses cleanly (`Symfony\Component\Yaml\Yaml::parseFile(...)` in the app container); job graph verified (`build-map-context-priority`/`build-map-context-rest` present, `deploy-staging.needs` = `[build-push-images, build-assets, build-map-context-priority]`). CI does not run this workflow on the MR (tag-triggered only) — **the workflow change will be validated on the next release**.
- `composer run fix` + `composer run analyse` both clean (an unrelated pre-existing formatting drift in `WowheadTranslationService.php` was reverted so the diff stays focused).
- Full `SeasonService` + `Console` test groups (59 tests total, run together) green; no regressions.

## Test plan

- [x] `ResolvesMapContextScopeTest` green (incl. the new next-season-merge test)
- [x] File-tree equivalence check (priority ∪ rest == all, priority ∩ rest == ∅)
- [x] Workflow YAML parses + job graph verified
- [x] `composer run fix` / `composer run analyse` clean
- [x] `SeasonService` + `Console` test groups green
