### PR TITLE
#3565 Resolve real visitor IP from CF-Connecting-IP for rate limiting

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -7,6 +7,7 @@ use Closure;
 use Illuminate\Http\Middleware\TrustProxies as Middleware;
 use Illuminate\Http\Request;
 use Override;
+use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\HttpFoundation\Response;
 
 class TrustProxies extends Middleware
@@ -32,10 +33,36 @@ class TrustProxies extends Middleware
             // Prefer caching inside the service so this isn’t fetched every request.
             // https://khalilst.medium.com/get-real-client-ip-behind-cloudflare-in-laravel-189cb89059ff
             $this->proxies = $this->cloudflareService->getIpRanges();
+
+            $this->useCloudflareConnectingIp($request);
         } else {
             $this->proxies = null; // no trusted proxies locally
         }
 
         return parent::handle($request, $next);
+    }
+
+    /**
+     * CloudFlare sends the real visitor IP in the CF-Connecting-IP header on every proxied request. It is a single
+     * value, so it sidesteps the X-Forwarded-For chain walk which - when it fails to yield a non-trusted client entry -
+     * falls back to returning the CloudFlare edge IP itself, bucketing swaths of unrelated visitors under one IP for
+     * rate limiting. Rewriting X-Forwarded-For to this single value lets the parent middleware resolve
+     * $request->ip() to the real visitor.
+     *
+     * This is only honoured when the connecting peer is itself a trusted CloudFlare proxy - the same trust boundary the
+     * parent middleware enforces - otherwise a client reaching the origin outside of CloudFlare could spoof the header
+     * and evade rate limiting entirely.
+     */
+    private function useCloudflareConnectingIp(Request $request): void
+    {
+        if (!$request->headers->has('CF-Connecting-IP')) {
+            return;
+        }
+
+        if (!IpUtils::checkIp((string)$request->server->get('REMOTE_ADDR', ''), $this->proxies ?? [])) {
+            return;
+        }
+
+        $request->headers->set('X-Forwarded-For', (string)$request->headers->get('CF-Connecting-IP'));
     }
 }

--- a/tests/Unit/App/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Unit/App/Http/Middleware/TrustProxiesTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit\App\Http\Middleware;
+
+use App\Http\Middleware\TrustProxies;
+use App\Service\Cloudflare\CloudflareServiceInterface;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Exception;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Middleware')]
+#[Group('TrustProxies')]
+class TrustProxiesTest extends PublicTestCase
+{
+    /** @var array<int, string> A CloudFlare range (172.64.0.0/13) plus an arbitrary one for coverage. */
+    private const array CLOUDFLARE_RANGES = ['172.64.0.0/13', '173.245.48.0/20'];
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The middleware only trusts CloudFlare and honours CF-Connecting-IP in production.
+        $this->app->detectEnvironment(static fn() => 'production');
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        // setTrustedProxies mutates static state on the Symfony request, so reset it between tests.
+        Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_GivenTrustedCloudflarePeerWithConnectingIp_ReturnsConnectingIp(): void
+    {
+        // Arrange - a genuine CloudFlare peer, with both an X-Forwarded-For entry and CF-Connecting-IP that disagree.
+        $middleware = $this->makeMiddleware();
+        $request    = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '172.68.0.1']);
+        $request->headers->set('X-Forwarded-For', '203.0.113.7');
+        $request->headers->set('CF-Connecting-IP', '198.51.100.42');
+
+        // Act
+        $middleware->handle($request, static fn() => new Response());
+
+        // Assert - CF-Connecting-IP is authoritative over whatever sits in X-Forwarded-For.
+        self::assertSame('198.51.100.42', $request->ip());
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_GivenTrustedCloudflarePeerWithoutForwardedFor_ReturnsConnectingIpInsteadOfEdgeIp(): void
+    {
+        // Arrange - the bug case: no usable X-Forwarded-For, so Symfony would otherwise fall back to the edge IP.
+        $middleware = $this->makeMiddleware();
+        $request    = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '172.68.0.1']);
+        $request->headers->set('CF-Connecting-IP', '198.51.100.42');
+
+        // Act
+        $middleware->handle($request, static fn() => new Response());
+
+        // Assert - the real visitor IP, not the CloudFlare edge IP (172.68.0.1).
+        self::assertSame('198.51.100.42', $request->ip());
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_GivenUntrustedPeerSpoofingConnectingIp_IgnoresConnectingIp(): void
+    {
+        // Arrange - a client reaching the origin outside of CloudFlare, spoofing CF-Connecting-IP.
+        $middleware = $this->makeMiddleware();
+        $request    = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '203.0.113.99']);
+        $request->headers->set('CF-Connecting-IP', '10.0.0.1');
+
+        // Act
+        $middleware->handle($request, static fn() => new Response());
+
+        // Assert - the spoofed header is ignored; the real connecting peer is used.
+        self::assertSame('203.0.113.99', $request->ip());
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function makeMiddleware(): TrustProxies
+    {
+        $cloudflareService = $this->createMockPublic(CloudflareServiceInterface::class);
+        $cloudflareService->method('getIpRanges')
+            ->willReturn(self::CLOUDFLARE_RANGES);
+
+        return new TrustProxies($cloudflareService);
+    }
+}


