### PR TITLE
#3570 Fix double slash in compiled asset URLs

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build assets
         # NOTE: pass flags *after* `--` so they reach your npm script
         env:
-          ASSETS_BASE_URL: https://assets.keystone.guru/
+          ASSETS_BASE_URL: https://assets.keystone.guru
         run: npm --output_version=${{ github.ref_name }} run production
 
       - name: Configure AWS (OIDC)

--- a/scripts/build/sass.mjs
+++ b/scripts/build/sass.mjs
@@ -29,6 +29,20 @@ const sassEntries = [
 ];
 
 /**
+ * Normalizes the CDN base injected as `$asset-url`, stripping any trailing slashes. The
+ * stylesheets already write `url('#{$asset-url}/images/...')`, supplying their own slash, so a
+ * base with a trailing slash (as the release workflow env once carried) produced `guru//images`.
+ * The old webpack production build hid this because cssnano's normalize-url collapsed the `//`;
+ * esbuild — the current minifier — does not, so the double slash reached shipped CSS (#3570).
+ *
+ * @param {string|undefined} base
+ * @returns {string}
+ */
+export function normalizeAssetBaseUrl(base) {
+    return (base ?? '').replace(/\/+$/, '');
+}
+
+/**
  * @param {string} rootDir
  * @param {string} version
  * @param {boolean} production
@@ -42,7 +56,7 @@ export function buildSassBundles(rootDir, version, production) {
     for (const [entry, outName] of sassEntries) {
         const entryPath = path.join(rootDir, entry);
         // Same injection sass-loader's additionalData used to do (CDN base for the sprite urls)
-        const source = `$asset-url: "${process.env.ASSETS_BASE_URL}";\n`
+        const source = `$asset-url: "${normalizeAssetBaseUrl(process.env.ASSETS_BASE_URL)}";\n`
             + rewritePlainCssImports(fs.readFileSync(entryPath, 'utf8'));
 
         const result = sass.compileString(source, {

--- a/scripts/build/sass.mjs
+++ b/scripts/build/sass.mjs
@@ -29,17 +29,17 @@ const sassEntries = [
 ];
 
 /**
- * Normalizes the CDN base injected as `$asset-url`, stripping any trailing slashes. The
- * stylesheets already write `url('#{$asset-url}/images/...')`, supplying their own slash, so a
- * base with a trailing slash (as the release workflow env once carried) produced `guru//images`.
- * The old webpack production build hid this because cssnano's normalize-url collapsed the `//`;
- * esbuild — the current minifier — does not, so the double slash reached shipped CSS (#3570).
+ * Strips any trailing slashes from a url. The stylesheets write `url('#{$asset-url}/images/...')`,
+ * supplying their own slash, so a base with a trailing slash (as the release workflow env once
+ * carried) produced `guru//images`. The old webpack production build hid this because cssnano's
+ * normalize-url collapsed the `//`; esbuild — the current minifier — does not, so the double slash
+ * reached shipped CSS (#3570).
  *
- * @param {string|undefined} base
+ * @param {string|undefined} url
  * @returns {string}
  */
