### PR TITLE
#3535 Clear stale dungeon_difficulty when switching away from a speedrun dungeon

### DIFF
--- a/app/Service/DungeonRoute/DungeonRouteSaveService.php
+++ b/app/Service/DungeonRoute/DungeonRouteSaveService.php
@@ -436,21 +436,27 @@ readonly class DungeonRouteSaveService implements DungeonRouteSaveServiceInterfa
 
     /**
      * Resolves the dungeon difficulty for speedrun-enabled dungeons: keeps the chosen difficulty when it is one of the
-     * dungeon's enabled speedrun difficulties, otherwise falls back to the first enabled difficulty.
+     * dungeon's enabled speedrun difficulties, otherwise falls back to the first enabled difficulty. Non-speedrun
+     * dungeons never have a difficulty, so a submitted value is discarded (defense in depth: see GitHub issue #3535,
+     * where a stale value from a previously-selected speedrun dungeon could otherwise survive a dungeon switch).
      */
     private function resolveDungeonDifficulty(Dungeon $dungeon, ?int $difficulty): ?int
     {
-        if ($difficulty !== null && $dungeon->speedrun_enabled) {
-            $enabledDifficulties = $dungeon->getEnabledSpeedrunDifficulties();
-
-            if (in_array($difficulty, $enabledDifficulties, true)) {
-                return $difficulty;
-            }
-
-            return $enabledDifficulties[0] ?? $difficulty;
+        if (!$dungeon->speedrun_enabled) {
+            return null;
         }
 
-        return $difficulty;
+        if ($difficulty === null) {
+            return null;
+        }
+
+        $enabledDifficulties = $dungeon->getEnabledSpeedrunDifficulties();
+
+        if (in_array($difficulty, $enabledDifficulties, true)) {
+            return $difficulty;
+        }
+
+        return $enabledDifficulties[0] ?? $difficulty;
     }
 
     /**

--- a/resources/assets/js/custom/inline/common/dungeonroute/create/dungeondifficultyselect.js
+++ b/resources/assets/js/custom/inline/common/dungeonroute/create/dungeondifficultyselect.js
@@ -39,6 +39,14 @@ class CommonDungeonrouteCreateDungeondifficultyselect extends InlineCode {
                 refreshSelectPickers();
                 $dungeonDifficultySelectContainer.show();
             } else {
+                // Only touch the select when it actually still holds options from a previously-selected
+                // speedrun dungeon: refreshSelectPickers() is a page-wide sync, so calling it unconditionally
+                // here (even when there is nothing to clear) would prematurely initialize Tom Select on other
+                // not-yet-activated .selectpicker elements on the page (see GitHub issue #3535).
+                if ($dungeonDifficultySelect.find('option').length > 0) {
+                    $dungeonDifficultySelect.find('option').remove();
+                    refreshSelectPickers();
+                }
                 $dungeonDifficultySelectContainer.hide();
             }
         };

--- a/resources/assets/js/custom/inline/common/dungeonroute/create/dungeondifficultyselect.test.js
+++ b/resources/assets/js/custom/inline/common/dungeonroute/create/dungeondifficultyselect.test.js
@@ -130,10 +130,11 @@ describe('CommonDungeonrouteCreateDungeondifficultyselect.activate', () => {
         expect(document.getElementById('dungeon_difficulty_select_container').style.display).not.toBe('none');
     });
 
-    it('activate_givenDungeonChangedFromSpeedrunToNonSpeedrun_hidesContainerButLeavesStaleOptionsAndSelection', () => {
-        // See GitHub issue #3535: dungeonSelectionChanged() only ever *hides* the container on
-        // switch-away from a speedrun dungeon - it never clears the difficulty select's options or
-        // selection. This pins that current (buggy) behaviour; it is not asserting the desired fix.
+    it('activate_givenDungeonChangedFromSpeedrunToNonSpeedrun_hidesContainerAndClearsOptionsAndSelection', () => {
+        // See GitHub issue #3535: dungeonSelectionChanged() used to only *hide* the container on
+        // switch-away from a speedrun dungeon, leaving the difficulty select's stale options/selection
+        // in place (a hidden <select> is still a successful form control, so the stale value would be
+        // submitted). It now also clears the options so nothing stale can be submitted.
         // Arrange
         buildAndActivate(CLASSIC_DUNGEON_SSC_ID);
         const $difficultySelect = $('#dungeon_difficulty_select');
@@ -145,8 +146,6 @@ describe('CommonDungeonrouteCreateDungeondifficultyselect.activate', () => {
 
         // Assert
         expect(document.getElementById('dungeon_difficulty_select_container').style.display).toBe('none');
-        const staleOptions = Array.from(document.getElementById('dungeon_difficulty_select').options);
-        expect(staleOptions.map((option) => option.value)).toEqual([String(DIFFICULTY_10_MAN), String(DIFFICULTY_25_MAN)]);
-        expect($difficultySelect.val()).toBe(String(DIFFICULTY_10_MAN));
+        expect(document.getElementById('dungeon_difficulty_select').options.length).toBe(0);
     });
 });

--- a/resources/assets/js/custom/inline/common/forms/createroute.serialization.test.js
+++ b/resources/assets/js/custom/inline/common/forms/createroute.serialization.test.js
@@ -311,11 +311,11 @@ describe('createroute.serialization', () => {
         }));
     });
 
-    it('serializeForm_givenSpeedrunDungeonSwitchedToNonSpeedrun_stillSubmitsStaleDifficulty', () => {
-        // Arrange: see GitHub issue #3535. dungeondifficultyselect.js only hides the container on
-        // switch-away from a speedrun dungeon; it never clears the select's options or selection, so
-        // the hidden <select> still submits the stale value from the previously-selected dungeon.
-        // This test pins that current (buggy) behaviour - it is not asserting the desired fix.
+    it('serializeForm_givenSpeedrunDungeonSwitchedToNonSpeedrun_clearsDifficultyInsteadOfSubmittingStaleValue', () => {
+        // Arrange: regression test for GitHub issue #3535. dungeondifficultyselect.js used to only hide
+        // the container on switch-away from a speedrun dungeon, leaving the select's stale options/
+        // selection in place, so the hidden <select> would still submit the stale value from the
+        // previously-selected dungeon. It now also clears the options.
         const form    = buildCreateRouteForm({
             gameVersion: 'classic',
             hasTeams: true,

--- a/tests/Feature/App/Service/DungeonRoute/DungeonRouteSaveServiceSaveTest.php
+++ b/tests/Feature/App/Service/DungeonRoute/DungeonRouteSaveServiceSaveTest.php
@@ -406,9 +406,11 @@ final class DungeonRouteSaveServiceSaveTest extends DungeonRouteSaveServiceTestC
     }
 
     #[Test]
-    public function save_givenNonSpeedrunDungeonWithDifficulty_keepsDifficulty(): void
+    public function save_givenNonSpeedrunDungeonWithDifficulty_discardsDifficulty(): void
     {
-        // Arrange — retail M+ dungeons are not speedrun-enabled
+        // Arrange — retail M+ dungeons are not speedrun-enabled. Regression test for GitHub issue #3535:
+        // a submitted difficulty is discarded for non-speedrun dungeons (defense in depth against a stale
+        // value carried over from a previously-selected speedrun dungeon).
         $dungeon = $this->getNonSpeedrunDungeon();
         $this->assertFalse((bool)$dungeon->speedrun_enabled, 'Expected a non-speedrun retail dungeon ' . $dungeon->key);
 
@@ -417,7 +419,7 @@ final class DungeonRouteSaveServiceSaveTest extends DungeonRouteSaveServiceTestC
         $validated = [
             'dungeon_id'          => $dungeon->id,
             'faction_id'          => 1,
-            'dungeon_route_title' => 'Difficulty Passthrough Test',
+            'dungeon_route_title' => 'Difficulty Discarded Test',
             'dungeon_difficulty'  => Dungeon::DIFFICULTY_ALL[Dungeon::DIFFICULTY_25_MAN],
         ];
 
@@ -426,7 +428,7 @@ final class DungeonRouteSaveServiceSaveTest extends DungeonRouteSaveServiceTestC
             $service->save($route, $validated);
 
             // Assert
-            $this->assertEquals(Dungeon::DIFFICULTY_ALL[Dungeon::DIFFICULTY_25_MAN], $route->dungeon_difficulty);
+            $this->assertNull($route->getRawOriginal('dungeon_difficulty'));
         } finally {
             if ($route->exists) {
                 $this->cleanupRoute($route);

--- a/tests/Feature/Controller/DungeonRouteCreateContractTest.php
+++ b/tests/Feature/Controller/DungeonRouteCreateContractTest.php
@@ -467,7 +467,7 @@ final class DungeonRouteCreateContractTest extends PublicTestCase
     }
 
     #[Test]
-    public function saveNew_givenClassicSpeedrunThenSwitchFixture_pinsStaleDifficultyBugIssue3535(): void
+    public function saveNew_givenClassicSpeedrunThenSwitchFixture_discardsStaleDifficultyIssue3535(): void
     {
         // Arrange
         Queue::fake();
@@ -492,10 +492,11 @@ final class DungeonRouteCreateContractTest extends PublicTestCase
 
             $dungeonRoute = $this->findCreatedRoute($dungeon, $user);
             $this->assertNotNull($dungeonRoute);
-            // BUG #3535, pinned as-is (not a fix): dungeondifficultyselect.js only hides the difficulty container
-            // on switch-away, it never clears the select's stale value, so a non-speedrun dungeon can end up with
-            // a persisted dungeon_difficulty left over from a previously-selected speedrun dungeon.
-            $this->assertSame(1, $dungeonRoute->getRawOriginal('dungeon_difficulty'));
+            // Regression test for GitHub issue #3535: dungeondifficultyselect.js now clears the select's stale
+            // value on switch-away, and DungeonRouteSaveService::resolveDungeonDifficulty() discards any
+            // submitted difficulty for a non-speedrun dungeon as defense in depth, so no stale difficulty
+            // left over from a previously-selected speedrun dungeon survives onto this route.
+            $this->assertNull($dungeonRoute->getRawOriginal('dungeon_difficulty'));
         } finally {
             $dungeonRoute?->delete();
         }

--- a/tests/Fixtures/CreateRoute/payloads/classic-speedrun-then-switch.json
+++ b/tests/Fixtures/CreateRoute/payloads/classic-speedrun-then-switch.json
@@ -1,12 +1,12 @@
 {
-    "description": "STALE-DIFFICULTY BUG PIN, see GitHub issue #3535. User first selects a speedrun dungeon (Serpentshrine Cavern-like), which auto-selects 10-man difficulty (value \"1\"); the user then switches the dungeon select to a non-speedrun dungeon. dungeondifficultyselect.js only hides the difficulty container on switch-away, it never clears the select's options/selection, so the hidden <select> still submits the stale dungeon_difficulty=\"1\" from the previously-selected speedrun dungeon. This is current (buggy) behaviour, pinned as-is - not a fix. dungeon_start_map_icon_id is entirely absent - see classic-speedrun-ssc-10man.json for why.",
+    "description": "Regression fixture for GitHub issue #3535. User first selects a speedrun dungeon (Serpentshrine Cavern-like), which auto-selects 10-man difficulty (value \"1\"); the user then switches the dungeon select to a non-speedrun dungeon. dungeondifficultyselect.js now clears the difficulty select's options/selection on switch-away (in addition to hiding the container), so the hidden <select> submits an empty dungeon_difficulty rather than the stale value from the previously-selected speedrun dungeon. dungeon_start_map_icon_id is entirely absent - see classic-speedrun-ssc-10man.json for why.",
     "endpoint": "dungeonroute.savenew",
     "gameVersion": "classic",
     "auth": true,
     "fields": [
         {"name": "dungeon_id", "value": "{{dungeon_id}}"},
         {"name": "team_id", "value": "-1"},
-        {"name": "dungeon_difficulty", "value": "1"},
+        {"name": "dungeon_difficulty", "value": ""},
         {"name": "dungeon_route_title", "value": "My Test Route"},
         {"name": "faction_id", "value": "1"},
         {"name": "class[]", "value": "0"},


### PR DESCRIPTION
:robot:

Closes #3535

## Summary
- `dungeondifficultyselect.js` only hid the difficulty select's container when switching away from a speedrun dungeon; it never cleared the select's options/selection, so a hidden `<select>` (still a successful form control) posted the stale difficulty value from the previously-selected speedrun dungeon.
- The else-branch now also clears the select's options (only when there are options to clear, to avoid prematurely triggering a page-wide `refreshSelectPickers()` sync on unrelated `.selectpicker` elements that haven't activated yet).
- `DungeonRouteSaveService::resolveDungeonDifficulty()` now discards any submitted difficulty for a non-speedrun dungeon (defense in depth), instead of passing it through unchanged.

## Test plan
- [x] Updated JS unit test (`dungeondifficultyselect.test.js`) and integration test (`createroute.serialization.test.js`) + shared fixture (`classic-speedrun-then-switch.json`) to assert the fixed behaviour instead of pinning the bug.
- [x] Updated `DungeonRouteSaveServiceSaveTest` and `DungeonRouteCreateContractTest` to assert the difficulty is discarded for non-speedrun dungeons.
- [x] `npx vitest run` — 199 passed.
- [x] `php artisan test --compact` on the affected DungeonRoute/contract test files — 104 passed.
- [x] `composer run analyse` — no errors.