### PR TITLE
#3462 Fix header dungeon selector spanning full screen width (BS5 regression)

### DIFF
--- a/resources/assets/css/custom.css
+++ b/resources/assets/css/custom.css
@@ -13,9 +13,11 @@
  *    `.row > *` already sets, so it stays correct there too.
  */
 
-/* Dungeon grid card: the dungeon-name overlay (.card-img-caption .card-text, position: absolute)
-   anchors to this column as its offset parent (see the .discover .card-img-caption .card-text rules) */
-.grid_dungeon {
+/* Dungeon grid card (.grid_dungeon) and header dungeon selector card (.list_dungeon): the
+   dungeon-name overlay (.card-img-caption .card-text, position: absolute) anchors to this column as
+   its offset parent (see the .discover .card-img-caption .card-text rules) */
+.grid_dungeon,
+.list_dungeon {
     position: relative;
 }
 


### PR DESCRIPTION
:robot: Follow-up regression fix for #3462 / #3513.

## Problem
The top header's dungeon selector was broken: the dungeon-name heading (`h5.card-text.dungeon_card_dungeon_name`) stretched to the **full screen width**, wrecking the header layout.

## Root cause
The shim-1 rewrite (#3513) removed the global BS4 compat shim `.col, [class^="col-"] { position: relative }` and only restored `position: relative` on `.grid_dungeon`. The header selector card uses **`.list_dungeon`**, whose caption is **not** wrapped in a Bootstrap `.card`, so it lost its offset parent. The absolutely-positioned `.dungeon_card_dungeon_name` overlay (`width: 100%`) then anchored to the next positioned ancestor — the `fixed-top` `.game_version_header` — resolving to the full viewport width.

The #3513 A/B verification covered `/search`, `/`, and the routes grid, but not the header dungeon-context selector, so it slipped through.

## Fix
Restore `position: relative` on `.list_dungeon` alongside `.grid_dungeon` in `resources/assets/css/custom.css` — no reintroduction of the global `[class^="col-"]` shim.

## Verification
Headless-Chrome A/B on `/explore/retail/mechagon-workshop` (1600px viewport), measuring the first `.dungeon_card_dungeon_name`:

| | h5 width | column width | offset parent |
|---|---|---|---|
| master (bug) | **1600px** | 155px | `game_version_header … fixed-top` |
| this branch | **155px** | 155px | `list_dungeon` |

Confirmed visually: labels now sit centered over their card thumbnails instead of sprawling across the viewport. Other grids (`.grid_dungeon` / `.card`) are untouched.