### PR DESCRIPTION
:robot: _Opened by Claude on behalf of @Wotuu._

Closes #3565

## Problem

Rate limiting (`AppServiceProvider::userKey`) keys off `$request->ip()`. Behind CloudFlare, `TrustProxies` trusts CloudFlare's published IP ranges — but when the `X-Forwarded-For` chain does not yield a non-trusted client entry, Symfony's `getClientIps()` falls back to returning the connecting peer, which is a **trusted CloudFlare edge IP**. With only a handful of edge IPs, swaths of unrelated visitors collapse into one rate-limit bucket and get throttled together, while an attacker whose XFF entry survives (e.g. `172.41.23.193`, not a CloudFlare range) is bucketed correctly.

## Fix

In `TrustProxies::handle()`, when the connecting peer is a trusted CloudFlare proxy, rewrite `X-Forwarded-For` to the single `CF-Connecting-IP` value (which CloudFlare sets on every proxied request and contains exactly the real visitor IP) before delegating to `parent::handle()`. Symfony's normal trusted-proxy walk then resolves `$request->ip()` to the real visitor.

The override is gated strictly on `IpUtils::checkIp(REMOTE_ADDR, cloudflare_ranges)` — the same trust boundary the parent middleware enforces — so a client reaching the origin outside CloudFlare cannot spoof the header to evade rate limiting.

Notes:
- Only affects the exact class of broken requests: a request misresolving to a CloudFlare IP must have `REMOTE_ADDR` in the CF ranges, which means it is a genuine CloudFlare request that always carries `CF-Connecting-IP`.
- No regression for currently-correct traffic: with CF connecting directly to origin (production nginx has no `real_ip` stripping), the rightmost XFF entry already equals `CF-Connecting-IP`, so the rewrite yields the same value.
- Self-healing after deploy: stale `perHour` buckets keyed by CF edge IPs age out while real-IP buckets start fresh — cut-off users unblock with no Redis purge.

## Tests

New `tests/Unit/App/Http/Middleware/TrustProxiesTest.php`:
1. Trusted CF peer + usable XFF + `CF-Connecting-IP` → returns the `CF-Connecting-IP` value (authoritative over XFF).
2. Trusted CF peer + missing XFF + `CF-Connecting-IP` → returns the real visitor IP instead of the CloudFlare edge IP (the bug).
3. Untrusted peer + spoofed `CF-Connecting-IP` → header ignored, real connecting peer used (security case).

`composer run analyse` and `composer run fix` clean.

Follow-up: #3564 (application-layer IP banning, which depends on this real-IP resolution).