### PR TITLE
Add release:publish command to un-draft a GitHub Release

### DIFF
--- a/app/Console/Commands/Release/Publish.php
+++ b/app/Console/Commands/Release/Publish.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Console\Commands\Release;
+
+use Github\Api\Repo;
+use GrahamCampbell\GitHub\Facades\GitHub;
+use Illuminate\Console\Command;
+
+class Publish extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'release:publish {tag}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publishes the draft GitHub Release for the given tag (takes it out of draft)';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $tag = $this->argument('tag');
+
+        /** @var Repo $githubRepoClient */
+        // @phpstan-ignore staticMethod.notFound
+        $githubRepoClient = GitHub::repo();
+
+        $owner      = config('keystoneguru.github_repository_owner');
+        $repository = config('keystoneguru.github_repository');
+
+        $githubRelease = null;
+        foreach ($githubRepoClient->releases()->all($owner, $repository) as $release) {
+            if ($release['tag_name'] === $tag) {
+                $githubRelease = $release;
+                break;
+            }
+        }
+
+        if ($githubRelease === null) {
+            $this->error(sprintf('Unable to find GitHub release %s', $tag));
+
+            return self::FAILURE;
+        }
+
+        if (!$githubRelease['draft']) {
+            $this->info(sprintf('GitHub release %s is already published; nothing to do.', $tag));
+
+            return self::SUCCESS;
+        }
+
+        $githubRepoClient->releases()->edit($owner, $repository, $githubRelease['id'], ['draft' => false]);
+
+        $this->info(sprintf('Published GitHub release %s.', $tag));
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Feature/App/Console/Commands/Release/PublishTest.php
+++ b/tests/Feature/App/Console/Commands/Release/PublishTest.php
@@ -20,7 +20,7 @@ final class PublishTest extends PublicTestCase
 
         GitHub::shouldReceive('repo->releases->edit')
             ->once()
-            ->with('test', 'test', 101, ['draft' => false])
+            ->with('RaiderIO', 'Keystone.guru', 101, ['draft' => false])
             ->andReturn([]);
 
         // Act & Assert

--- a/tests/Feature/App/Console/Commands/Release/PublishTest.php
+++ b/tests/Feature/App/Console/Commands/Release/PublishTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\App\Console\Commands\Release;
+
+use GrahamCampbell\GitHub\Facades\GitHub;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Release')]
+final class PublishTest extends PublicTestCase
+{
+    #[Test]
+    public function handle_givenDraftRelease_publishesIt(): void
+    {
+        // Arrange
+        $this->mockGithubReleases([
+            $this->githubRelease(101, 'v15.6.0', draft: true),
+        ]);
+
+        GitHub::shouldReceive('repo->releases->edit')
+            ->once()
+            ->with('test', 'test', 101, ['draft' => false])
+            ->andReturn([]);
+
+        // Act & Assert
+        $this->artisan('release:publish', ['tag' => 'v15.6.0'])->assertExitCode(0);
+    }
+
+    #[Test]
+    public function handle_givenAlreadyPublishedRelease_doesNotEditIt(): void
+    {
+        // Arrange
+        $this->mockGithubReleases([
+            $this->githubRelease(101, 'v15.6.0', draft: false),
+        ]);
+
+        GitHub::shouldReceive('repo->releases->edit')->never();
+
+        // Act & Assert
+        $this->artisan('release:publish', ['tag' => 'v15.6.0'])->assertExitCode(0);
+    }
+
+    #[Test]
+    public function handle_givenUnknownTag_returnsFailure(): void
+    {
+        // Arrange
+        $this->mockGithubReleases([
+            $this->githubRelease(101, 'v15.6.0', draft: true),
+        ]);
+
+        GitHub::shouldReceive('repo->releases->edit')->never();
+
+        // Act & Assert
+        $this->artisan('release:publish', ['tag' => 'v99.99.99'])->assertExitCode(1);
+    }
+
+    /** @param array<int, array<string, mixed>> $githubReleases */
+    private function mockGithubReleases(array $githubReleases): void
+    {
+        GitHub::shouldReceive('repo->releases->all')->andReturn($githubReleases);
+    }
+
+    /** @return array<string, mixed> */
+    private function githubRelease(int $id, string $tag, bool $draft): array
+    {
+        return [
+            'id'       => $id,
+            'tag_name' => $tag,
+            'name'     => $tag,
+            'draft'    => $draft,
+        ];
+    }
+}


### PR DESCRIPTION
:robot: ## Summary

Part of RaiderIO/keystoneguru-infra#40.

Adds `release:publish {tag}`, which looks up a GitHub Release by tag via the existing
`GrahamCampbell\GitHub` client and flips `draft` to `false`. Idempotent — no-ops if the
release is already published.

This replaces `make:githubrelease`, which was deleted in #3480/#3497 ("Retire DB-seeded
releases in favour of GitHub Releases") but is still referenced by
`keystoneguru-infra`'s `migrate-stack.ts` post-deploy `<stage>-release` ECS task. Since
that removal, production releases have never left draft status (`v15.4.5`, `v15.5.0`),
and `release:report`'s Discord announcement never fires either, since it only looks at
non-draft releases.

A companion `keystoneguru-infra` PR will swap `make:githubrelease` for `release:publish`
in `migrate-stack.ts`, running it *before* `release:report` so the announce step can see
the now-published release.

## Test plan

- [x] `php artisan test --compact --group=Release` (9 passed)
- [x] `composer run fix` / `composer run analyse` clean
