### PR TITLE
Upgrade vitest to 4.1.10 (supersedes #3530)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
                 "php-array-parser": "^1.0.1",
                 "pusher-js": "^8.5.0",
                 "sass": "^1.89.2",
-                "vitest": "^3.2.6"
+                "vitest": "^4.1.10"
             }
         },
         "node_modules/@asamuzakjp/css-color": {
@@ -306,6 +306,40 @@
             "license": "MIT",
             "engines": {
                 "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@epic-web/invariant": {
@@ -769,6 +803,25 @@
             "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
             "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.3"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -818,6 +871,16 @@
             "resolved": "https://registry.npmjs.org/@orchidjs/unicode-variants/-/unicode-variants-1.1.2.tgz",
             "integrity": "sha512-5DobW1CHgnBROOEpFlEXytED5OosEWESFvg/VYmH0143oXcijYTprRYJTs+55HzGM4IqxiLFSuqEzu9mPNwVsA==",
             "license": "Apache-2.0"
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
         },
         "node_modules/@parcel/watcher": {
             "version": "2.5.1",
@@ -1183,330 +1246,287 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-            "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-            "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-            "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-            "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-            "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
-            "cpu": [
-                "arm64"
             ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-            "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-            "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-            "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
-            "cpu": [
-                "arm"
             ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-            "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-            "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-            "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
-            "cpu": [
-                "loong64"
+            "libc": [
+                "musl"
             ],
-            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-            "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
-            "cpu": [
-                "loong64"
             ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-            "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-            "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
-            "cpu": [
-                "ppc64"
+            "libc": [
+                "glibc"
             ],
-            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-            "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
-            "cpu": [
-                "riscv64"
             ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-            "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-            "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-            "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-            "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-            "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
-            "cpu": [
-                "x64"
             ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "openbsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-            "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-            "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-            "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
-            "cpu": [
-                "ia32"
             ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-            "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-            "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
-            "cpu": [
-                "x64"
             ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "license": "MIT"
         },
         "node_modules/@shopify/draggable": {
             "version": "1.2.1",
@@ -1531,17 +1551,36 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
             "license": "MIT"
         },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@types/chai": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
             "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/deep-eql": "*",
                 "assertion-error": "^2.0.1"
@@ -1551,7 +1590,8 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
             "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.9",
@@ -1580,106 +1620,113 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
-            "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "3.2.6",
-                "@vitest/utils": "3.2.6",
-                "chai": "^5.2.0",
-                "tinyrainbow": "^2.0.0"
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@vitest/pretty-format": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
-            "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "tinyrainbow": "^2.0.0"
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
-            "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "3.2.6",
-                "pathe": "^2.0.3",
-                "strip-literal": "^3.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/@vitest/snapshot": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
-            "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
-            "dev": true,
-            "dependencies": {
-                "@vitest/pretty-format": "3.2.6",
-                "magic-string": "^0.30.17",
+                "@vitest/utils": "4.1.10",
                 "pathe": "^2.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
-            "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "tinyrainbow": "^2.0.0"
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
-            "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
             "dev": true,
-            "dependencies": {
-                "tinyspy": "^4.0.3"
-            },
+            "license": "MIT",
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
-            "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "3.2.6",
-                "loupe": "^3.1.4",
-                "tinyrainbow": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
-            "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
-            "dev": true,
-            "dependencies": {
-                "tinyrainbow": "^2.0.0"
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
@@ -1755,6 +1802,7 @@
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
             "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             }
@@ -2060,15 +2108,6 @@
                 "node": "*"
             }
         },
-        "node_modules/cac": {
-            "version": "6.7.14",
-            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2097,28 +2136,13 @@
             "integrity": "sha512-ceOhN1DL7Y4O6M0j9ICgmTYziV89WMd96SvSl0REd8PMgrY0B/WBOPoed5S1KUmJqXgUXh8gzSe6E3ae27upsQ=="
         },
         "node_modules/chai": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
             "dev": true,
-            "dependencies": {
-                "assertion-error": "^2.0.1",
-                "check-error": "^2.1.1",
-                "deep-eql": "^5.0.1",
-                "loupe": "^3.1.0",
-                "pathval": "^2.0.0"
-            },
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/check-error": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 16"
             }
         },
         "node_modules/chokidar": {
@@ -2390,6 +2414,13 @@
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=23"
             }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/core-js": {
             "version": "3.26.0",
@@ -2854,15 +2885,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/deep-eql": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/degenerator": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -3066,9 +3088,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "dev": true,
             "license": "MIT"
         },
@@ -3199,6 +3221,7 @@
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
             "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
             }
@@ -4080,6 +4103,289 @@
             "resolved": "https://registry.npmjs.org/leaflet-rotatedmarker/-/leaflet-rotatedmarker-0.2.0.tgz",
             "integrity": "sha512-yc97gxLXwbZa+Gk9VCcqI0CkvIBC9oNTTjFsHqq4EQvANrvaboib4UdeQLyTnEqDpaXHCqzwwVIDHtvz2mUiDg=="
         },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss/node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/lightslider": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/lightslider/-/lightslider-1.1.6.tgz",
@@ -4114,12 +4420,6 @@
             "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
             "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
         },
-        "node_modules/loupe": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-            "dev": true
-        },
         "node_modules/lru-cache": {
             "version": "11.5.2",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -4135,6 +4435,7 @@
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
             "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
@@ -4208,9 +4509,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -4218,6 +4519,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -4266,6 +4568,20 @@
             "resolved": "https://registry.npmjs.org/noty/-/noty-3.2.0-beta-deprecated.tgz",
             "integrity": "sha512-ntRbHuQ9SnnnVFZm/oq5L1DBCaHQUvsU24AwZH3PGjAWx2YqR/IhOadMk11vmJovYiQo00oqTj6Hp+D6PGtmLA==",
             "deprecated": "no longer supported"
+        },
+        "node_modules/obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
         },
         "node_modules/offset-polygon": {
             "version": "0.9.2",
@@ -4411,16 +4727,8 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "dev": true
-        },
-        "node_modules/pathval": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
             "dev": true,
-            "engines": {
-                "node": ">= 14.16"
-            }
+            "license": "MIT"
         },
         "node_modules/pend": {
             "version": "1.2.0",
@@ -4462,9 +4770,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+            "version": "8.5.19",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
             "dev": true,
             "funding": [
                 {
@@ -4480,6 +4788,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
@@ -4739,48 +5048,38 @@
             "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
             "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
         },
-        "node_modules/rollup": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-            "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+        "node_modules/rolldown": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.9"
+                "@oxc-project/types": "=0.139.0",
+                "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
-                "rollup": "dist/bin/rollup"
+                "rolldown": "bin/cli.mjs"
             },
             "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.62.2",
-                "@rollup/rollup-android-arm64": "4.62.2",
-                "@rollup/rollup-darwin-arm64": "4.62.2",
-                "@rollup/rollup-darwin-x64": "4.62.2",
-                "@rollup/rollup-freebsd-arm64": "4.62.2",
-                "@rollup/rollup-freebsd-x64": "4.62.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-                "@rollup/rollup-linux-arm64-musl": "4.62.2",
-                "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-                "@rollup/rollup-linux-loong64-musl": "4.62.2",
-                "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-                "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-                "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-                "@rollup/rollup-linux-x64-gnu": "4.62.2",
-                "@rollup/rollup-linux-x64-musl": "4.62.2",
-                "@rollup/rollup-openbsd-x64": "4.62.2",
-                "@rollup/rollup-openharmony-arm64": "4.62.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-                "@rollup/rollup-win32-x64-gnu": "4.62.2",
-                "@rollup/rollup-win32-x64-msvc": "4.62.2",
-                "fsevents": "~2.3.2"
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
         "node_modules/run-parallel": {
@@ -5128,9 +5427,9 @@
             "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
             "dev": true,
             "license": "MIT"
         },
@@ -5168,24 +5467,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/strip-literal": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-            "dev": true,
-            "dependencies": {
-                "js-tokens": "^9.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/strip-literal/node_modules/js-tokens": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-            "dev": true
         },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
@@ -5246,17 +5527,21 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
             "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
                 "picomatch": "^4.0.4"
@@ -5273,6 +5558,7 @@
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -5290,6 +5576,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
             "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -5297,30 +5584,12 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/tinypool": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            }
-        },
-        "node_modules/tinyrainbow": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/tinyspy": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-            "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-            "dev": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -5460,92 +5729,18 @@
             "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
             "optional": true
         },
