### PR TITLE
#3553 Defer release_* table drops to a guarded follow-up migration

### DIFF
--- a/database/migrations/2026_07_09_000000_drop_release_tables.php
+++ b/database/migrations/2026_07_09_000000_drop_release_tables.php
@@ -22,24 +22,20 @@ return new class extends Migration {
             ->update(['release_report_logs.version' => DB::raw('releases.version')]);
 
         Schema::table('release_report_logs', static function (Blueprint $table): void {
-            $table->dropColumn('release_id');
             $table->index('version');
         });
 
-        Schema::dropIfExists('release_changelog_changes');
-        Schema::dropIfExists('release_changelogs');
-        Schema::dropIfExists('release_changelog_categories');
-        Schema::dropIfExists('releases');
+        // The destructive drops (release_id column + release_* tables) are deferred to the follow-up
+        // migration 2026_07_14_000000_drop_release_tables_followup so that old still-running containers
+        // keep working during the non-atomic deploy window (expand/contract, see #3553).
     }
 
     /**
-     * Reverse the migrations. The dropped tables (and their seeded contents) are not restored - release
-     * notes now live on GitHub Releases.
+     * Reverse the migrations.
      */
     public function down(): void
     {
         Schema::table('release_report_logs', static function (Blueprint $table): void {
-            $table->integer('release_id')->after('id')->default(0);
             $table->dropIndex(['version']);
             $table->dropColumn('version');
         });

--- a/database/migrations/2026_07_14_000000_drop_release_tables_followup.php
+++ b/database/migrations/2026_07_14_000000_drop_release_tables_followup.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Contract half of the expand/contract for #3480 (see #3553). The additive work (re-keying the
+     * release_report_logs announce-dedupe log to `version`) shipped in v15.4.5; this drops the now-unused
+     * release_id column and the release_* tables one release later, once no running container references them.
+     *
+     * Guarded/idempotent because environments reach this migration in different states: staging already ran
+     * the original destructive body of 2026_07_09_000000_drop_release_tables (tables gone, release_id gone),
+     * while production (neutralised via an additive-only hotfix) and fresh databases still have them.
+     */
+    public function up(): void
+    {
+        if (Schema::hasColumn('release_report_logs', 'release_id')) {
+            Schema::table('release_report_logs', static function (Blueprint $table): void {
+                $table->dropColumn('release_id');
+            });
+        }
+
+        Schema::dropIfExists('release_changelog_changes');
+        Schema::dropIfExists('release_changelogs');
+        Schema::dropIfExists('release_changelog_categories');
+        Schema::dropIfExists('releases');
+    }
+
+    /**
+     * Reverse the migration. The dropped release_* tables and their contents are not restored - release notes
+     * now live on GitHub Releases. Only the release_report_logs.release_id column is re-added for symmetry.
+     */
+    public function down(): void
+    {
+        if (!Schema::hasColumn('release_report_logs', 'release_id')) {
+            Schema::table('release_report_logs', static function (Blueprint $table): void {
+                $table->integer('release_id')->after('id')->default(0);
+            });
+        }
+    }
+};


### PR DESCRIPTION
:robot: Closes #3553

Expand/contract follow-up to #3480. The original `2026_07_09_000000_drop_release_tables` dropped the `release_*` tables and `release_report_logs.release_id` **in the same release (v15.4.5)** that removed their code consumers — which would have 500'd old still-running v15.4.4 containers during the non-atomic deploy window (same failure mode as #3497). For v15.4.5 the drops were neutralised in production via an **additive-only hotfix** of that migration file.

This lands the proper split on master:

- **`2026_07_09_000000_drop_release_tables`** is reduced to its **additive half** — add + backfill `release_report_logs.version` + index — matching what production actually ran via the hotfix. No drops.
- **`2026_07_14_000000_drop_release_tables_followup`** (new) performs the destructive drops (`release_id` column + `releases`, `release_changelogs`, `release_changelog_categories`, `release_changelog_changes`), **guarded** with `hasColumn` / `dropIfExists` so it is idempotent across all environment states:
  - **staging** — original destructive body already ran, tables/column already gone → no-op;
  - **production** — neutralised via hotfix, tables/column still present → dropped;
  - **fresh DBs / CI** — tables/column present → dropped.

Ships the destructive half one release later (v15.4.6+), by which point the last consumer (v15.4.5) is already live everywhere, so the drop is safe.

## Verification

Ran both migrations against an isolated throwaway SQLite database (no shared DB touched) across both real-world states:

- **Fresh/prod:** additive-only `07_09` adds `version` and drops nothing; follow-up then drops `release_id` + all four tables and retains `version`. ✅
- **Staging:** follow-up runs clean when the tables/column are already absent, and is idempotent on a repeat run. ✅

`composer run fix` and `composer run analyse` (PHPStan) both clean.
