### PR TITLE
#3524 Remove empty FA icon widening the pull-number edit button (BS5 regression)

### DIFF
--- a/resources/assets/js/handlebars/map_killzonessidebar_killzone_row_edit_template.handlebars
+++ b/resources/assets/js/handlebars/map_killzonessidebar_killzone_row_edit_template.handlebars
@@ -7,7 +7,6 @@
                     type="button"
                     class="btn btn-primary"
                     data-bs-toggle="button" aria-pressed="false">
-                <i class="fa" aria-hidden="true"></i>
                 <span id="map_killzonessidebar_killzone_{{id}}_index" style="font-size: 1em"></span>
             </button>
         </div>


### PR DESCRIPTION
:robot: Closes #3524

## Problem
When editing a route, the pull-number toggle button in the killzones sidebar (`#map_killzonessidebar_killzone_<id>_edit`) is too wide — there's dead whitespace to the left of the pull index. It used to hug the index character. A BS4→BS5 regression.

## Cause
The edit handlebars template contained an empty, never-populated icon inside the button:
```html
<i class="fa" aria-hidden="true"></i>
<span id="map_killzonessidebar_killzone_{{id}}_index" ...></span>
```
Nothing in `rowelementkillzone.js` ever injects an icon into that `<i>`, and the sibling **view** template renders the `_index` span directly without it. Under BS5/FA the empty `.fa` element plus surrounding whitespace now reserves horizontal space.

## Fix
Remove the stray `<i class="fa">` from the edit template so it matches the view template and hugs the index. One-line deletion in `map_killzonessidebar_killzone_row_edit_template.handlebars`.

## Verification
Statically confirmed the element is unused (no JS reference; view template already omits it). The reporter visually confirmed removing it fixes the width. Handlebars is precompiled into the JS bundle at build time, so this ships in a release (not a hotfix) — CI rebuilds the bundle.