-        "node_modules/vite-node": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+        "node_modules/vite": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+            "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "cac": "^6.7.14",
-                "debug": "^4.4.1",
-                "es-module-lexer": "^1.7.0",
-                "pathe": "^2.0.3",
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-            },
-            "bin": {
-                "vite-node": "vite-node.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/vite-node/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vite-node/node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vite-node/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
-        },
-        "node_modules/vite-node/node_modules/picomatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/vite-node/node_modules/vite": {
-            "version": "7.3.6",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-            "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
-            "dev": true,
-            "dependencies": {
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
-                "tinyglobby": "^0.2.15"
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.16",
+                "rolldown": "~1.1.4",
+                "tinyglobby": "^0.2.17"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -5561,9 +5756,10 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
                 "sass": "^1.70.0",
                 "sass-embedded": "^1.70.0",
                 "stylus": ">=0.54.8",
@@ -5576,13 +5772,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {
@@ -5608,65 +5807,93 @@
                 }
             }
         },
-        "node_modules/vitest": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
-            "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+        "node_modules/vite/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/chai": "^5.2.2",
-                "@vitest/expect": "3.2.6",
-                "@vitest/mocker": "3.2.6",
-                "@vitest/pretty-format": "^3.2.6",
-                "@vitest/runner": "3.2.6",
-                "@vitest/snapshot": "3.2.6",
-                "@vitest/spy": "3.2.6",
-                "@vitest/utils": "3.2.6",
-                "chai": "^5.2.0",
-                "debug": "^4.4.1",
-                "expect-type": "^1.2.1",
-                "magic-string": "^0.30.17",
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.2",
-                "std-env": "^3.9.0",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
                 "tinybench": "^2.9.0",