-export function normalizeAssetBaseUrl(base) {
-    return (base ?? '').replace(/\/+$/, '');
+export function normalizeUrl(url) {
+    return (url ?? '').replace(/\/+$/, '');
 }
 
 /**
@@ -56,7 +56,7 @@ export function buildSassBundles(rootDir, version, production) {
     for (const [entry, outName] of sassEntries) {
         const entryPath = path.join(rootDir, entry);
         // Same injection sass-loader's additionalData used to do (CDN base for the sprite urls)
-        const source = `$asset-url: "${normalizeAssetBaseUrl(process.env.ASSETS_BASE_URL)}";\n`
+        const source = `$asset-url: "${normalizeUrl(process.env.ASSETS_BASE_URL)}";\n`
             + rewritePlainCssImports(fs.readFileSync(entryPath, 'utf8'));
 
         const result = sass.compileString(source, {

--- a/scripts/build/sass.test.mjs
+++ b/scripts/build/sass.test.mjs
@@ -2,25 +2,25 @@
 import path from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {describe, expect, it} from 'vitest';
-import {createSassImporter, hoistPlainCssImports, normalizeAssetBaseUrl, rewritePlainCssImports, scopeThemeRootSelectors} from './sass.mjs';
+import {createSassImporter, hoistPlainCssImports, normalizeUrl, rewritePlainCssImports, scopeThemeRootSelectors} from './sass.mjs';
 
 const rootDir = path.resolve(import.meta.dirname, '..', '..');
 
-describe('normalizeAssetBaseUrl', () => {
-    it('normalizeAssetBaseUrl_givenTrailingSlash_stripsIt', () => {
-        expect(normalizeAssetBaseUrl('https://assets.keystone.guru/')).toBe('https://assets.keystone.guru');
+describe('normalizeUrl', () => {
+    it('normalizeUrl_givenTrailingSlash_stripsIt', () => {
+        expect(normalizeUrl('https://assets.keystone.guru/')).toBe('https://assets.keystone.guru');
     });
 
-    it('normalizeAssetBaseUrl_givenMultipleTrailingSlashes_stripsThemAll', () => {
-        expect(normalizeAssetBaseUrl('https://assets.keystone.guru///')).toBe('https://assets.keystone.guru');
+    it('normalizeUrl_givenMultipleTrailingSlashes_stripsThemAll', () => {
+        expect(normalizeUrl('https://assets.keystone.guru///')).toBe('https://assets.keystone.guru');
     });
 
-    it('normalizeAssetBaseUrl_givenNoTrailingSlash_leavesItUnchanged', () => {
-        expect(normalizeAssetBaseUrl('https://assets.keystone.guru')).toBe('https://assets.keystone.guru');
+    it('normalizeUrl_givenNoTrailingSlash_leavesItUnchanged', () => {
+        expect(normalizeUrl('https://assets.keystone.guru')).toBe('https://assets.keystone.guru');
     });
 
-    it('normalizeAssetBaseUrl_givenUndefined_returnsEmptyString', () => {
-        expect(normalizeAssetBaseUrl(undefined)).toBe('');
+    it('normalizeUrl_givenUndefined_returnsEmptyString', () => {
+        expect(normalizeUrl(undefined)).toBe('');
     });
 });
 

--- a/scripts/build/sass.test.mjs
+++ b/scripts/build/sass.test.mjs
@@ -2,9 +2,27 @@
 import path from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {describe, expect, it} from 'vitest';
-import {createSassImporter, hoistPlainCssImports, rewritePlainCssImports, scopeThemeRootSelectors} from './sass.mjs';
+import {createSassImporter, hoistPlainCssImports, normalizeAssetBaseUrl, rewritePlainCssImports, scopeThemeRootSelectors} from './sass.mjs';
 
 const rootDir = path.resolve(import.meta.dirname, '..', '..');
+
+describe('normalizeAssetBaseUrl', () => {
+    it('normalizeAssetBaseUrl_givenTrailingSlash_stripsIt', () => {
+        expect(normalizeAssetBaseUrl('https://assets.keystone.guru/')).toBe('https://assets.keystone.guru');
+    });
+
+    it('normalizeAssetBaseUrl_givenMultipleTrailingSlashes_stripsThemAll', () => {
+        expect(normalizeAssetBaseUrl('https://assets.keystone.guru///')).toBe('https://assets.keystone.guru');
+    });
+
+    it('normalizeAssetBaseUrl_givenNoTrailingSlash_leavesItUnchanged', () => {
+        expect(normalizeAssetBaseUrl('https://assets.keystone.guru')).toBe('https://assets.keystone.guru');
+    });
+
+    it('normalizeAssetBaseUrl_givenUndefined_returnsEmptyString', () => {
+        expect(normalizeAssetBaseUrl(undefined)).toBe('');
+    });
+});
 
 describe('rewritePlainCssImports', () => {
     it('rewritePlainCssImports_givenCssExtensionImport_stripsTheExtension', () => {


### PR DESCRIPTION
:robot: Closes #3570

### Problem

v15.5.0's compiled CSS references sprites with a double slash, breaking them on production:

```
background-image: url(https://assets.keystone.guru//images/affixes/affixes-midnight-s1.png)
```

### Root cause

- `.github/workflows/release-deploy.yml` injected `ASSETS_BASE_URL: https://assets.keystone.guru/` **with a trailing slash**, while every other definition (`.env.example`, `js-tests.yml`, prod runtime) has none. The SCSS writes `url('#{$asset-url}/images/...')`, already supplying the slash → `//`.
- The trailing slash is **not new** (present since #3320). It was masked because the old webpack production build ran **cssnano** (`postcss-normalize-url` collapses `//` → `/`). After the webpack removal (#3449), the new `scripts/build/sass.mjs` pipeline minifies with **esbuild**, which does no URL normalization — so the double slash now leaks into shipped CSS.

Reproduced locally: with a trailing slash esbuild emits `guru//images/…`; without it, the correct single-slash form.

### Fix

- Drop the trailing slash in `release-deploy.yml`.
- Normalize `ASSETS_BASE_URL` in `sass.mjs` (`normalizeAssetBaseUrl`, strips trailing slashes) so a stray slash can never reintroduce the bug — esbuild won't catch it.

### Verification

- New unit tests for `normalizeAssetBaseUrl`; full `sass.test.mjs` suite green (19 passed).
- Ran `buildSassBundles` in production mode with the worst-case trailing-slash env: compiled bundle now emits `url(https://assets.keystone.guru/images/...)` with **zero** double slashes.

### Note

v15.5.0's compiled CSS is immutable on S3; this fix takes effect on the **next release**. It cannot be hotfixed (compiled CSS is baked into release assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArakgH1TXrqehHM3QECW9w
