### PR TITLE
#3568 Optimize DungeonRoute::dropCaches() with a per-route Redis hash

### DIFF
--- a/app/Models/DungeonRoute/DungeonRoute.php
+++ b/app/Models/DungeonRoute/DungeonRoute.php
@@ -45,6 +45,7 @@ use App\Models\Traits\Reportable;
 use App\Models\Traits\SerializesDates;
 use App\Models\Traits\Taggable;
 use App\Models\User;
+use App\Service\Cache\CacheServiceInterface;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use App\Service\Expansion\ExpansionServiceInterface;
 use App\Service\Season\SeasonAffixGroupServiceInterface;
@@ -66,11 +67,9 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Override;
-use Psr\SimpleCache\InvalidArgumentException;
 
 /**
  * @property int                  $id
@@ -1363,47 +1362,27 @@ class DungeonRoute extends Model implements TracksPageViewInterface
 
     /**
      * Drops any caches associated with this dungeon route.
+     *
+     * All card variants of a route live as fields in a single Redis hash, so every variant is dropped in one
+     * bounded operation regardless of how many orientation/locale/flag combinations exist.
      */
     public static function dropCaches(int $dungeonRouteId): void
     {
-        try {
-            // This can be better - but it's fine if you're using it to drop caches for 1 route.
-            $orientations = [
-                'vertical',
-                'horizontal',
-                'horizontal_row',
-            ];
-            $locales     = language()->allowed();
-            $showAffixes = [
-                0,
-                1,
-            ];
-            $showDungeon = [
-                0,
-                1,
-            ];
-            $isAdmin = [
-                0,
-                1,
-            ];
-
-            foreach ($orientations as $orientation) {
-                foreach ($locales as $code => $name) {
-                    foreach ($showAffixes as $showAffix) {
-                        foreach ($showDungeon as $showDungeonImage) {
-                            foreach ($isAdmin as $admin) {
-                                Cache::delete(self::getCardCacheKey($dungeonRouteId, $orientation, $code, $showAffix, $showDungeonImage, $admin));
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (InvalidArgumentException) {
-        }
+        resolve(CacheServiceInterface::class)->dropHashCache(self::getCardCacheKey($dungeonRouteId));
     }
 
-    public static function getCardCacheKey(
-        int    $dungeonRouteId,
+    /**
+     * The Redis hash key holding every cached card variant of a route.
+     */
+    public static function getCardCacheKey(int $dungeonRouteId): string
+    {
+        return sprintf('dungeonroute_card:%d', $dungeonRouteId);
+    }
+
+    /**
+     * The field within the card cache hash identifying a single card variant.
+     */
+    public static function getCardCacheField(
         string $orientation,
         string $locale,
         int    $showAffixes,
@@ -1411,13 +1390,12 @@ class DungeonRoute extends Model implements TracksPageViewInterface
         int    $isAdmin,
     ): string {
         return sprintf(
-            'view:dungeonroute_card:%s:%s_%d_%d_%d_%d',
+            '%s:%s_%d_%d_%d',
             $orientation,
             $locale,
             $showAffixes,
             $showDungeonImage,
             $isAdmin,
-            $dungeonRouteId,
         );
     }
 

--- a/app/Service/Cache/CacheService.php
+++ b/app/Service/Cache/CacheService.php
@@ -6,6 +6,7 @@ use App\Service\Cache\Logging\CacheServiceLoggingInterface;
 use App\Service\Cache\Redis\RedisServiceInterface;
 use Closure;
 use DateInterval;
+use DateTimeImmutable;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Redis\Connections\Connection;
 use Illuminate\Support\Facades\Cache;
@@ -30,6 +31,33 @@ class CacheService implements CacheServiceInterface
         $cacheConfig = config('keystoneguru.cache');
 
         return isset($cacheConfig[$key]) ? DateInterval::createFromDateString($cacheConfig[$key]['ttl']) : null;
+    }
+
+    /**
+     * Converts a TTL - an int of seconds, a '1 hour'-style string, or a DateInterval - into a number of seconds
+     * suitable for a Redis EXPIRE. Returns null when no TTL is given (the key should not expire).
+     */
+    private function ttlToSeconds(mixed $ttl): ?int
+    {
+        if ($ttl === null) {
+            return null;
+        }
+
+        if (is_int($ttl)) {
+            return $ttl;
+        }
+
+        if (is_string($ttl)) {
+            $ttl = DateInterval::createFromDateString($ttl);
+        }
+
+        if ($ttl instanceof DateInterval) {
+            $reference = new DateTimeImmutable();
+
+            return $reference->add($ttl)->getTimestamp() - $reference->getTimestamp();
+        }
+
+        return null;
     }
 
     public function isCacheEnabled(): bool
@@ -128,6 +156,58 @@ class CacheService implements CacheServiceInterface
         });
     }
 
+    /**
+     * @param  Closure|mixed $value
+     * @return mixed
+     */
+    public function rememberInHash(string $hashKey, string $field, mixed $value, mixed $ttl = null): mixed
+    {
+        // Just like remember(), do not populate the model cache for the queries inside $value()
+        return app('model-cache')->runDisabled(function () use ($hashKey, $field, $value, $ttl) {
+            $prefixedKey = config('database.redis.options.prefix') . $hashKey;
+            $redis       = Redis::connection('default');
+
+            // Return the cached field when it exists and the cache is enabled. A missing field is false (phpredis)
+            // or null (predis); a genuinely stored null is distinguishable as the serialized string 'N;'.
+            if ($this->cacheEnabled) {
+                $cached = $this->redisService->rawCommand($redis, 'HGET', $prefixedKey, $field);
+                if ($cached !== false && $cached !== null) {
+                    return unserialize((string)$cached);
+                }
+            }
+
+            // Cache miss - resolve the value by calling the closure
+            if ($value instanceof Closure) {
+                $value = $value();
+            }
+
+            // Only write it to cache when we're not bypassing it
+            if (!$this->isBypassCache()) {
+                $this->redisService->rawCommand($redis, 'HSET', $prefixedKey, $field, serialize($value));
+
+                // Redis can only expire a hash as a whole, so refresh the TTL of the entire hash on every write.
+                // A frequently viewed route thus keeps all of its cached variants warm together.
+                $ttlSeconds = $this->ttlToSeconds($ttl);
+                if ($ttlSeconds !== null) {
+                    $this->redisService->rawCommand($redis, 'EXPIRE', $prefixedKey, (string)$ttlSeconds);
+                }
+            }
+
+            return $value;
+        });
+    }
+
+    /**
+     * Drops an entire hash - and every field within it - in a single Redis DEL, regardless of how many fields
+     * exist. This is what makes dropping a route's card caches a bounded operation.
+     */
+    public function dropHashCache(string $hashKey): void
+    {
+        $prefixedKey = config('database.redis.options.prefix') . $hashKey;
+
+        $this->redisService->rawCommand(Redis::connection('default'), 'DEL', $prefixedKey);
+    }
+
     public function get(string $key): mixed
     {
         return Cache::get($key);
@@ -171,8 +251,8 @@ class CacheService implements CacheServiceInterface
             // MDT
             sprintf('/%smdt_npcs_[a-z_]+/', $prefix),
             sprintf('/%smdt_enemies_[a-z_]+/', $prefix),
-            // Cards
-            sprintf('/%sdungeonroute_card:(?>vertical|horizontal):[a-zA-Z_]+:[01]_[01]_[01]_\d+/', $prefix),
+            // Cards - one hash per route, keyed dungeonroute_card:{id}
+            sprintf('/%sdungeonroute_card:\d+/', $prefix),
             // Dungeon data used in MapContext
             sprintf('/%sdungeon_\d+_\d+_[a-z_]+/', $prefix),
             // Per-region view variables, keyed by release: view_variables:{release}:game_server_region:{short}

--- a/app/Service/Cache/CacheServiceInterface.php
+++ b/app/Service/Cache/CacheServiceInterface.php
@@ -12,6 +12,20 @@ interface CacheServiceInterface
 
     public function remember(string $key, mixed $value, mixed $ttl = null): mixed;
 
+    /**
+     * Remembers a value in a single Redis hash, keyed by field. All fields of a hash can then be dropped in one
+     * operation with {@see self::dropHashCache()}, regardless of how many fields exist.
+     *
+     * @param  \Closure|mixed      $value
+     * @return \Closure|mixed|null
+     */
+    public function rememberInHash(string $hashKey, string $field, mixed $value, mixed $ttl = null): mixed;
+
+    /**
+     * Drops an entire Redis hash (and all its fields) in a single operation.
+     */
+    public function dropHashCache(string $hashKey): void;
+
     public function get(string $key): mixed;
 
     public function set(string $key, mixed $object, mixed $ttl = null): bool;

--- a/resources/views/common/dungeonroute/cardhorizontal.blade.php
+++ b/resources/views/common/dungeonroute/cardhorizontal.blade.php
@@ -237,8 +237,9 @@ use (
 if ($cache) {
     $currentUserLocale = app()->getLocale();
 // Echo the result of this function
-    echo $cacheService->remember(
-        DungeonRoute::getCardCacheKey($dungeonroute->id, 'horizontal', $currentUserLocale, $showAffixes, $showDungeonImage, (int)$isAdmin),
+    echo $cacheService->rememberInHash(
+        DungeonRoute::getCardCacheKey($dungeonroute->id),
+        DungeonRoute::getCardCacheField('horizontal', $currentUserLocale, $showAffixes, $showDungeonImage, (int)$isAdmin),
         $cacheFn,
         config('keystoneguru.view.common.dungeonroute.card.cache.ttl')
     );

--- a/resources/views/common/dungeonroute/cardhorizontalrow.blade.php
+++ b/resources/views/common/dungeonroute/cardhorizontalrow.blade.php
@@ -219,8 +219,9 @@ use (
 
 if ($cache) {
     $currentUserLocale = app()->getLocale();
-    echo $cacheService->remember(
-        DungeonRoute::getCardCacheKey($dungeonroute->id, 'horizontal_row', $currentUserLocale, $showAffixes, $showDungeonImage, (int)$isAdmin),
+    echo $cacheService->rememberInHash(
+        DungeonRoute::getCardCacheKey($dungeonroute->id),
+        DungeonRoute::getCardCacheField('horizontal_row', $currentUserLocale, $showAffixes, $showDungeonImage, (int)$isAdmin),
         $cacheFn,
         config('keystoneguru.view.common.dungeonroute.card.cache.ttl')
     );

--- a/resources/views/common/dungeonroute/cardvertical.blade.php
+++ b/resources/views/common/dungeonroute/cardvertical.blade.php
@@ -250,8 +250,9 @@ use (
 if ($cache) {
     $currentUserLocale = app()->getLocale();
 // Echo the result of this function
-    echo $cacheService->remember(
-        DungeonRoute::getCardCacheKey($dungeonroute->id, 'vertical', $currentUserLocale, $showAffixes, $showDungeonImage, (int)$isAdmin),
+    echo $cacheService->rememberInHash(
+        DungeonRoute::getCardCacheKey($dungeonroute->id),
+        DungeonRoute::getCardCacheField('vertical', $currentUserLocale, $showAffixes, $showDungeonImage, (int)$isAdmin),
         $cacheFn,
         config('keystoneguru.view.common.dungeonroute.card.cache.ttl')
     );

--- a/tests/Feature/App/Models/DungeonRoute/DungeonRouteDropCachesTest.php
+++ b/tests/Feature/App/Models/DungeonRoute/DungeonRouteDropCachesTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\App\Models\DungeonRoute;
+
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Service\Cache\CacheServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Guards that dropping a route's card caches is a single bounded operation: it delegates to
+ * CacheServiceInterface::dropHashCache with the per-route hash key rather than looping over every
+ * orientation/locale/flag permutation.
+ */
+#[Group('DungeonRoute')]
+#[Group('DungeonRouteDropCaches')]
+final class DungeonRouteDropCachesTest extends PublicTestCase
+{
+    #[Test]
+    public function dropCaches_givenRouteId_dropsTheRouteCardHashOnce(): void
+    {
+        // Arrange
+        /** @var MockObject&CacheServiceInterface $cacheService */
+        $cacheService = $this->createMockPublic(CacheServiceInterface::class);
+        $cacheService->expects($this->once())
+            ->method('dropHashCache')
+            ->with('dungeonroute_card:123');
+        app()->instance(CacheServiceInterface::class, $cacheService);
+
+        // Act
+        DungeonRoute::dropCaches(123);
+
+        // Assert - handled by the mock expectation above.
+    }
+
+    #[Test]
+    public function getCardCacheKey_givenRouteId_returnsPerRouteHashKey(): void
+    {
+        // Arrange & Act
+        $key = DungeonRoute::getCardCacheKey(123);
+
+        // Assert - the hash key carries only the route id; variants are hash fields, not separate keys.
+        $this->assertSame('dungeonroute_card:123', $key);
+    }
+
+    #[Test]
+    public function getCardCacheField_givenVariant_returnsFieldFromOrientationLocaleAndFlags(): void
+    {
+        // Arrange & Act
+        $field = DungeonRoute::getCardCacheField('vertical', 'en_US', 0, 1, 0);
+
+        // Assert
+        $this->assertSame('vertical:en_US_0_1_0', $field);
+    }
+}

--- a/tests/Feature/App/Service/Cache/CacheServiceHashTest.php
+++ b/tests/Feature/App/Service/Cache/CacheServiceHashTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\App\Service\Cache;
+
+use App\Service\Cache\CacheService;
+use App\Service\Cache\Logging\CacheServiceLoggingInterface;
+use App\Service\Cache\Redis\RedisServiceInterface;
+use Illuminate\Redis\Connections\Connection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Covers the Redis-hash card cache: every card variant of a route lives as a field in a single hash keyed
+ * dungeonroute_card:{id}, so dropping a route's caches is a single bounded DEL regardless of variant count.
+ */
+#[Group('Cache')]
+#[Group('CacheServiceHash')]
+final class CacheServiceHashTest extends PublicTestCase
+{
+    private function prefix(): string
+    {
+        return config('database.redis.options.prefix');
+    }
+
+    /**
+     * Builds a CacheService whose Redis layer is fully mocked. Every rawCommand call is recorded, and the
+     * HGET response is configurable so a hit and a miss can both be exercised without touching real Redis.
+     *
+     * @param  array<int, array{command: string, params: array<int, mixed>}> $recordedCommands
+     * @return CacheService
+     */
+    private function makeCacheService(mixed $hgetResponse, array &$recordedCommands): CacheService
+    {
+        /** @var MockObject&RedisServiceInterface $redisService */
+        $redisService = $this->createMockPublic(RedisServiceInterface::class);
+        $redisService->method('rawCommand')->willReturnCallback(
+            function (Connection $redis, string $command, ...$params) use ($hgetResponse, &$recordedCommands): mixed {
+                $recordedCommands[] = ['command' => $command, 'params' => $params];
+
+                return match ($command) {
+                    'HGET'          => $hgetResponse,
+                    'HSET'          => 1,
+                    'EXPIRE', 'DEL' => 1,
+                    default         => null,
+                };
+            },
+        );
+
+        /** @var MockObject&CacheServiceLoggingInterface $log */
+        $log = $this->createMockPublic(CacheServiceLoggingInterface::class);
+
+        return new CacheService($redisService, $log);
+    }
+
+    /**
+     * @param  array<int, array{command: string, params: array<int, mixed>}> $recordedCommands
+     * @return array<int, array<int, mixed>>
+     */
+    private function paramsForCommand(array $recordedCommands, string $command): array
+    {
+        return array_values(
+            array_map(
+                static fn(array $recorded): array => $recorded['params'],
+                array_filter($recordedCommands, static fn(array $recorded): bool => $recorded['command'] === $command),
+            ),
+        );
+    }
+
+    #[Test]
+    public function rememberInHash_givenCacheMiss_setsHashFieldAndReturnsClosureValue(): void
+    {
+        // Arrange
+        $recordedCommands = [];
+        // HGET returns false: phpredis reports a missing hash field as false.
+        $cacheService = $this->makeCacheService(false, $recordedCommands);
+        $closureCalls = 0;
+
+        // Act
+        $result = $cacheService->rememberInHash(
+            'dungeonroute_card:123',
+            'vertical:en_US_0_1_0',
+            function () use (&$closureCalls): string {
+                $closureCalls++;
+
+                return '<div>card</div>';
+            },
+            '1 hour',
+        );
+
+        // Assert
+        $this->assertSame('<div>card</div>', $result, 'The resolved value must be returned on a cache miss');
+        $this->assertSame(1, $closureCalls, 'The closure must be called exactly once on a cache miss');
+
+        $hsetCalls = $this->paramsForCommand($recordedCommands, 'HSET');
+        $this->assertCount(1, $hsetCalls, 'A cache miss must write the field once via HSET');
+        $this->assertSame($this->prefix() . 'dungeonroute_card:123', $hsetCalls[0][0], 'HSET must target the prefixed hash key');
+        $this->assertSame('vertical:en_US_0_1_0', $hsetCalls[0][1], 'HSET must target the requested field');
+        $this->assertSame('<div>card</div>', unserialize($hsetCalls[0][2]), 'HSET must store the serialized value');
+
+        $expireCalls = $this->paramsForCommand($recordedCommands, 'EXPIRE');
+        $this->assertCount(1, $expireCalls, 'A cache miss with a TTL must refresh the hash TTL via EXPIRE');
+        $this->assertSame($this->prefix() . 'dungeonroute_card:123', $expireCalls[0][0], 'EXPIRE must target the prefixed hash key');
+        $this->assertSame((string)(60 * 60), $expireCalls[0][1], 'A "1 hour" TTL must expire the hash after 3600 seconds');
+    }
+
+    #[Test]
+    public function rememberInHash_givenCacheHit_returnsCachedValueWithoutRunningClosure(): void
+    {
+        // Arrange
+        $recordedCommands = [];
+        $cacheService     = $this->makeCacheService(serialize('<div>cached</div>'), $recordedCommands);
+        $closureCalls     = 0;
+
+        // Act
+        $result = $cacheService->rememberInHash(
+            'dungeonroute_card:123',
+            'vertical:en_US_0_1_0',
+            function () use (&$closureCalls): string {
+                $closureCalls++;
+
+                return '<div>fresh</div>';
+            },
+            '1 hour',
+        );
+
+        // Assert
+        $this->assertSame('<div>cached</div>', $result, 'A cache hit must return the cached value');
+        $this->assertSame(0, $closureCalls, 'The closure must not be called on a cache hit');
+        $this->assertCount(0, $this->paramsForCommand($recordedCommands, 'HSET'), 'A cache hit must not write anything');
+        $this->assertCount(0, $this->paramsForCommand($recordedCommands, 'EXPIRE'), 'A cache hit must not touch the TTL');
+    }
+
+    #[Test]
+    public function dropHashCache_givenRouteKey_issuesSingleDel(): void
+    {
+        // Arrange
+        $recordedCommands = [];
+        $cacheService     = $this->makeCacheService(false, $recordedCommands);
+
+        // Act
+        $cacheService->dropHashCache('dungeonroute_card:123');
+
+        // Assert - dropping every card variant of a route is exactly one DEL, regardless of variant count.
+        $delCalls = $this->paramsForCommand($recordedCommands, 'DEL');
+        $this->assertCount(1, $delCalls, 'Dropping a route hash must issue exactly one DEL');
+        $this->assertSame($this->prefix() . 'dungeonroute_card:123', $delCalls[0][0], 'DEL must target the prefixed hash key');
+    }
+}


### PR DESCRIPTION
:robot: Closes #3568

## Problem

`DungeonRoute::dropCaches($routeId)` invalidated a route's card caches by looping over every combination of `orientation × locale × showAffixes × showDungeon × isAdmin` and issuing one `Cache::delete` per permutation — **~200–360 blind Redis deletes** for a single route, on **every** `touch()`/save. It scaled poorly and grew every time a new card dimension was added.

## Fix

Move the permutation out of the Redis **key name** and into Redis **hash fields**. All card variants of a route now live as fields in a single hash keyed `dungeonroute_card:{id}`, so dropping a route's caches is a **single `DEL`** — bounded regardless of how many variants exist or are added later.

- **`CacheService`**: new `rememberInHash()` (HGET read; HSET write + whole-hash `EXPIRE`) and `dropHashCache()` (single `DEL`), reusing the existing `RedisServiceInterface::rawCommand` plumbing so it stays client-agnostic and mockable. The global `dropCaches()` "drop all caches" card regex is updated to the new `dungeonroute_card:\d+` key shape.
- **`DungeonRoute`**: `getCardCacheKey()` now returns just the per-route hash key; the variant tuple moved to a new `getCardCacheField()`. `dropCaches()` delegates one `dropHashCache()`. Signature stays `(int)`, so all existing callers are unaffected.
- **Card blades** (`cardvertical`/`cardhorizontal`/`cardhorizontalrow`): switched from `remember()` to `rememberInHash()`.

## Behaviour note

TTL is now per-route-hash (Redis can only expire a hash as a whole), refreshed on each variant write. Practically harmless with the 1-hour card TTL, and arguably better — a hot route keeps all its variants warm together.

## Tests

- `CacheServiceHashTest` — cache miss writes `HSET`+`EXPIRE` and returns the value; cache hit returns the cached value without running the closure; `dropHashCache` issues exactly one `DEL`.
- `DungeonRouteDropCachesTest` — `dropCaches()` delegates a single `dropHashCache('dungeonroute_card:{id}')`; locks the key/field formats.
- Verified end-to-end against real Redis: two variants → one hash key (`fields=2`, `ttl=3600`); re-read is a cache hit; `dropCaches()` clears the whole route in one op.

`composer run fix` + `composer run analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