-                "tinyexec": "^0.3.2",
-                "tinyglobby": "^0.2.14",
-                "tinypool": "^1.1.1",
-                "tinyrainbow": "^2.0.0",
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-                "vite-node": "3.2.4",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
                 "vitest": "vitest.mjs"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
                 "@edge-runtime/vm": "*",
-                "@types/debug": "^4.1.12",
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-                "@vitest/browser": "3.2.6",
-                "@vitest/ui": "3.2.6",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
                 "happy-dom": "*",
-                "jsdom": "*"
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "@edge-runtime/vm": {
                     "optional": true
                 },
-                "@types/debug": {
+                "@opentelemetry/api": {
                     "optional": true
                 },
                 "@types/node": {
                     "optional": true
                 },
-                "@vitest/browser": {
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
                     "optional": true
                 },
                 "@vitest/ui": {
@@ -5677,161 +5904,23 @@
                 },
                 "jsdom": {
                     "optional": true
-                }
-            }
-        },
-        "node_modules/vitest/node_modules/@vitest/mocker": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
-            "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
-            "dev": true,
-            "dependencies": {
-                "@vitest/spy": "3.2.6",
-                "estree-walker": "^3.0.3",
-                "magic-string": "^0.30.17"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            },
-            "peerDependencies": {
-                "msw": "^2.4.9",
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-            },
-            "peerDependenciesMeta": {
-                "msw": {
-                    "optional": true
                 },
                 "vite": {
-                    "optional": true
+                    "optional": false
                 }
             }
-        },
-        "node_modules/vitest/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vitest/node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vitest/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/vitest/node_modules/picomatch": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
             "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/vitest/node_modules/vite": {
-            "version": "7.3.6",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-            "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
-            "dev": true,
-            "dependencies": {
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
-                "tinyglobby": "^0.2.15"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
             }
         },
         "node_modules/w3c-xmlserializer": {
@@ -6194,6 +6283,37 @@
             "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
             "dev": true
         },
+        "@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tslib": "^2.4.0"
+            }
+        },
         "@epic-web/invariant": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
@@ -6405,6 +6525,16 @@
             "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
             "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
         },
