### PR TITLE
#3493 Build migration stage 3: post-mix cleanup

### DIFF
--- a/.claude/skills/new-map-view/SKILL.md
+++ b/.claude/skills/new-map-view/SKILL.md
@@ -150,10 +150,11 @@ class CommonMapsMycontrol extends SearchInlineBase {
 }
 ```
 
-**Auto-bundling**: `webpack.mix.js` uses the glob `'resources/assets/js/custom/inline/*/**/*.js'`
-so any file placed under `resources/assets/js/custom/inline/` is automatically compiled.
-No manual registration is needed. After creating a new inline JS file, restart `npm run watch`
-(or run `npm run build`) for it to be picked up.
+**Auto-bundling**: `scripts/build/custom-scripts-order.mjs` ends with the glob
+`'resources/assets/js/custom/inline/*/**/*.js'` so any file placed under
+`resources/assets/js/custom/inline/` is automatically compiled. No manual registration is needed.
+After creating a new inline JS file, restart `npm run watch` (or run `npm run dev`) for it to be
+picked up.
 
 ## Map Context Classes
 

--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,7 @@
         "rector": "rector process --dry-run",
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,assets"
         ]
     },
     "config": {

--- a/sh/worktree.sh
+++ b/sh/worktree.sh
@@ -119,13 +119,14 @@ cmd_create() {
     fi
 
     # 2c. Seed git-ignored build artifacts from the main checkout when missing. vendor/ is required
-    #     to boot artisan; the public/* assets let the browser render (blade mix() needs the
-    #     manifest). Each is an independent copy the worktree can rebuild if its deps/assets change.
+    #     to boot artisan; the public/* assets let the browser render (blades reference compiled
+    #     files by the version in the repo-root `version` file). Each is an independent copy the
+    #     worktree can rebuild if its deps/assets change.
     echo "==> seeding build artifacts from main repo (vendor + compiled assets)"
     [ -f "$REPO_ROOT/vendor/autoload.php" ] || die "main repo has no vendor/ — run composer install there first"
     local rel
     for rel in vendor version \
-        public/mix-manifest.json public/css public/js public/main.js public/resources \
+        public/css public/js public/resources \
         public/vendor public/webfonts public/images \
         public/VERSION public/COMMITHASH public/LASTCOMMITDATETIME; do
         if [ -e "$REPO_ROOT/$rel" ] && [ ! -e "$wt_path/$rel" ]; then


### PR DESCRIPTION
:robot: Part of #3493 (stage 3 of #3449). Stacked on #3503 (`3492-esbuild-stage2`), which is stacked on #3494 — retarget to `master` once those merge. This MR covers the cleanup half of the issue; the first-release watch stays open on #3493 until the next release tag is cut and verified.

## Changes

- **composer.json** `dev` script: renamed the misleading `vite` concurrently label to `assets` — it points at `npm run dev`, which is the esbuild build.
- **`.claude/skills/new-map-view/SKILL.md`**: inline JS auto-bundling is now the glob at the end of `scripts/build/custom-scripts-order.mjs` (not `webpack.mix.js`), and the referenced `npm run build` script never existed — corrected to `npm run dev`.
- **`sh/worktree.sh`**: dropped `public/mix-manifest.json` (no longer produced by the esbuild pipeline) and `public/main.js` (stale, unreferenced artifact from Feb 2024) from the seeded build artifacts, and updated the `mix()` comment — blades resolve compiled assets via the repo-root `version` file.

## Verified already clean (no change needed)

- **`.github/dependabot.yml`**: the webpack ignore rule + comment block was already removed in stage 2 (f2f3fd62d).
- **Full sweep** `grep -ri "laravel-mix\|webpack\|mix-manifest"` (excluding node_modules/vendor/public/release JSONs) finds only:
  - `scripts/build/*.mjs` comments — intentional parity notes documenting why the esbuild pipeline mirrors the old webpack behavior; kept as design rationale.
  - `composer.lock` — a third-party package's `suggest` entry (`symfony/webpack-encore-bundle`), not ours.
- `npm run production` references (package.json `prod` alias, `js-tests.yml`) are still valid — the script now runs `scripts/build/build.mjs --production`.
- `CLAUDE.md`, `readme.md`, and the other `.claude/` skills contain no mix/webpack references; the `javascript-in-blade-files` / `admin-artisan-command` skills' `npm run watch` instructions remain accurate.

## Remaining on #3493 after this merges

- First-release watch: monitor `release-deploy.yml` on the next tag (esbuild `build-assets` timing, `compiled/<tag>/` S3 file set diff vs previous tag, production page loads), with rollback via re-referencing the previous tag's immutable assets.

## Verification

- `bash -n sh/worktree.sh` passes; `composer.json` validates.
- `composer run fix` (one unrelated pre-existing drift discarded) and `composer run analyse` (0 errors) run in the worktree container.
- No PHP/JS runtime code changed, so no test changes apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)