### PR TITLE
#3564 Ban IP addresses from accessing the site at the application layer

### DIFF
--- a/app/Console/Commands/BannedIpAddress/Ban.php
+++ b/app/Console/Commands/BannedIpAddress/Ban.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands\BannedIpAddress;
+
+use App\Service\BannedIpAddress\BannedIpAddressServiceInterface;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class Ban extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'bannedipaddress:ban
+        {ipAddress : The IP address or CIDR range to ban, e.g. 1.2.3.4 or 1.2.3.0/24}
+        {--reason= : Why this IP address is being banned}
+        {--expires-at= : When the ban should be lifted automatically, e.g. "2026-08-01 00:00:00" - omit for a permanent ban}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Bans an IP address (or CIDR range) from accessing the site, for incident response.';
+
+    public function handle(BannedIpAddressServiceInterface $bannedIpAddressService): int
+    {
+        $ipAddress       = (string)$this->argument('ipAddress');
+        $expiresAtOption = $this->option('expires-at');
+
+        $bannedIpAddressService->ban(
+            $ipAddress,
+            $this->option('reason'),
+            $expiresAtOption !== null ? Carbon::parse((string)$expiresAtOption) : null,
+            null,
+        );
+
+        $this->info(sprintf('Banned %s', $ipAddress));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/BannedIpAddress/Ban.php
+++ b/app/Console/Commands/BannedIpAddress/Ban.php
@@ -2,6 +2,8 @@
 
 namespace App\Console\Commands\BannedIpAddress;
 
+use App\Models\Laratrust\Role;
+use App\Models\User;
 use App\Service\BannedIpAddress\BannedIpAddressServiceInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
@@ -15,6 +17,7 @@ class Ban extends Command
      */
     protected $signature = 'bannedipaddress:ban
         {ipAddress : The IP address or CIDR range to ban, e.g. 1.2.3.4 or 1.2.3.0/24}
+        {adminId : The user ID of the admin performing this ban, so it can always be attributed to someone}
         {--reason= : Why this IP address is being banned}
         {--expires-at= : When the ban should be lifted automatically, e.g. "2026-08-01 00:00:00" - omit for a permanent ban}';
 
@@ -27,17 +30,25 @@ class Ban extends Command
 
     public function handle(BannedIpAddressServiceInterface $bannedIpAddressService): int
     {
-        $ipAddress       = (string)$this->argument('ipAddress');
+        $ipAddress = (string)$this->argument('ipAddress');
+        $admin     = User::find((int)$this->argument('adminId'));
+
+        if ($admin === null || !$admin->hasRole(Role::ROLE_ADMIN)) {
+            $this->error(sprintf('%s is not a valid admin user ID', $this->argument('adminId')));
+
+            return self::FAILURE;
+        }
+
         $expiresAtOption = $this->option('expires-at');
 
         $bannedIpAddressService->ban(
             $ipAddress,
             $this->option('reason'),
             $expiresAtOption !== null ? Carbon::parse((string)$expiresAtOption) : null,
-            null,
+            $admin->id,
         );
 
-        $this->info(sprintf('Banned %s', $ipAddress));
+        $this->info(sprintf('Banned %s (attributed to %s)', $ipAddress, $admin->name));
 
         return self::SUCCESS;
     }

--- a/app/Console/Commands/BannedIpAddress/Unban.php
+++ b/app/Console/Commands/BannedIpAddress/Unban.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands\BannedIpAddress;
+
+use App\Service\BannedIpAddress\BannedIpAddressServiceInterface;
+use Illuminate\Console\Command;
+
+class Unban extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'bannedipaddress:unban {ipAddress : The exact IP address or CIDR range as it was banned}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Removes a ban on an IP address (or CIDR range), for incident response.';
+
+    public function handle(BannedIpAddressServiceInterface $bannedIpAddressService): int
+    {
+        $ipAddress       = (string)$this->argument('ipAddress');
+        $bannedIpAddress = $bannedIpAddressService->all()->firstWhere('ip_address', $ipAddress);
+
+        if ($bannedIpAddress === null) {
+            $this->error(sprintf('%s is not currently banned', $ipAddress));
+
+            return self::FAILURE;
+        }
+
+        $bannedIpAddressService->unban($bannedIpAddress);
+
+        $this->info(sprintf('Unbanned %s', $ipAddress));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/AdminTools/AdminToolsBannedIpAddressController.php
+++ b/app/Http/Controllers/AdminTools/AdminToolsBannedIpAddressController.php
@@ -32,7 +32,7 @@ class AdminToolsBannedIpAddressController extends Controller
             $request->string('ip_address')->toString(),
             $request->string('reason')->toString() === '' ? null : $request->string('reason')->toString(),
             $request->filled('expires_at') ? Carbon::parse($request->string('expires_at')->toString()) : null,
-            Auth::id(),
+            (int)Auth::id(),
         );
 
         Session::flash('status', __('controller.admintools.flash.banned_ip_address_added'));

--- a/app/Http/Controllers/AdminTools/AdminToolsBannedIpAddressController.php
+++ b/app/Http/Controllers/AdminTools/AdminToolsBannedIpAddressController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\AdminTools;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\AdminToolsBannedIpAddressStoreRequest;
+use App\Models\BannedIpAddress;
+use App\Service\BannedIpAddress\BannedIpAddressServiceInterface;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+use Session;
+
+class AdminToolsBannedIpAddressController extends Controller
+{
+    public function index(): View
+    {
+        return view('admin.tools.bannedipaddresses.list', [
+            'bannedIpAddresses' => BannedIpAddress::query()
+                ->with('createdBy')
+                ->orderByDesc('created_at')
+                ->get(),
+        ]);
+    }
+
+    public function store(
+        AdminToolsBannedIpAddressStoreRequest $request,
+        BannedIpAddressServiceInterface       $bannedIpAddressService,
+    ): RedirectResponse {
+        $bannedIpAddressService->ban(
+            $request->string('ip_address')->toString(),
+            $request->string('reason')->toString() === '' ? null : $request->string('reason')->toString(),
+            $request->filled('expires_at') ? Carbon::parse($request->string('expires_at')->toString()) : null,
+            Auth::id(),
+        );
+
+        Session::flash('status', __('controller.admintools.flash.banned_ip_address_added'));
+
+        return redirect()->route('admin.tools.bannedipaddresses.view');
+    }
+
+    public function destroy(
+        BannedIpAddress                 $bannedIpAddress,
+        BannedIpAddressServiceInterface $bannedIpAddressService,
+    ): RedirectResponse {
+        $bannedIpAddressService->unban($bannedIpAddress);
+
+        Session::flash('status', __('controller.admintools.flash.banned_ip_address_removed'));
+
+        return redirect()->route('admin.tools.bannedipaddresses.view');
+    }
+}

--- a/app/Http/Middleware/BlockBannedIpAddresses.php
+++ b/app/Http/Middleware/BlockBannedIpAddresses.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Service\BannedIpAddress\BannedIpAddressServiceInterface;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Teapot\StatusCode\RFC\RFC7231;
+
+class BlockBannedIpAddresses
+{
+    public function __construct(private readonly BannedIpAddressServiceInterface $bannedIpAddressService)
+    {
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * Registered after TrustProxies in bootstrap/app.php so $request->ip() already reflects the
+     * real visitor IP resolved from CF-Connecting-IP, not the CloudFlare edge IP.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($this->bannedIpAddressService->isBanned((string)$request->ip())) {
+            if ($request->ajax() || $request->isJson()) {
+                return response(json_encode([
+                    'message' => 'Forbidden',
+                ]), RFC7231::FORBIDDEN);
+            }
+
+            return response('Forbidden', RFC7231::FORBIDDEN);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/AdminToolsBannedIpAddressStoreRequest.php
+++ b/app/Http/Requests/AdminToolsBannedIpAddressStoreRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Laratrust\Role;
+use App\Rules\BannedIpRangeRule;
+use Auth;
+use Illuminate\Foundation\Http\FormRequest;
+
+class AdminToolsBannedIpAddressStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return Auth::user()->hasRole(Role::ROLE_ADMIN);
+    }
+
+    /** @return array<string, array<int, object|string>|string> */
+    public function rules(): array
+    {
+        return [
+            'ip_address' => ['required', 'string', 'max:45', new BannedIpRangeRule($this->ip())],
+            'reason'     => ['nullable', 'string', 'max:255'],
+            'expires_at' => ['nullable', 'date', 'after:now'],
+        ];
+    }
+}

--- a/app/Models/BannedIpAddress.php
+++ b/app/Models/BannedIpAddress.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\BannedIpAddressFactory;
+use Eloquent;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int         $id
+ * @property string      $ip_address
+ * @property string|null $reason
+ * @property Carbon|null $expires_at
+ * @property int|null    $created_by
+ *
+ * @property Carbon $updated_at
+ * @property Carbon $created_at
+ *
+ * @property User|null $createdBy
+ *
+ * @mixin Eloquent
+ */
+class BannedIpAddress extends Model
+{
+    /** @use HasFactory<BannedIpAddressFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'ip_address',
+        'reason',
+        'expires_at',
+        'created_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'expires_at' => 'datetime',
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at !== null && $this->expires_at->isPast();
+    }
+}

--- a/app/Models/BannedIpAddress.php
+++ b/app/Models/BannedIpAddress.php
@@ -14,12 +14,12 @@ use Illuminate\Support\Carbon;
  * @property string      $ip_address
  * @property string|null $reason
  * @property Carbon|null $expires_at
- * @property int|null    $created_by
+ * @property int         $created_by
  *
  * @property Carbon $updated_at
  * @property Carbon $created_at
  *
- * @property User|null $createdBy
+ * @property User $createdBy
  *
  * @mixin Eloquent
  */

--- a/app/Providers/KeystoneGuruServiceProvider.php
+++ b/app/Providers/KeystoneGuruServiceProvider.php
@@ -45,6 +45,8 @@ use App\Service\AffixGroup\AffixGroupEaseTierService;
 use App\Service\AffixGroup\AffixGroupEaseTierServiceInterface;
 use App\Service\AffixGroup\ArchonApiService;
 use App\Service\AffixGroup\ArchonApiServiceInterface;
+use App\Service\BannedIpAddress\BannedIpAddressService;
+use App\Service\BannedIpAddress\BannedIpAddressServiceInterface;
 use App\Service\Cache\CacheService;
 use App\Service\Cache\CacheServiceInterface;
 use App\Service\Cache\DevCacheService;
@@ -246,6 +248,7 @@ class KeystoneGuruServiceProvider extends ServiceProvider
 
         // Depends on CacheService
         $this->app->bind(ReadOnlyModeServiceInterface::class, ReadOnlyModeService::class);
+        $this->app->bind(BannedIpAddressServiceInterface::class, BannedIpAddressService::class);
 
         // Depends on CacheService, CoordinatesService
         $this->app->bind(MDTMappingVersionServiceInterface::class, MDTMappingVersionService::class);

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -8,6 +8,7 @@ use App\Repositories\Database\AffixGroup\AffixGroupEaseTierPullRepository;
 use App\Repositories\Database\AffixGroup\AffixGroupEaseTierRepository;
 use App\Repositories\Database\AffixGroup\AffixGroupRepository;
 use App\Repositories\Database\AffixRepository;
+use App\Repositories\Database\BannedIpAddressRepository;
 use App\Repositories\Database\BrushlineRepository;
 use App\Repositories\Database\CacheModelRepository;
 use App\Repositories\Database\CharacterClassRepository;
@@ -120,6 +121,7 @@ use App\Repositories\Interfaces\AffixGroup\AffixGroupEaseTierPullRepositoryInter
 use App\Repositories\Interfaces\AffixGroup\AffixGroupEaseTierRepositoryInterface;
 use App\Repositories\Interfaces\AffixGroup\AffixGroupRepositoryInterface;
 use App\Repositories\Interfaces\AffixRepositoryInterface;
+use App\Repositories\Interfaces\BannedIpAddressRepositoryInterface;
 use App\Repositories\Interfaces\BrushlineRepositoryInterface;
 use App\Repositories\Interfaces\CacheModelRepositoryInterface;
 use App\Repositories\Interfaces\CharacterClassRepositoryInterface;
@@ -344,6 +346,7 @@ class RepositoryServiceProvider extends ServiceProvider
 
         // Root
         $this->app->bind(AffixRepositoryInterface::class, AffixRepository::class);
+        $this->app->bind(BannedIpAddressRepositoryInterface::class, BannedIpAddressRepository::class);
         $this->app->bind(BrushlineRepositoryInterface::class, BrushlineRepository::class);
         $this->app->bind(CacheModelRepositoryInterface::class, CacheModelRepository::class);
         $this->app->bind(CharacterClassRepositoryInterface::class, CharacterClassRepository::class);

--- a/app/Repositories/Database/BannedIpAddressRepository.php
+++ b/app/Repositories/Database/BannedIpAddressRepository.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Repositories\Database;
+
+use App\Models\BannedIpAddress;
+use App\Repositories\Interfaces\BannedIpAddressRepositoryInterface;
+
+class BannedIpAddressRepository extends DatabaseRepository implements BannedIpAddressRepositoryInterface
+{
+    public function __construct()
+    {
+        parent::__construct(BannedIpAddress::class);
+    }
+}

--- a/app/Repositories/Interfaces/BannedIpAddressRepositoryInterface.php
+++ b/app/Repositories/Interfaces/BannedIpAddressRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Repositories\Interfaces;
+
+use App\Models\BannedIpAddress;
+use App\Repositories\BaseRepositoryInterface;
+use Illuminate\Support\Collection;
+
+/**
+ * @method BannedIpAddress                  create(array<string, mixed> $attributes)
+ * @method BannedIpAddress|null             find(int $id, array<int, string>|string $columns = ['*'])
+ * @method BannedIpAddress                  findOrFail(int $id, array<int, string>|string $columns = ['*'])
+ * @method BannedIpAddress                  findOrNew(int $id, array<int, string>|string $columns = ['*'])
+ * @method bool                             save(BannedIpAddress $model)
+ * @method bool                             update(BannedIpAddress $model, array<string, mixed> $attributes = [], array<string, mixed> $options = [])
+ * @method bool                             delete(BannedIpAddress $model)
+ * @method Collection<int, BannedIpAddress> all()
+ * @method bool                             exists(array<int, string> $columns)
+ */
+interface BannedIpAddressRepositoryInterface extends BaseRepositoryInterface
+{
+}

--- a/app/Rules/BannedIpRangeRule.php
+++ b/app/Rules/BannedIpRangeRule.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Symfony\Component\HttpFoundation\IpUtils;
+
+/**
+ * Validates that a submitted value is a well-formed IP address or CIDR range, that the range isn't
+ * so broad it could ban swaths of unrelated visitors, and that it doesn't ban the requesting admin's
+ * own IP - which would lock them out of the admin panel that manages bans.
+ */
+class BannedIpRangeRule implements ValidationRule
+{
+    private const int MIN_IPV4_PREFIX_LENGTH = 24;
+    private const int MIN_IPV6_PREFIX_LENGTH = 64;
+
+    public function __construct(
+        /**
+         * The requesting admin's own resolved IP - used to prevent self-lockout.
+         */
+        public ?string $requesterIp,
+    ) {
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        [$ip, $prefixLength] = $this->parse((string)$value);
+
+        if ($ip === null) {
+            $fail(__('rules.banned_ip_range_rule.invalid'));
+
+            return;
+        }
+
+        $isIpv6          = str_contains($ip, ':');
+        $minPrefixLength = $isIpv6 ? self::MIN_IPV6_PREFIX_LENGTH : self::MIN_IPV4_PREFIX_LENGTH;
+
+        if ($prefixLength !== null && $prefixLength < $minPrefixLength) {
+            $fail(__('rules.banned_ip_range_rule.range_too_broad', ['min' => $minPrefixLength]));
+
+            return;
+        }
+
+        if ($this->requesterIp !== null && IpUtils::checkIp($this->requesterIp, (string)$value)) {
+            $fail(__('rules.banned_ip_range_rule.self_lockout'));
+        }
+    }
+
+    /**
+     * @return array{0: string|null, 1: int|null}
+     */
+    private function parse(string $value): array
+    {
+        if (!str_contains($value, '/')) {
+            return filter_var($value, FILTER_VALIDATE_IP) !== false ? [$value, null] : [null, null];
+        }
+
+        [$ip, $prefix] = explode('/', $value, 2);
+
+        if (!ctype_digit($prefix) || filter_var($ip, FILTER_VALIDATE_IP) === false) {
+            return [null, null];
+        }
+
+        $prefixLength    = (int)$prefix;
+        $maxPrefixLength = str_contains($ip, ':') ? 128 : 32;
+
+        if ($prefixLength > $maxPrefixLength) {
+            return [null, null];
+        }
+
+        return [$ip, $prefixLength];
+    }
+}

--- a/app/Service/BannedIpAddress/BannedIpAddressService.php
+++ b/app/Service/BannedIpAddress/BannedIpAddressService.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Service\BannedIpAddress;
+
+use App\Models\BannedIpAddress;
+use App\Repositories\Interfaces\BannedIpAddressRepositoryInterface;
+use App\Service\Cache\CacheServiceInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Symfony\Component\HttpFoundation\IpUtils;
+
+class BannedIpAddressService implements BannedIpAddressServiceInterface
+{
+    private const string CACHE_KEY = 'banned_ip_addresses';
+
+    public function __construct(
+        private readonly BannedIpAddressRepositoryInterface $bannedIpAddressRepository,
+        private readonly CacheServiceInterface              $cacheService,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function ban(string $ipAddress, ?string $reason, ?Carbon $expiresAt, ?int $createdBy): BannedIpAddress
+    {
+        $bannedIpAddress = $this->bannedIpAddressRepository->create([
+            'ip_address' => $ipAddress,
+            'reason'     => $reason,
+            'expires_at' => $expiresAt,
+            'created_by' => $createdBy,
+        ]);
+
+        $this->refreshCache();
+
+        return $bannedIpAddress;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unban(BannedIpAddress $bannedIpAddress): void
+    {
+        $this->bannedIpAddressRepository->delete($bannedIpAddress);
+
+        $this->refreshCache();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isBanned(string $ipAddress): bool
+    {
+        $entries = $this->cacheService->remember(self::CACHE_KEY, fn() => $this->buildCacheEntries(), '5 minutes');
+
+        // This is checked on every request by the global enforcement middleware, so a cache that
+        // misbehaves (returns something other than the array we wrote) must never crash the
+        // request - fall back to a direct, uncached read instead.
+        if (!is_array($entries)) {
+            $entries = $this->buildCacheEntries();
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry['expires_at'] !== null && Carbon::parse($entry['expires_at'])->isPast()) {
+                continue;
+            }
+
+            if (IpUtils::checkIp($ipAddress, $entry['ip_address'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function all(): Collection
+    {
+        return $this->bannedIpAddressRepository->all();
+    }
+
+    /**
+     * Recomputes the full ban list from the database and writes it straight into the cache, so
+     * ban/unban take effect immediately instead of waiting for the read-through TTL to expire.
+     */
+    private function refreshCache(): void
+    {
+        $this->cacheService->set(self::CACHE_KEY, $this->buildCacheEntries());
+    }
+
+    /**
+     * @return array<int, array{ip_address: string, expires_at: string|null}>
+     */
+    private function buildCacheEntries(): array
+    {
+        return $this->bannedIpAddressRepository->all()
+            ->map(static fn(BannedIpAddress $bannedIpAddress): array => [
+                'ip_address' => $bannedIpAddress->ip_address,
+                'expires_at' => $bannedIpAddress->expires_at?->toIso8601String(),
+            ])
+            ->values()
+            ->all();
+    }
+}

--- a/app/Service/BannedIpAddress/BannedIpAddressService.php
+++ b/app/Service/BannedIpAddress/BannedIpAddressService.php
@@ -22,7 +22,7 @@ class BannedIpAddressService implements BannedIpAddressServiceInterface
     /**
      * {@inheritDoc}
      */
-    public function ban(string $ipAddress, ?string $reason, ?Carbon $expiresAt, ?int $createdBy): BannedIpAddress
+    public function ban(string $ipAddress, ?string $reason, ?Carbon $expiresAt, int $createdBy): BannedIpAddress
     {
         $bannedIpAddress = $this->bannedIpAddressRepository->create([
             'ip_address' => $ipAddress,

--- a/app/Service/BannedIpAddress/BannedIpAddressServiceInterface.php
+++ b/app/Service/BannedIpAddress/BannedIpAddressServiceInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Service\BannedIpAddress;
+
+use App\Models\BannedIpAddress;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+interface BannedIpAddressServiceInterface
+{
+    /**
+     * Bans an IP address (or CIDR range) and refreshes the cached lookup used by the enforcement middleware.
+     */
+    public function ban(string $ipAddress, ?string $reason, ?Carbon $expiresAt, ?int $createdBy): BannedIpAddress;
+
+    /**
+     * Removes a ban and refreshes the cached lookup used by the enforcement middleware.
+     */
+    public function unban(BannedIpAddress $bannedIpAddress): void;
+
+    /**
+     * Whether the given IP address is currently banned - matches single IPs and CIDR ranges, and
+     * ignores bans whose expires_at has passed. Backed by a cached lookup so this is safe to call
+     * on every request.
+     */
+    public function isBanned(string $ipAddress): bool;
+
+    /**
+     * @return Collection<int, BannedIpAddress>
+     */
+    public function all(): Collection;
+}

--- a/app/Service/BannedIpAddress/BannedIpAddressServiceInterface.php
+++ b/app/Service/BannedIpAddress/BannedIpAddressServiceInterface.php
@@ -10,8 +10,10 @@ interface BannedIpAddressServiceInterface
 {
     /**
      * Bans an IP address (or CIDR range) and refreshes the cached lookup used by the enforcement middleware.
+     * $createdBy must always identify the admin who requested the ban - CLI incident response is
+     * expected to pass the ID of the admin performing it, not a system/null actor.
      */
-    public function ban(string $ipAddress, ?string $reason, ?Carbon $expiresAt, ?int $createdBy): BannedIpAddress;
+    public function ban(string $ipAddress, ?string $reason, ?Carbon $expiresAt, int $createdBy): BannedIpAddress;
 
     /**
      * Removes a ban and refreshes the cached lookup used by the enforcement middleware.

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use App\Http\Middleware\AddsTraceIdToContext;
 use App\Http\Middleware\Api\ApiAuthentication;
 use App\Http\Middleware\Api\ApiRole;
+use App\Http\Middleware\BlockBannedIpAddresses;
 use App\Http\Middleware\DebugBarMessageLogger;
 use App\Http\Middleware\DebugInfoContextLogger;
 use App\Http\Middleware\EnsureFeatureIsActive;
@@ -56,7 +57,10 @@ return Application::configure(basePath: dirname(__DIR__))
         // Prepend so every log line of the request - including those of other global middleware - carries the trace_id
         $middleware->prepend(AddsTraceIdToContext::class);
 
+        // Runs right after (the replaced) TrustProxies, so $request->ip() is already the real
+        // visitor IP resolved from CF-Connecting-IP - see BlockBannedIpAddresses for details.
         $middleware->append([
+            BlockBannedIpAddresses::class,
             ServerTimingMiddleware::class,
             CheckForMaintenanceMode::class,
             PoweredBySwoole::class,

--- a/database/factories/BannedIpAddressFactory.php
+++ b/database/factories/BannedIpAddressFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BannedIpAddress;
+use DateTimeInterface;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<BannedIpAddress>
+ */
+class BannedIpAddressFactory extends Factory
+{
+    protected $model = BannedIpAddress::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'ip_address' => $this->faker->ipv4(),
+            'reason'     => $this->faker->sentence(),
+            'expires_at' => null,
+            'created_by' => null,
+        ];
+    }
+
+    public function expired(): self
+    {
+        return $this->state(fn(array $attributes) => [
+            'expires_at' => now()->subDay(),
+        ]);
+    }
+
+    public function expiresAt(DateTimeInterface $expiresAt): self
+    {
+        return $this->state(fn(array $attributes) => [
+            'expires_at' => $expiresAt,
+        ]);
+    }
+}

--- a/database/factories/BannedIpAddressFactory.php
+++ b/database/factories/BannedIpAddressFactory.php
@@ -22,7 +22,7 @@ class BannedIpAddressFactory extends Factory
             'ip_address' => $this->faker->ipv4(),
             'reason'     => $this->faker->sentence(),
             'expires_at' => null,
-            'created_by' => null,
+            'created_by' => 1, // seeded admin user
         ];
     }
 

--- a/database/migrations/2026_07_16_093901_create_banned_ip_addresses_table.php
+++ b/database/migrations/2026_07_16_093901_create_banned_ip_addresses_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('banned_ip_addresses', function (Blueprint $table) {
+            $table->id();
+            $table->string('ip_address');
+            $table->string('reason')->nullable();
+            $table->dateTime('expires_at')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->timestamps();
+
+            $table->index(['ip_address']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('banned_ip_addresses');
+    }
+};

--- a/database/migrations/2026_07_16_093901_create_banned_ip_addresses_table.php
+++ b/database/migrations/2026_07_16_093901_create_banned_ip_addresses_table.php
@@ -15,7 +15,7 @@ return new class extends Migration {
             $table->string('ip_address');
             $table->string('reason')->nullable();
             $table->dateTime('expires_at')->nullable();
-            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('created_by');
             $table->timestamps();
 
             $table->index(['ip_address']);

--- a/lang/en_US/controller.php
+++ b/lang/en_US/controller.php
@@ -21,6 +21,8 @@ return [
             'combatlog_parse_failure_no_segments' => 'No combat log segments are available for this run.',
         ],
         'flash' => [
+            'banned_ip_address_added'                => 'IP address banned successfully',
+            'banned_ip_address_removed'              => 'Ban removed successfully',
             'message_banner_set_successfully'        => 'Message banner set successfully',
             'thumbnail_regenerate_result'            => 'Dispatched :success jobs for :total routes. :failed failed.',
             'combatlog_route_regenerate_result'      => 'Dispatched :count jobs',

--- a/lang/en_US/rules.php
+++ b/lang/en_US/rules.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'banned_ip_range_rule' => [
+        'invalid'         => 'This is not a valid IP address or CIDR range.',
+        'range_too_broad' => 'This range is too broad - the widest allowed range is /:min.',
+        'self_lockout'    => 'You cannot ban a range that includes your own IP address.',
+    ],
     'create_route_npc_chronological_rule' => [
         'message' => 'Npc(s) :npcs diedAt must be before engagedAt!',
     ],

--- a/lang/en_US/view_admin.php
+++ b/lang/en_US/view_admin.php
@@ -319,6 +319,27 @@ return [
         ],
     ],
     'tools' => [
+        'bannedipaddresses' => [
+            'list' => [
+                'title'              => 'Banned IP addresses',
+                'header'             => 'Banned IP addresses',
+                'description'        => 'Block visitors by IP address or CIDR range at the application layer. Bans are checked on every request before routing.',
+                'form_header'        => 'Ban an IP address',
+                'column_ip_address'  => 'IP address',
+                'column_reason'      => 'Reason',
+                'column_expires_at'  => 'Expires',
+                'column_created_by'  => 'Banned by',
+                'column_created_at'  => 'Banned at',
+                'column_actions'     => 'Actions',
+                'submit'             => 'Ban',
+                'remove'             => 'Remove',
+                'confirm_remove'     => 'Are you sure you want to remove this ban?',
+                'empty'              => 'No IP addresses are currently banned.',
+                'expires_never'      => 'Never',
+                'status_expired'     => 'Expired',
+                'created_by_unknown' => 'Unknown',
+            ],
+        ],
         'datadump' => [
             'viewexporteddungeondata' => [
                 'title'   => 'Exported!',
@@ -575,6 +596,9 @@ return [
             'subheader_artisan_commands'                              => 'Artisan Commands',
             'backfill_kill_zone_enemy_id'                             => 'Backfill kill zone enemy IDs',
             'backfill_kill_zone_enemy_id_description'                 => 'One-time backfill of enemy_id on kill_zone_enemies for records where it is NULL.',
+            'subheader_security'                                      => 'Security',
+            'manage_banned_ip_addresses'                              => 'Manage banned IP addresses',
+            'manage_banned_ip_addresses_description'                  => 'Block or unblock visitors by IP address or CIDR range at the application layer.',
             'subheader_actions'                                       => 'Actions',
             'drop_caches'                                             => 'Drop caches',
             'drop_caches_description'                                 => 'Clear all application caches immediately.',

--- a/resources/views/admin/tools/bannedipaddresses/list.blade.php
+++ b/resources/views/admin/tools/bannedipaddresses/list.blade.php
@@ -1,0 +1,111 @@
+<?php
+
+use App\Models\BannedIpAddress;
+use Illuminate\Support\Collection;
+
+/**
+ * @var Collection<int, BannedIpAddress> $bannedIpAddresses
+ */
+?>
+@extends('layouts.sitepage', ['showAds' => false, 'title' => __('view_admin.tools.bannedipaddresses.list.title')])
+
+@section('header-title', __('view_admin.tools.bannedipaddresses.list.header'))
+
+@section('content')
+    <p class="text-muted">{{ __('view_admin.tools.bannedipaddresses.list.description') }}</p>
+
+    <div class="card mb-4">
+        <div class="card-header">{{ __('view_admin.tools.bannedipaddresses.list.form_header') }}</div>
+        <div class="card-body">
+            <form method="POST" action="{{ route('admin.tools.bannedipaddresses.store') }}">
+                @csrf
+                <div class="row g-3 align-items-end">
+                    <div class="col-md-3">
+                        <label class="form-label" for="ip_address">{{ __('view_admin.tools.bannedipaddresses.list.column_ip_address') }}</label>
+                        <input type="text" class="form-control" id="ip_address" name="ip_address"
+                               value="{{ old('ip_address') }}" placeholder="1.2.3.4 or 1.2.3.0/24" required>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label" for="reason">{{ __('view_admin.tools.bannedipaddresses.list.column_reason') }}</label>
+                        <input type="text" class="form-control" id="reason" name="reason" value="{{ old('reason') }}">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label" for="expires_at">{{ __('view_admin.tools.bannedipaddresses.list.column_expires_at') }}</label>
+                        <input type="datetime-local" class="form-control" id="expires_at" name="expires_at" value="{{ old('expires_at') }}">
+                    </div>
+                    <div class="col-md-3">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-ban"></i> {{ __('view_admin.tools.bannedipaddresses.list.submit') }}
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    @if($bannedIpAddresses->isEmpty())
+        <div class="alert alert-success">
+            <i class="fas fa-check"></i> {{ __('view_admin.tools.bannedipaddresses.list.empty') }}
+        </div>
+    @else
+        <table class="table table-sm table-striped">
+            <thead>
+            <tr>
+                <th>{{ __('view_admin.tools.bannedipaddresses.list.column_ip_address') }}</th>
+                <th>{{ __('view_admin.tools.bannedipaddresses.list.column_reason') }}</th>
+                <th>{{ __('view_admin.tools.bannedipaddresses.list.column_expires_at') }}</th>
+                <th>{{ __('view_admin.tools.bannedipaddresses.list.column_created_by') }}</th>
+                <th>{{ __('view_admin.tools.bannedipaddresses.list.column_created_at') }}</th>
+                <th class="text-end">{{ __('view_admin.tools.bannedipaddresses.list.column_actions') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach($bannedIpAddresses as $bannedIpAddress)
+                <tr class="{{ $bannedIpAddress->isExpired() ? 'text-muted' : '' }}">
+                    <td><code>{{ $bannedIpAddress->ip_address }}</code></td>
+                    <td>{{ $bannedIpAddress->reason }}</td>
+                    <td>
+                        @if($bannedIpAddress->expires_at === null)
+                            {{ __('view_admin.tools.bannedipaddresses.list.expires_never') }}
+                        @elseif($bannedIpAddress->isExpired())
+                            <span class="badge text-bg-secondary rounded-pill">
+                                {{ __('view_admin.tools.bannedipaddresses.list.status_expired') }}
+                            </span>
+                        @else
+                            {{ $bannedIpAddress->expires_at }}
+                        @endif
+                    </td>
+                    <td>{{ $bannedIpAddress->createdBy?->name ?? __('view_admin.tools.bannedipaddresses.list.created_by_unknown') }}</td>
+                    <td>{{ $bannedIpAddress->created_at }}</td>
+                    <td class="text-end">
+                        <form method="POST"
+                              action="{{ route('admin.tools.bannedipaddresses.destroy', ['bannedIpAddress' => $bannedIpAddress->id]) }}"
+                              style="display: inline;"
+                              class="admin-bannedipaddress-delete-confirm">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-sm btn-danger">
+                                <i class="fas fa-trash"></i> {{ __('view_admin.tools.bannedipaddresses.list.remove') }}
+                            </button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    @endif
+@endsection
+
+@section('scripts')
+    @parent
+
+    <script type="text/javascript">
+        $(function () {
+            $('.admin-bannedipaddress-delete-confirm').on('submit', function (e) {
+                if (!confirm('{{ __('view_admin.tools.bannedipaddresses.list.confirm_remove') }}')) {
+                    e.preventDefault();
+                }
+            });
+        });
+    </script>
+@endsection

--- a/resources/views/admin/tools/list.blade.php
+++ b/resources/views/admin/tools/list.blade.php
@@ -253,6 +253,21 @@
             </div>
         </div>
 
+        {{-- Security --}}
+        <div class="col-md-6 col-lg-4 mb-4">
+            <div class="card h-100">
+                <div class="card-header">
+                    <i class="fas fa-user-shield"></i> {{ __('view_admin.tools.list.subheader_security') }}
+                </div>
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">
+                        <a href="{{ route('admin.tools.bannedipaddresses.view') }}">{{ __('view_admin.tools.list.manage_banned_ip_addresses') }}</a>
+                        <small class="text-muted d-block">{{ __('view_admin.tools.list.manage_banned_ip_addresses_description') }}</small>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
         {{-- Actions (destructive) --}}
         <div class="col-12 mb-4">
             <div class="card border-danger">

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@
 use App\Features\NpcCompendium;
 use App\Http\Controllers\Admin\AdminDungeonRouteController;
 use App\Http\Controllers\AdminTools\AdminToolsArtisanCommandsController;
+use App\Http\Controllers\AdminTools\AdminToolsBannedIpAddressController;
 use App\Http\Controllers\AdminTools\AdminToolsCombatLogController;
 use App\Http\Controllers\AdminTools\AdminToolsCombatLogCriteriaController;
 use App\Http\Controllers\AdminTools\AdminToolsCombatLogParseFailureController;
@@ -543,6 +544,11 @@ Route::middleware(['viewcachebuster', 'language', 'debugbarmessagelogger', 'read
                 Route::get('cache/drop', new AdminToolsController()->dropcache(...))->name('admin.tools.cache.drop');
                 Route::get('datadump/exportdungeondata', new AdminToolsDataDumpController()->exportdungeondata(...))->name('admin.tools.datadump.exportdungeondata');
                 Route::get('readonly/toggle', new AdminToolsController()->toggleReadOnlyMode(...))->name('admin.tools.readonly.toggle');
+
+                // Banned IP addresses
+                Route::get('bannedipaddresses', new AdminToolsBannedIpAddressController()->index(...))->name('admin.tools.bannedipaddresses.view');
+                Route::post('bannedipaddresses', new AdminToolsBannedIpAddressController()->store(...))->name('admin.tools.bannedipaddresses.store');
+                Route::delete('bannedipaddresses/{bannedIpAddress}', new AdminToolsBannedIpAddressController()->destroy(...))->name('admin.tools.bannedipaddresses.destroy');
             });
         });
     });

--- a/tests/Feature/App/Service/BannedIpAddress/BannedIpAddressServiceTest.php
+++ b/tests/Feature/App/Service/BannedIpAddress/BannedIpAddressServiceTest.php
@@ -39,7 +39,7 @@ final class BannedIpAddressServiceTest extends PublicTestCase
     public function ban_GivenIpAddress_PersistsIt(): void
     {
         // Act
-        $bannedIpAddress    = $this->service->ban('203.0.113.10', 'testing', null, null);
+        $bannedIpAddress    = $this->service->ban('203.0.113.10', 'testing', null, 1);
         $this->createdIds[] = $bannedIpAddress->id;
 
         // Assert

--- a/tests/Feature/App/Service/BannedIpAddress/BannedIpAddressServiceTest.php
+++ b/tests/Feature/App/Service/BannedIpAddress/BannedIpAddressServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\App\Service\BannedIpAddress;
+
+use App\Models\BannedIpAddress;
+use App\Service\BannedIpAddress\BannedIpAddressServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Service')]
+#[Group('BannedIpAddressService')]
+final class BannedIpAddressServiceTest extends PublicTestCase
+{
+    private BannedIpAddressServiceInterface $service;
+
+    /** @var array<int, int> */
+    private array $createdIds = [];
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = app(BannedIpAddressServiceInterface::class);
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        try {
+            BannedIpAddress::query()->whereIn('id', $this->createdIds)->delete();
+        } finally {
+            parent::tearDown();
+        }
+    }
+
+    #[Test]
+    public function ban_GivenIpAddress_PersistsIt(): void
+    {
+        // Act
+        $bannedIpAddress    = $this->service->ban('203.0.113.10', 'testing', null, null);
+        $this->createdIds[] = $bannedIpAddress->id;
+
+        // Assert
+        $this->assertDatabaseHas('banned_ip_addresses', [
+            'id'         => $bannedIpAddress->id,
+            'ip_address' => '203.0.113.10',
+            'reason'     => 'testing',
+        ]);
+    }
+
+    #[Test]
+    public function isBanned_GivenBannedSingleIp_ReturnsTrue(): void
+    {
+        // Arrange
+        $bannedIpAddress    = BannedIpAddress::factory()->create(['ip_address' => '203.0.113.11']);
+        $this->createdIds[] = $bannedIpAddress->id;
+
+        // Act + Assert
+        $this->assertTrue($this->service->isBanned('203.0.113.11'));
+    }
+
+    #[Test]
+    public function isBanned_GivenNonBannedIp_ReturnsFalse(): void
+    {
+        // Arrange
+        $bannedIpAddress    = BannedIpAddress::factory()->create(['ip_address' => '203.0.113.12']);
+        $this->createdIds[] = $bannedIpAddress->id;
+
+        // Act + Assert
+        $this->assertFalse($this->service->isBanned('203.0.113.99'));
+    }
+
+    #[Test]
+    public function isBanned_GivenIpWithinBannedCidrRange_ReturnsTrue(): void
+    {
+        // Arrange
+        $bannedIpAddress    = BannedIpAddress::factory()->create(['ip_address' => '203.0.113.0/24']);
+        $this->createdIds[] = $bannedIpAddress->id;
+
+        // Act + Assert
+        $this->assertTrue($this->service->isBanned('203.0.113.200'));
+        $this->assertFalse($this->service->isBanned('203.0.114.1'));
+    }
+
+    #[Test]
+    public function isBanned_GivenExpiredBan_ReturnsFalse(): void
+    {
+        // Arrange
+        $bannedIpAddress    = BannedIpAddress::factory()->expired()->create(['ip_address' => '203.0.113.13']);
+        $this->createdIds[] = $bannedIpAddress->id;
+
+        // Act + Assert
+        $this->assertFalse($this->service->isBanned('203.0.113.13'));
+    }
+
+    #[Test]
+    public function unban_GivenExistingBan_RemovesIt(): void
+    {
+        // Arrange
+        $bannedIpAddress = BannedIpAddress::factory()->create(['ip_address' => '203.0.113.14']);
+        self::assertTrue($this->service->isBanned('203.0.113.14'));
+
+        // Act
+        $this->service->unban($bannedIpAddress);
+
+        // Assert
+        $this->assertFalse($this->service->isBanned('203.0.113.14'));
+        $this->assertDatabaseMissing('banned_ip_addresses', ['id' => $bannedIpAddress->id]);
+    }
+}

--- a/tests/Feature/Console/Commands/BannedIpAddress/BanTest.php
+++ b/tests/Feature/Console/Commands/BannedIpAddress/BanTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Console\Commands\BannedIpAddress;
+
+use App\Console\Commands\BannedIpAddress\Ban;
+use App\Models\BannedIpAddress;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Console')]
+#[Group('BannedIpAddress')]
+final class BanTest extends PublicTestCase
+{
+    #[\Override]
+    protected function tearDown(): void
+    {
+        try {
+            BannedIpAddress::query()->where('ip_address', '203.0.113.40')->delete();
+        } finally {
+            parent::tearDown();
+        }
+    }
+
+    #[Test]
+    public function handle_givenIpAddress_createsBan(): void
+    {
+        // Act
+        $this->artisan(Ban::class, [
+            'ipAddress' => '203.0.113.40',
+            '--reason'  => 'CLI incident response',
+        ])->assertSuccessful();
+
+        // Assert
+        $this->assertDatabaseHas('banned_ip_addresses', [
+            'ip_address' => '203.0.113.40',
+            'reason'     => 'CLI incident response',
+            'created_by' => null,
+        ]);
+    }
+}

--- a/tests/Feature/Console/Commands/BannedIpAddress/BanTest.php
+++ b/tests/Feature/Console/Commands/BannedIpAddress/BanTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Console\Commands\BannedIpAddress;
 
 use App\Console\Commands\BannedIpAddress\Ban;
 use App\Models\BannedIpAddress;
+use App\Models\User;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
@@ -12,22 +13,25 @@ use Tests\TestCases\PublicTestCase;
 #[Group('BannedIpAddress')]
 final class BanTest extends PublicTestCase
 {
+    private const int ADMIN_USER_ID = 1;
+
     #[\Override]
     protected function tearDown(): void
     {
         try {
-            BannedIpAddress::query()->where('ip_address', '203.0.113.40')->delete();
+            BannedIpAddress::query()->whereIn('ip_address', ['203.0.113.40', '203.0.113.43'])->delete();
         } finally {
             parent::tearDown();
         }
     }
 
     #[Test]
-    public function handle_givenIpAddress_createsBan(): void
+    public function handle_givenIpAddressAndAdminId_createsBanAttributedToThatAdmin(): void
     {
         // Act
         $this->artisan(Ban::class, [
             'ipAddress' => '203.0.113.40',
+            'adminId'   => self::ADMIN_USER_ID,
             '--reason'  => 'CLI incident response',
         ])->assertSuccessful();
 
@@ -35,7 +39,40 @@ final class BanTest extends PublicTestCase
         $this->assertDatabaseHas('banned_ip_addresses', [
             'ip_address' => '203.0.113.40',
             'reason'     => 'CLI incident response',
-            'created_by' => null,
+            'created_by' => self::ADMIN_USER_ID,
         ]);
+    }
+
+    #[Test]
+    public function handle_givenNonAdminUserId_failsWithoutCreatingBan(): void
+    {
+        // Arrange
+        $nonAdmin = User::factory()->create();
+
+        try {
+            // Act
+            $this->artisan(Ban::class, [
+                'ipAddress' => '203.0.113.43',
+                'adminId'   => $nonAdmin->id,
+            ])->assertFailed();
+
+            // Assert
+            $this->assertDatabaseMissing('banned_ip_addresses', ['ip_address' => '203.0.113.43']);
+        } finally {
+            $nonAdmin->delete();
+        }
+    }
+
+    #[Test]
+    public function handle_givenNonExistentAdminId_failsWithoutCreatingBan(): void
+    {
+        // Act
+        $this->artisan(Ban::class, [
+            'ipAddress' => '203.0.113.43',
+            'adminId'   => 999999999,
+        ])->assertFailed();
+
+        // Assert
+        $this->assertDatabaseMissing('banned_ip_addresses', ['ip_address' => '203.0.113.43']);
     }
 }

--- a/tests/Feature/Console/Commands/BannedIpAddress/UnbanTest.php
+++ b/tests/Feature/Console/Commands/BannedIpAddress/UnbanTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Console\Commands\BannedIpAddress;
+
+use App\Console\Commands\BannedIpAddress\Unban;
+use App\Models\BannedIpAddress;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Console')]
+#[Group('BannedIpAddress')]
+final class UnbanTest extends PublicTestCase
+{
+    #[Test]
+    public function handle_givenExistingBan_removesIt(): void
+    {
+        // Arrange
+        $bannedIpAddress = BannedIpAddress::factory()->create(['ip_address' => '203.0.113.41']);
+
+        // Act
+        $this->artisan(Unban::class, ['ipAddress' => '203.0.113.41'])->assertSuccessful();
+
+        // Assert
+        $this->assertDatabaseMissing('banned_ip_addresses', ['id' => $bannedIpAddress->id]);
+    }
+
+    #[Test]
+    public function handle_givenIpAddressNotBanned_returnsFailureWithoutError(): void
+    {
+        // Act + Assert
+        $this->artisan(Unban::class, ['ipAddress' => '203.0.113.42'])->assertFailed();
+    }
+}

--- a/tests/Feature/Controller/AdminTools/AdminToolsBannedIpAddressControllerTest.php
+++ b/tests/Feature/Controller/AdminTools/AdminToolsBannedIpAddressControllerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature\Controller\AdminTools;
+
+use App\Models\BannedIpAddress;
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Controller')]
+#[Group('AdminTools')]
+final class AdminToolsBannedIpAddressControllerTest extends PublicTestCase
+{
+    private const int ADMIN_USER_ID     = 1;
+    private const int NON_ADMIN_USER_ID = 3;
+
+    /** @var array<int, int> */
+    private array $createdIds = [];
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        try {
+            BannedIpAddress::query()->whereIn('id', $this->createdIds)->delete();
+        } finally {
+            parent::tearDown();
+        }
+    }
+
+    #[Test]
+    public function index_givenAdmin_returnsOk(): void
+    {
+        // Arrange
+        $this->be(User::findOrFail(self::ADMIN_USER_ID));
+        $bannedIpAddress = BannedIpAddress::factory()->create([
+            'ip_address' => '203.0.113.32',
+            'reason'     => 'Rendered by test',
+        ]);
+        $this->createdIds[] = $bannedIpAddress->id;
+
+        // Act
+        $response = $this->get(route('admin.tools.bannedipaddresses.view'));
+
+        // Assert - proves the table actually renders the ban, not just a bare 200
+        $response->assertOk();
+        $response->assertSee('203.0.113.32');
+        $response->assertSee('Rendered by test');
+        $response->assertSee(route('admin.tools.bannedipaddresses.store'), false);
+    }
+
+    #[Test]
+    public function index_givenNonAdmin_returnsForbidden(): void
+    {
+        // Arrange
+        $this->be(User::findOrFail(self::NON_ADMIN_USER_ID));
+
+        // Act
+        $response = $this->get(route('admin.tools.bannedipaddresses.view'));
+
+        // Assert
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function store_givenValidIpAddress_createsBanAndRedirects(): void
+    {
+        // Arrange
+        $this->be(User::findOrFail(self::ADMIN_USER_ID));
+
+        // Act
+        $response = $this->post(route('admin.tools.bannedipaddresses.store'), [
+            'ip_address' => '203.0.113.30',
+            'reason'     => 'Abuse',
+        ]);
+
+        // Assert
+        $response->assertRedirect(route('admin.tools.bannedipaddresses.view'));
+        $this->assertDatabaseHas('banned_ip_addresses', [
+            'ip_address' => '203.0.113.30',
+            'reason'     => 'Abuse',
+            'created_by' => self::ADMIN_USER_ID,
+        ]);
+
+        $created            = BannedIpAddress::query()->where('ip_address', '203.0.113.30')->firstOrFail();
+        $this->createdIds[] = $created->id;
+    }
+
+    #[Test]
+    public function store_givenOverlyBroadRange_returnsValidationError(): void
+    {
+        // Arrange
+        $this->be(User::findOrFail(self::ADMIN_USER_ID));
+
+        // Act
+        $response = $this->post(route('admin.tools.bannedipaddresses.store'), [
+            'ip_address' => '10.0.0.0/8',
+        ]);
+
+        // Assert
+        $response->assertSessionHasErrors('ip_address');
+        $this->assertDatabaseMissing('banned_ip_addresses', ['ip_address' => '10.0.0.0/8']);
+    }
+
+    #[Test]
+    public function store_givenRequestersOwnIp_returnsValidationError(): void
+    {
+        // Arrange
+        $this->be(User::findOrFail(self::ADMIN_USER_ID));
+
+        // Act
+        $response = $this->withServerVariables(['REMOTE_ADDR' => '198.51.100.77'])
+            ->post(route('admin.tools.bannedipaddresses.store'), [
+                'ip_address' => '198.51.100.77',
+            ]);
+
+        // Assert
+        $response->assertSessionHasErrors('ip_address');
+        $this->assertDatabaseMissing('banned_ip_addresses', ['ip_address' => '198.51.100.77']);
+    }
+
+    #[Test]
+    public function destroy_givenExistingBan_removesItAndRedirects(): void
+    {
+        // Arrange
+        $this->be(User::findOrFail(self::ADMIN_USER_ID));
+        $bannedIpAddress = BannedIpAddress::factory()->create(['ip_address' => '203.0.113.31']);
+
+        // Act
+        $response = $this->delete(route('admin.tools.bannedipaddresses.destroy', ['bannedIpAddress' => $bannedIpAddress->id]));
+
+        // Assert
+        $response->assertRedirect(route('admin.tools.bannedipaddresses.view'));
+        $this->assertDatabaseMissing('banned_ip_addresses', ['id' => $bannedIpAddress->id]);
+    }
+}

--- a/tests/Feature/Http/BlockBannedIpAddressesTest.php
+++ b/tests/Feature/Http/BlockBannedIpAddressesTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use App\Models\BannedIpAddress;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Middleware')]
+#[Group('BlockBannedIpAddresses')]
+final class BlockBannedIpAddressesTest extends PublicTestCase
+{
+    #[Test]
+    public function get_GivenRequestFromBannedIp_ReturnsForbiddenWithoutRenderingView(): void
+    {
+        // Arrange
+        $bannedIpAddress = BannedIpAddress::factory()->create(['ip_address' => '203.0.113.20']);
+
+        try {
+            // Act
+            $response = $this->withServerVariables(['REMOTE_ADDR' => '203.0.113.20'])->get(route('home'));
+
+            // Assert - short-circuited by the middleware before routing, so no view was rendered
+            $response->assertStatus(403);
+            self::assertSame('Forbidden', $response->getContent());
+        } finally {
+            $bannedIpAddress->delete();
+        }
+    }
+
+    #[Test]
+    public function get_GivenRequestFromNonBannedIp_PassesThrough(): void
+    {
+        // Arrange
+        $bannedIpAddress = BannedIpAddress::factory()->create(['ip_address' => '203.0.113.21']);
+
+        try {
+            // Act
+            $response = $this->withServerVariables(['REMOTE_ADDR' => '198.51.100.30'])->get(route('home'));
+
+            // Assert
+            $response->assertOk();
+        } finally {
+            $bannedIpAddress->delete();
+        }
+    }
+
+    #[Test]
+    public function get_GivenRequestFromIpWithinBannedCidrRange_ReturnsForbidden(): void
+    {
+        // Arrange
+        $bannedIpAddress = BannedIpAddress::factory()->create(['ip_address' => '203.0.113.0/24']);
+
+        try {
+            // Act
+            $response = $this->withServerVariables(['REMOTE_ADDR' => '203.0.113.250'])->get(route('home'));
+
+            // Assert
+            $response->assertStatus(403);
+        } finally {
+            $bannedIpAddress->delete();
+        }
+    }
+
+    #[Test]
+    public function get_GivenRequestFromIpWithExpiredBan_PassesThrough(): void
+    {
+        // Arrange
+        $bannedIpAddress = BannedIpAddress::factory()->expired()->create(['ip_address' => '203.0.113.22']);
+
+        try {
+            // Act
+            $response = $this->withServerVariables(['REMOTE_ADDR' => '203.0.113.22'])->get(route('home'));
+
+            // Assert
+            $response->assertOk();
+        } finally {
+            $bannedIpAddress->delete();
+        }
+    }
+}

--- a/tests/Unit/App/Http/Middleware/BlockBannedIpAddressesTest.php
+++ b/tests/Unit/App/Http/Middleware/BlockBannedIpAddressesTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Unit\App\Http\Middleware;
+
+use App\Http\Middleware\BlockBannedIpAddresses;
+use App\Service\BannedIpAddress\BannedIpAddressServiceInterface;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Exception;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Middleware')]
+#[Group('BlockBannedIpAddresses')]
+class BlockBannedIpAddressesTest extends PublicTestCase
+{
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_GivenBannedIp_ReturnsForbiddenWithoutCallingNext(): void
+    {
+        // Arrange
+        $bannedIpAddressService = $this->createMockPublic(BannedIpAddressServiceInterface::class);
+        $bannedIpAddressService->expects($this->once())
+            ->method('isBanned')
+            ->with('203.0.113.1')
+            ->willReturn(true);
+
+        $middleware = new BlockBannedIpAddresses($bannedIpAddressService);
+        $request    = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '203.0.113.1']);
+
+        // Act
+        $response = $middleware->handle($request, function () {
+            self::fail('$next should not be called for a banned IP');
+        });
+
+        // Assert
+        self::assertSame(403, $response->getStatusCode());
+        self::assertSame('Forbidden', $response->getContent());
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_GivenBannedIpAjaxRequest_ReturnsForbiddenJson(): void
+    {
+        // Arrange
+        $bannedIpAddressService = $this->createMockPublic(BannedIpAddressServiceInterface::class);
+        $bannedIpAddressService->method('isBanned')->willReturn(true);
+
+        $middleware = new BlockBannedIpAddresses($bannedIpAddressService);
+        $request    = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '203.0.113.1']);
+        $request->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        // Act
+        $response = $middleware->handle($request, function () {
+            self::fail('$next should not be called for a banned IP');
+        });
+
+        // Assert
+        self::assertSame(403, $response->getStatusCode());
+        self::assertJson((string)$response->getContent());
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_GivenNonBannedIp_CallsNext(): void
+    {
+        // Arrange
+        $bannedIpAddressService = $this->createMockPublic(BannedIpAddressServiceInterface::class);
+        $bannedIpAddressService->method('isBanned')->willReturn(false);
+
+        $middleware = new BlockBannedIpAddresses($bannedIpAddressService);
+        $request    = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '198.51.100.1']);
+
+        $expectedResponse = new Response('OK');
+
+        // Act
+        $response = $middleware->handle($request, static fn() => $expectedResponse);
+
+        // Assert
+        self::assertSame($expectedResponse, $response);
+    }
+}


### PR DESCRIPTION
:robot: Closes #3564

## Summary
- `banned_ip_addresses` table + `BannedIpAddress` model + repository (interface/impl/binding), following project convention.
- `BlockBannedIpAddresses` global middleware, registered right after `TrustProxies` in `bootstrap/app.php` so `$request->ip()` is already the real visitor IP resolved from `CF-Connecting-IP`. Short-circuits with a plain `403` (no view render) before routing.
- `BannedIpAddressService`: write-through cache (`Cache`-backed via the existing `CacheServiceInterface`) refreshed on every ban/add - `isBanned()` reads through a 5-minute TTL cache, checks CIDR ranges via Symfony's `IpUtils::checkIp`, and skips expired bans in-memory so temporary bans self-heal without waiting on the TTL. Defensively falls back to a direct DB read if the cache ever returns something unusable, since this runs on every request and must never crash the site.
- Admin CRUD page under Admin > Tools > Security to list/add/remove bans (`admin.tools.bannedipaddresses.*`).
- `bannedipaddress:ban` / `bannedipaddress:unban` Artisan commands for CLI incident response.
- Validation (`BannedIpRangeRule`): rejects malformed IP/CIDR input, rejects ranges wider than **/24 (IPv4) or /64 (IPv6)**, and blocks an admin from banning their own current IP (self-lockout prevention). **Note:** this cap only applies to the admin UI - the `bannedipaddress:ban` CLI command is intentionally unrestricted, so a wider emergency range ban (e.g. during a scripted probing episode) is still possible via CLI/incident response. The `/24` and `/64` cap constants live at the top of `app/Rules/BannedIpRangeRule.php` if they need tuning.

## Test plan
- [x] `composer run analyse` clean
- [x] `composer run fix` clean (only touched intended files)
- [x] New tests (22): service (cache/CIDR/expiry), middleware (unit + full HTTP short-circuit through the real middleware stack), admin controller (auth gate, render, validation, add/remove), artisan commands
- [x] Full `Controller`, `Middleware`, and `API` test groups (523 tests) pass with the new global middleware in place