+        "@napi-rs/wasm-runtime": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "@tybys/wasm-util": "^0.10.3"
+            }
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6443,6 +6573,12 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@orchidjs/unicode-variants/-/unicode-variants-1.1.2.tgz",
             "integrity": "sha512-5DobW1CHgnBROOEpFlEXytED5OosEWESFvg/VYmH0143oXcijYTprRYJTs+55HzGM4IqxiLFSuqEzu9mPNwVsA=="
+        },
+        "@oxc-project/types": {
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "dev": true
         },
         "@parcel/watcher": {
             "version": "2.5.1",
@@ -6595,180 +6731,121 @@
                 }
             }
         },
-        "@rollup/rollup-android-arm-eabi": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-            "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+        "@rolldown/binding-android-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-android-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-            "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+        "@rolldown/binding-darwin-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-darwin-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-            "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+        "@rolldown/binding-darwin-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-darwin-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-            "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+        "@rolldown/binding-freebsd-x64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-freebsd-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-            "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+        "@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-freebsd-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-            "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+        "@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-            "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+        "@rolldown/binding-linux-arm64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-            "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+        "@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-            "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+        "@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-linux-arm64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-            "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+        "@rolldown/binding-linux-x64-gnu": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-            "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+        "@rolldown/binding-linux-x64-musl": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-linux-loong64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-            "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+        "@rolldown/binding-openharmony-arm64": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-            "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+        "@rolldown/binding-wasm32-wasi": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            }
+        },
+        "@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-            "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+        "@rolldown/binding-win32-x64-msvc": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "dev": true,
             "optional": true
         },
-        "@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-            "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
-            "dev": true,
-            "optional": true
-        },
-        "@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-            "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
-            "dev": true,
-            "optional": true
-        },
-        "@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-            "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
-            "dev": true,
-            "optional": true
-        },
-        "@rollup/rollup-linux-x64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-            "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
-            "dev": true,
-            "optional": true
-        },
-        "@rollup/rollup-linux-x64-musl": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-            "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
-            "dev": true,
-            "optional": true
-        },
-        "@rollup/rollup-openbsd-x64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-            "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
-            "dev": true,
-            "optional": true
-        },
-        "@rollup/rollup-openharmony-arm64": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-            "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
-            "dev": true,
-            "optional": true
-        },
-        "@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-            "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
-            "dev": true,
-            "optional": true
-        },
-        "@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-            "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
-            "dev": true,
-            "optional": true
-        },
-        "@rollup/rollup-win32-x64-gnu": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-            "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
-            "dev": true,
-            "optional": true
-        },
-        "@rollup/rollup-win32-x64-msvc": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-            "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
-            "dev": true,
-            "optional": true
+        "@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true
         },
         "@shopify/draggable": {
             "version": "1.2.1",
@@ -6791,10 +6868,26 @@
             "dev": true,
             "peer": true
         },
+        "@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true
+        },
         "@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
+        },
+        "@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tslib": "^2.4.0"
+            }
         },
         "@types/chai": {
             "version": "5.2.3",
@@ -6837,89 +6930,76 @@
             }
         },
         "@vitest/expect": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
-            "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
             "dev": true,
             "requires": {
+                "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "3.2.6",
-                "@vitest/utils": "3.2.6",
-                "chai": "^5.2.0",
-                "tinyrainbow": "^2.0.0"
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            }
+        },
+        "@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "requires": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
             }
         },
         "@vitest/pretty-format": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
-            "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
             "dev": true,
             "requires": {
-                "tinyrainbow": "^2.0.0"
+                "tinyrainbow": "^3.1.0"
             }
         },
         "@vitest/runner": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
-            "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
             "dev": true,
             "requires": {
-                "@vitest/utils": "3.2.6",
-                "pathe": "^2.0.3",
-                "strip-literal": "^3.0.0"
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
             }
         },
         "@vitest/snapshot": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
-            "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
             "dev": true,
             "requires": {
-                "@vitest/pretty-format": "3.2.6",
-                "magic-string": "^0.30.17",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
-            },
-            "dependencies": {
-                "@vitest/pretty-format": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
-                    "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
-                    "dev": true,
-                    "requires": {
-                        "tinyrainbow": "^2.0.0"
-                    }
-                }
             }
         },
         "@vitest/spy": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
-            "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
-            "dev": true,
-            "requires": {
-                "tinyspy": "^4.0.3"
-            }
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true
         },
         "@vitest/utils": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
-            "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
             "dev": true,
             "requires": {
-                "@vitest/pretty-format": "3.2.6",
-                "loupe": "^3.1.4",
-                "tinyrainbow": "^2.0.0"
-            },
-            "dependencies": {
-                "@vitest/pretty-format": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
-                    "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
-                    "dev": true,
-                    "requires": {
-                        "tinyrainbow": "^2.0.0"
-                    }
-                }
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
             }
         },
         "agent-base": {
@@ -7156,12 +7236,6 @@
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
         },
-        "cac": {
-            "version": "6.7.14",
-            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-            "dev": true
-        },
         "call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -7183,22 +7257,9 @@
             "integrity": "sha512-ceOhN1DL7Y4O6M0j9ICgmTYziV89WMd96SvSl0REd8PMgrY0B/WBOPoed5S1KUmJqXgUXh8gzSe6E3ae27upsQ=="
         },
         "chai": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-            "dev": true,
-            "requires": {
-                "assertion-error": "^2.0.1",
-                "check-error": "^2.1.1",
-                "deep-eql": "^5.0.1",
-                "loupe": "^3.1.0",
-                "pathval": "^2.0.0"
-            }
-        },
-        "check-error": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
             "dev": true
         },
         "chokidar": {
@@ -7370,6 +7431,12 @@
                     "dev": true
                 }
             }
+        },
+        "convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true
         },
         "core-js": {
             "version": "3.26.0",
@@ -7698,12 +7765,6 @@
             "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
             "dev": true
         },
-        "deep-eql": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-            "dev": true
-        },
         "degenerator": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -7843,9 +7904,9 @@
             "dev": true
         },
         "es-module-lexer": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "dev": true
         },
         "es-object-atoms": {
@@ -8545,6 +8606,111 @@
             "resolved": "https://registry.npmjs.org/leaflet-rotatedmarker/-/leaflet-rotatedmarker-0.2.0.tgz",
             "integrity": "sha512-yc97gxLXwbZa+Gk9VCcqI0CkvIBC9oNTTjFsHqq4EQvANrvaboib4UdeQLyTnEqDpaXHCqzwwVIDHtvz2mUiDg=="
         },
+        "lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "requires": {
+                "detect-libc": "^2.0.3",
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            },
+            "dependencies": {
+                "detect-libc": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+                    "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+                    "dev": true
+                }
+            }
+        },
+        "lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "dev": true,
+            "optional": true
+        },
+        "lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "dev": true,
+            "optional": true
+        },
+        "lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "dev": true,
+            "optional": true
+        },
+        "lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "dev": true,
+            "optional": true
+        },
+        "lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "dev": true,
+            "optional": true
+        },
+        "lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "dev": true,
+            "optional": true
+        },
+        "lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "dev": true,
+            "optional": true
+        },
+        "lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "dev": true,
+            "optional": true
+        },
+        "lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "dev": true,
+            "optional": true
+        },
+        "lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "dev": true,
+            "optional": true
+        },
+        "lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "dev": true,
+            "optional": true
+        },
         "lightslider": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/lightslider/-/lightslider-1.1.6.tgz",
@@ -8578,12 +8744,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
             "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
-        },
-        "loupe": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-            "dev": true
         },
         "lru-cache": {
             "version": "11.5.2",
@@ -8648,9 +8808,9 @@
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
         },
         "nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true
         },
         "nanopop": {
@@ -8685,6 +8845,12 @@
             "version": "3.2.0-beta-deprecated",
             "resolved": "https://registry.npmjs.org/noty/-/noty-3.2.0-beta-deprecated.tgz",
             "integrity": "sha512-ntRbHuQ9SnnnVFZm/oq5L1DBCaHQUvsU24AwZH3PGjAWx2YqR/IhOadMk11vmJovYiQo00oqTj6Hp+D6PGtmLA=="
+        },
+        "obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true
         },
         "offset-polygon": {
             "version": "0.9.2",
@@ -8792,12 +8958,6 @@
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true
         },
-        "pathval": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-            "dev": true
-        },
         "pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -8830,9 +8990,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.5.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+            "version": "8.5.19",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
             "dev": true,
             "requires": {
                 "nanoid": "^3.3.12",
@@ -9007,39 +9167,29 @@
             "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
             "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
         },
-        "rollup": {
-            "version": "4.62.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-            "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+        "rolldown": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "dev": true,
             "requires": {
-                "@rollup/rollup-android-arm-eabi": "4.62.2",
-                "@rollup/rollup-android-arm64": "4.62.2",
-                "@rollup/rollup-darwin-arm64": "4.62.2",
-                "@rollup/rollup-darwin-x64": "4.62.2",
-                "@rollup/rollup-freebsd-arm64": "4.62.2",
-                "@rollup/rollup-freebsd-x64": "4.62.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-                "@rollup/rollup-linux-arm64-musl": "4.62.2",
-                "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-                "@rollup/rollup-linux-loong64-musl": "4.62.2",
-                "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-                "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-                "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-                "@rollup/rollup-linux-x64-gnu": "4.62.2",
-                "@rollup/rollup-linux-x64-musl": "4.62.2",
-                "@rollup/rollup-openbsd-x64": "4.62.2",
-                "@rollup/rollup-openharmony-arm64": "4.62.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-                "@rollup/rollup-win32-x64-gnu": "4.62.2",
-                "@rollup/rollup-win32-x64-msvc": "4.62.2",
-                "@types/estree": "1.0.9",
-                "fsevents": "~2.3.2"
+                "@oxc-project/types": "=0.139.0",
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5",
+                "@rolldown/pluginutils": "^1.0.0"
             }
         },
         "run-parallel": {
@@ -9272,9 +9422,9 @@
             "dev": true
         },
         "std-env": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
             "dev": true
         },
         "streamx": {
@@ -9303,23 +9453,6 @@
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "requires": {
                 "ansi-regex": "^5.0.1"
-            }
-        },
-        "strip-literal": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-            "dev": true,
-            "requires": {
-                "js-tokens": "^9.0.1"
-            },
-            "dependencies": {
-                "js-tokens": {
-                    "version": "9.0.1",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-                    "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-                    "dev": true
-                }
             }
         },
         "symbol-tree": {
@@ -9373,9 +9506,9 @@
             "dev": true
         },
         "tinyexec": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
             "dev": true
         },
         "tinyglobby": {
@@ -9403,22 +9536,10 @@
                 }
             }
         },
-        "tinypool": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-            "dev": true
-        },
         "tinyrainbow": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-            "dev": true
-        },
-        "tinyspy": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-            "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
             "dev": true
         },
         "tldts": {
@@ -9514,148 +9635,61 @@
             "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
             "optional": true
         },
-        "vite-node": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+        "vite": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+            "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
             "dev": true,
             "requires": {
-                "cac": "^6.7.14",
-                "debug": "^4.4.1",
-                "es-module-lexer": "^1.7.0",
-                "pathe": "^2.0.3",
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+                "fsevents": "~2.3.3",
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.16",
+                "rolldown": "~1.1.4",
+                "tinyglobby": "^0.2.17"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.4.3",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-                    "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.3"
-                    }
-                },
-                "fdir": {
-                    "version": "6.5.0",
-                    "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-                    "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-                    "dev": true,
-                    "requires": {}
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-                    "dev": true
-                },
                 "picomatch": {
                     "version": "4.0.5",
                     "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
                     "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
                     "dev": true
-                },
-                "vite": {
-                    "version": "7.3.6",
-                    "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-                    "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
-                    "dev": true,
-                    "requires": {
-                        "esbuild": "^0.27.0 || ^0.28.0",
-                        "fdir": "^6.5.0",
-                        "fsevents": "~2.3.3",
-                        "picomatch": "^4.0.3",
-                        "postcss": "^8.5.6",
-                        "rollup": "^4.43.0",
-                        "tinyglobby": "^0.2.15"
-                    }
                 }
             }
         },
         "vitest": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
-            "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
             "dev": true,
             "requires": {
-                "@types/chai": "^5.2.2",
-                "@vitest/expect": "3.2.6",
-                "@vitest/mocker": "3.2.6",
-                "@vitest/pretty-format": "^3.2.6",
-                "@vitest/runner": "3.2.6",
-                "@vitest/snapshot": "3.2.6",
-                "@vitest/spy": "3.2.6",
-                "@vitest/utils": "3.2.6",
-                "chai": "^5.2.0",
-                "debug": "^4.4.1",
-                "expect-type": "^1.2.1",
-                "magic-string": "^0.30.17",
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.2",
-                "std-env": "^3.9.0",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
                 "tinybench": "^2.9.0",
-                "tinyexec": "^0.3.2",
-                "tinyglobby": "^0.2.14",
-                "tinypool": "^1.1.1",
-                "tinyrainbow": "^2.0.0",
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-                "vite-node": "3.2.4",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
                 "why-is-node-running": "^2.3.0"
             },
             "dependencies": {
-                "@vitest/mocker": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
-                    "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
-                    "dev": true,
-                    "requires": {
-                        "@vitest/spy": "3.2.6",
-                        "estree-walker": "^3.0.3",
-                        "magic-string": "^0.30.17"
-                    }
-                },
-                "debug": {
-                    "version": "4.4.3",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-                    "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.3"
-                    }
-                },
-                "fdir": {
-                    "version": "6.5.0",
-                    "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-                    "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-                    "dev": true,
-                    "requires": {}
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-                    "dev": true
-                },
                 "picomatch": {
                     "version": "4.0.5",
                     "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
                     "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
                     "dev": true
-                },
-                "vite": {
-                    "version": "7.3.6",
-                    "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-                    "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
-                    "dev": true,
-                    "requires": {
-                        "esbuild": "^0.27.0 || ^0.28.0",
-                        "fdir": "^6.5.0",
-                        "fsevents": "~2.3.3",
-                        "picomatch": "^4.0.3",
-                        "postcss": "^8.5.6",
-                        "rollup": "^4.43.0",
-                        "tinyglobby": "^0.2.15"
-                    }
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "php-array-parser": "^1.0.1",
         "pusher-js": "^8.5.0",
         "sass": "^1.89.2",
-        "vitest": "^3.2.6"
+        "vitest": "^4.1.10"
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,11 @@ export default defineConfig({
     test: {
         environment: 'jsdom',
         globals: true,
+        // Restore `vi.spyOn` originals before each test. The jsdom environment (and thus globals
+        // like `history`) is shared across tests in a file; since Vitest 4 no longer auto-restores
+        // spies between tests, re-spying a shared global would otherwise accumulate call history
+        // from earlier tests (e.g. menuitemsanchor's `history.replaceState` count).
+        restoreMocks: true,
         setupFiles: ['resources/assets/js/test/setup.js'],
         include: ['resources/assets/js/**/*.test.{js,ts}', 'scripts/build/**/*.test.mjs'],
     },


### PR DESCRIPTION
:robot: Upgrades **vitest 3.2.6 → 4.1.10**, superseding Dependabot PR #3530 (which fails CI as-is).

## Why #3530 fails and what fixes it

Vitest 4 no longer auto-restores `vi.spyOn` originals between tests in the same file. The jsdom environment — and shared globals like `history` — persist across a file's tests, so re-spying `history.replaceState` in a later test inherited the call history of earlier tests. This broke the exact-call-count assertion in `menuitemsanchor.test.js › activate_givenNavLinkClicked_doesNotAssignLocationHashDirectly` (it saw 3 calls: the prior test's click, that test's `afterEach`, then its own click).

Fixed at the root by enabling **`restoreMocks: true`** in `vitest.config.js`, which restores spied originals before each test suite-wide (the recommended Vitest setting). No test relies on a spy persisting across tests (there are no `beforeAll` spies), so this is safe.

## Verification (in worktree Docker, node 24)
- `npm test` → **157/157 pass** (was 156/157 on #3530).
- `npm run production` → esbuild bundle builds clean. The new lockfile entries (`@rolldown/*`, `lightningcss-*`, `@vitest/*`) are Vitest 4's internal test-runner deps — dev-only, not in the shipped bundle.

Once merged, Dependabot's #3530 auto-closes (same version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
