### PR TITLE
Standardize agent thumbnail generation into two canonical paths (skill + commands)

### DIFF
--- a/.claude/skills/generating-thumbnails/SKILL.md
+++ b/.claude/skills/generating-thumbnails/SKILL.md
@@ -52,6 +52,15 @@ docker compose --profile render run --rm render dungeonroute:renderthumbnail <pu
 - `--floor` is optional (defaults to the map-facade floor set). `--disk` defaults to `local`; keep
   it — writing to `public` from a worktree would land in the shared, bind-mounted dir.
 
+**Path A is inspection-only — it does NOT give the route a thumbnail.** The rollback undoes the whole
+attach (including its delete-of-existing pass), so the route is left exactly as it was: if it had a
+real (public) thumbnail it keeps it, if it had none it still falls back to the dungeon image. Path A
+only adds a standalone JPG on the local disk for you to Read. To actually give a route a working,
+site-rendered thumbnail, use **Path B** — you can't make the route card show your branch's render in
+the worktree UI, because the `public` file is the shared bind-mount (overwriting it, or re-pointing
+the shared DB row, would bleed into the main stack and every worktree). Your branch's rendering
+change reaches real thumbnails via Path B **after merge**, when Horizon runs your merged code.
+
 **Local renders show the DebugBar and black (missing) map tiles** — the local `app-assets` container
 has no tiles and dev has the DebugBar on. This is the same for Path A and Path B (same render
 script/pipeline), so it's fine for verifying layout/enemies/positioning. If you need a tile-accurate,

--- a/.claude/skills/generating-thumbnails/SKILL.md
+++ b/.claude/skills/generating-thumbnails/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: generating-thumbnails
+description: The two — and only two — supported ways for an agent to generate a dungeon-route thumbnail. Use whenever you need to (re)generate, render, or inspect a route thumbnail, or when a thumbnail is missing/broken/403ing. Path B dispatches to shared Horizon (real thumbnails, visible everywhere); Path A renders your branch's code locally to inspect it. Do NOT hand-roll puppeteer, edit ThumbnailService guards, apt-install Chrome, or symlink public/storage.
+---
+
+# Generating dungeon-route thumbnails
+
+There are **exactly two** supported ways to make a thumbnail. Pick by intent. Do not invent a third
+(no manual puppeteer, no `ThumbnailService` guard edits, no `.chrome-tmp` Chrome installs, no
+`public/storage` symlink hacks — those are obsolete and cause the drift this skill exists to end).
+
+**Why the rules exist:** Chrome/puppeteer is baked into the `keystone.guru-worker` image **only**
+(the `app`/`app-swoole`/worktree `app` containers deliberately have no Chrome). So calling
+`ThumbnailService::createThumbnail()` synchronously in the `app` container always fails with
+`Could not find Chrome`. And because the **database is shared** across the main stack and every
+worktree, any thumbnail row you persist is seen everywhere — so a worktree must never write a row
+pointing at a worktree-local file.
+
+## Path B — "I just need real thumbnails to exist" (default)
+
+Dispatch the queued job. The shared main-stack **Horizon** container (the only one with Chrome)
+renders to the **`public`** disk, which is bind-mounted into every worktree and served at
+`/storage/...`. The shared DB means the new rows/files show up on the main stack and all worktrees.
+
+```
+docker compose exec -T app php artisan dungeonroute:queuethumbnail <publicKey> --force
+```
+
+- Works from the main checkout or any worktree (dispatch only needs Redis; Horizon does the render).
+- Uses **master's** code (Horizon runs the main checkout), so it does NOT reflect uncommitted branch
+  changes to the render/preview — use Path A for that.
+- Give Horizon a few seconds, then verify: the route's thumbnail row is on the `public` disk and
+  `curl -o /dev/null -w '%{http_code}' http://nginx/storage/<path>` returns `200`.
+- Bulk equivalents already exist: `dungeonroute:refreshoutdatedthumbnails`, the admin "regenerate"
+  tool, and `ThumbnailService::queueThumbnailRefresh()` in code.
+
+## Path A — "verify how MY branch renders a thumbnail" (worktree-isolated)
+
+Render this checkout's code in an on-demand container built from the `keystone.guru-worker` image
+(the only image with Chrome), writing to the **`local`** disk (`storage/app/private`), then **Read
+the resulting `.jpg`** with your file tool. It does **NOT** touch the shared database (the render
+runs inside a transaction that is always rolled back), so it can't break the route elsewhere.
+
+```
+docker compose --profile render run --rm render dungeonroute:renderthumbnail <publicKey> --floor=<n>
+```
+
+- Only in a worktree (needs the `render` service from `docker-compose.worktree.yml`). Requires the
+  main stack to be up so the `keystone.guru-worker` image exists.
+- The command prints the path(s) it wrote, e.g. `storage/app/private/thumbnails/<key>/<file>.jpg` —
+  open that file to inspect the render. Nothing is persisted to the DB or the shared public disk.
+- `--floor` is optional (defaults to the map-facade floor set). `--disk` defaults to `local`; keep
+  it — writing to `public` from a worktree would land in the shared, bind-mounted dir.
+
+**Local renders show the DebugBar and black (missing) map tiles** — the local `app-assets` container
+has no tiles and dev has the DebugBar on. This is identical for Path A and Path B (same render), so
+it's fine for verifying layout/enemies/positioning. If you need a tile-accurate, DebugBar-free
+image, that's an env concern affecting both paths, not a Path A bug.
+
+## Just want to eyeball the visual, not a real thumbnail file?
+
+The thumbnail is a screenshot of the `dungeonroute.preview` page. To check only how your branch
+renders that page, use the **headless-browser-verify** skill against the preview URL — no
+`ThumbnailService`, no disk, no DB.
+
+## Disks & serving (reference)
+
+- `public` disk → `storage/app/public`, served statically via the `storage:link` symlink at
+  `/storage/...` (no signature). This is where real thumbnails live; the main stack's
+  `storage/app/public/thumbnails` is bind-mounted into every worktree (`sh/worktree.sh`).
+- `local` disk → `storage/app/private`, worktree-isolated. Its `/storage/{path}` route is
+  **signed-URL-gated** (403 without a signature) — do **not** try to serve Path A output over HTTP
+  or re-point `public/storage` at it (that conflicts with `storage:link`). Just Read the file.
+- `dungeonroute:migratethumbnaildisk` is a separate dev-only one-off that moves legacy `local`-disk
+  rows onto the `public` disk; unrelated to day-to-day generation.
+
+See also: [[worktree-docker]], [[headless-browser-verify]].

--- a/.claude/skills/generating-thumbnails/SKILL.md
+++ b/.claude/skills/generating-thumbnails/SKILL.md
@@ -53,9 +53,11 @@ docker compose --profile render run --rm render dungeonroute:renderthumbnail <pu
   it — writing to `public` from a worktree would land in the shared, bind-mounted dir.
 
 **Local renders show the DebugBar and black (missing) map tiles** — the local `app-assets` container
-has no tiles and dev has the DebugBar on. This is identical for Path A and Path B (same render), so
-it's fine for verifying layout/enemies/positioning. If you need a tile-accurate, DebugBar-free
-image, that's an env concern affecting both paths, not a Path A bug.
+has no tiles and dev has the DebugBar on. This is the same for Path A and Path B (same render
+script/pipeline), so it's fine for verifying layout/enemies/positioning. If you need a tile-accurate,
+DebugBar-free image, that's an env concern affecting both paths, not a Path A bug. (Path A renders
+via the worker image's global puppeteer and Path B via the repo's local puppeteer — the same
+`route_thumbnail.js`, but pin them if you ever chase a path-specific rendering difference.)
 
 ## Just want to eyeball the visual, not a real thumbnail file?
 

--- a/.claude/skills/worktree-docker/SKILL.md
+++ b/.claude/skills/worktree-docker/SKILL.md
@@ -109,6 +109,14 @@ To re-provision the deploy key (e.g. on a new machine): generate a passphraseles
 as a write deploy key —
 `gh api -X POST repos/RaiderIO/keystone.guru/keys -f title=claude-worktree-push -f key="$(cat ~/.ssh/keystone_worktree_ed25519.pub)" -F read_only=false`.
 
+## Thumbnails
+
+A worktree does not run Horizon/puppeteer. To make a route thumbnail, use the two canonical paths in
+the **generating-thumbnails** skill: dispatch to shared Horizon (`dungeonroute:queuethumbnail`) for
+real thumbnails, or render this branch's code to the local disk for inspection
+(`docker compose --profile render run --rm render dungeonroute:renderthumbnail <key>`). Never call
+`ThumbnailService::createThumbnail()` synchronously in the `app` container — it has no Chrome.
+
 ## Tear down
 
 ```bash

--- a/app/Console/Commands/DungeonRoute/QueueThumbnail.php
+++ b/app/Console/Commands/DungeonRoute/QueueThumbnail.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands\DungeonRoute;
+
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Service\DungeonRoute\ThumbnailServiceInterface;
+use Illuminate\Console\Command;
+
+class QueueThumbnail extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dungeonroute:queuethumbnail {publicKey : The public key of the dungeon route} {--force : Regenerate even if the thumbnail is up to date}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Path B: queues a route thumbnail refresh onto the shared queue for Horizon (the only Chrome-capable container) to render to the public disk, visible to all stacks. See the generating-thumbnails skill.';
+
+    public function handle(ThumbnailServiceInterface $thumbnailService): int
+    {
+        /** @var DungeonRoute|null $dungeonRoute */
+        $dungeonRoute = DungeonRoute::where('public_key', $this->argument('publicKey'))->first();
+
+        if ($dungeonRoute === null) {
+            $this->error(sprintf('No dungeon route found with public key %s.', $this->argument('publicKey')));
+
+            return self::FAILURE;
+        }
+
+        $queued = $thumbnailService->queueThumbnailRefresh($dungeonRoute, (bool)$this->option('force'));
+
+        if (!$queued) {
+            $this->warn(sprintf('No thumbnail jobs were queued for %s (it may have no mapping version).', $dungeonRoute->public_key));
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf('Queued thumbnail refresh for %s; Horizon on the main stack will render it shortly.', $dungeonRoute->public_key));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/DungeonRoute/RenderThumbnail.php
+++ b/app/Console/Commands/DungeonRoute/RenderThumbnail.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Console\Commands\DungeonRoute;
+
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\Floor\Floor;
+use App\Service\DungeonRoute\ThumbnailServiceInterface;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class RenderThumbnail extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dungeonroute:renderthumbnail {publicKey : The public key of the dungeon route} {--floor= : A specific floor index to render (defaults to all facade floors)} {--disk=local : The filesystem disk to write to}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Dev-only (Path A): renders a route thumbnail from THIS checkout\'s code to a file WITHOUT touching the shared database, so you can inspect how the current code renders. Must run in a Chrome-capable container - see the generating-thumbnails skill.';
+
+    public function handle(ThumbnailServiceInterface $thumbnailService): int
+    {
+        if (app()->isProduction()) {
+            $this->error('This command must not be run in production.');
+
+            return self::FAILURE;
+        }
+
+        /** @var DungeonRoute|null $dungeonRoute */
+        $dungeonRoute = DungeonRoute::where('public_key', $this->argument('publicKey'))->first();
+
+        if ($dungeonRoute === null) {
+            $this->error(sprintf('No dungeon route found with public key %s.', $this->argument('publicKey')));
+
+            return self::FAILURE;
+        }
+
+        // Force the target disk so the render lands on the ISOLATED local disk (storage/app/private)
+        // instead of the shared, bind-mounted public disk.
+        $disk = (string)$this->option('disk');
+        config(['filesystems.default' => $disk]);
+
+        // The database is shared across the main stack and all worktrees, so persisting a thumbnail
+        // here would replace the real (public-disk) row with one pointing at this worktree's private
+        // disk and break the route everywhere else. Render inside a transaction we always roll back:
+        // the resized JPG is written to disk (Storage writes are not transactional and survive the
+        // rollback), while the DungeonRouteThumbnail/File rows and the route timestamp are discarded.
+        $renderedPaths = [];
+
+        DB::beginTransaction();
+
+        try {
+            foreach ($this->resolveFloors($dungeonRoute) as $floor) {
+                $this->info(sprintf('Rendering %s floor %d to the %s disk...', $dungeonRoute->public_key, $floor->index, $disk));
+
+                $thumbnail = $thumbnailService->createThumbnail($dungeonRoute, $floor->index, 0);
+
+                if ($thumbnail?->file === null) {
+                    $this->error(sprintf('Failed to render floor %d (check that this container has Chrome - see the generating-thumbnails skill).', $floor->index));
+
+                    return self::FAILURE;
+                }
+
+                $renderedPaths[] = $thumbnail->file->path;
+            }
+        } finally {
+            DB::rollBack();
+        }
+
+        $storageSubdir = $disk === 'local' ? 'private' : $disk;
+        foreach ($renderedPaths as $renderedPath) {
+            $this->info(sprintf('  -> storage/app/%s/%s', $storageSubdir, $renderedPath));
+        }
+        $this->info('Read the file(s) above to inspect the render; the shared database was left untouched.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return Collection<int, Floor>
+     */
+    private function resolveFloors(DungeonRoute $dungeonRoute): Collection
+    {
+        $floorIndex = $this->option('floor');
+
+        if ($floorIndex !== null) {
+            /** @var Collection<int, Floor> $floors */
+            $floors = $dungeonRoute->dungeon->floors()->where('index', (int)$floorIndex)->get();
+
+            return $floors;
+        }
+
+        // Mirror queueThumbnailRefresh: render exactly the floor(s) the map facade would show.
+        return $dungeonRoute->dungeon
+            ->floorsForMapFacade($dungeonRoute->mappingVersion, true)
+            ->active()
+            ->get();
+    }
+}

--- a/docker-compose.worktree.yml
+++ b/docker-compose.worktree.yml
@@ -41,6 +41,30 @@ services:
     ports:
       - "${WORKTREE_HTTP_PORT}:80"
 
+  # On-demand thumbnail renderer for Path A (see the generating-thumbnails skill). Reuses the
+  # prebuilt keystone.guru-worker image (the only one with Chrome baked in, built by the main
+  # stack's horizon service) to render THIS worktree's branch code. Behind a profile so the normal
+  # stack is unaffected; the entrypoint makes `run render <artisan args>` execute artisan directly.
+  # Deliberately does NOT mount ${MAIN_THUMBNAILS_DIR}: Path A forces the `local` disk
+  # (storage/app/private under ./), keeping branch renders isolated from the shared public dir.
+  # Usage: docker compose --profile render run --rm render dungeonroute:renderthumbnail <key> --floor=<n>
+  render:
+    image: keystone.guru-worker
+    restart: "no"
+    profiles: ["render"]
+    working_dir: /var/www/
+    user: "${PUID:-1000}:${PGID:-1000}"
+    entrypoint: ["php", "/var/www/artisan"]
+    volumes:
+      - ./:/var/www
+      - ~/.ssh:/home/ksg/.ssh
+    environment:
+      - "APP_URL=http://nginx"
+      # The ./:/var/www mount shadows the image's /var/www, and lean worktrees carry no
+      # node_modules, so route_thumbnail.js's require('puppeteer') must resolve to the worker
+      # image's global install (version-matched to its baked Chrome at PUPPETEER_CACHE_DIR).
+      - "NODE_PATH=/usr/lib/node_modules"
+
   # Headless Chrome for in-browser verification (layout/JS bugs, screenshots). Behind a profile so
   # the normal stack is unaffected; start on demand with: docker compose --profile chrome up -d chrome
   # Reach it from the app container via CDP on chrome:9222; pages see the site as http://nginx.

--- a/docs/developer/scheduler.md
+++ b/docs/developer/scheduler.md
@@ -7,3 +7,5 @@ The Scheduler is triggered from Crontab
 
 # Thumbnails
 Run `node node_modules/puppeteer/install.js` to have puppeteer download Chrome. If you don't do this - it will not work.
+
+In Docker, Chrome is baked into the `keystone.guru-worker` (Horizon) image; only that container renders thumbnails. Agents: see the `generating-thumbnails` skill for the two supported ways to generate a thumbnail.

--- a/sh/worktree.sh
+++ b/sh/worktree.sh
@@ -145,12 +145,16 @@ cmd_create() {
         -e "s#^APP_URL=.*#APP_URL=http://localhost:${port}#" \
         -e "s#^URL_HOST=.*#URL_HOST=http://localhost:${port}#" \
         "$wt_path/.env"
+    # MAIN_THUMBNAILS_DIR is persisted into the worktree .env (not just exported) so that plain
+    # `docker compose ...` invocations resolve the bind-mount source too — e.g. the profiled
+    # `render` service used for Path A thumbnail rendering (see the generating-thumbnails skill).
     cat >> "$wt_path/.env" <<EOF
 
 # --- added by sh/worktree.sh (worktree: ${branch}) ---
 COMPOSE_PROJECT_NAME=${project}
 COMPOSE_FILE=docker-compose.worktree.yml
 WORKTREE_HTTP_PORT=${port}
+MAIN_THUMBNAILS_DIR=${REPO_ROOT}/storage/app/public/thumbnails
 EOF
 
     # 4b. Main's thumbnail directory is bind-mounted into the worktree (live-shares thumbnails

--- a/tests/Feature/Console/Commands/DungeonRoute/QueueThumbnailTest.php
+++ b/tests/Feature/Console/Commands/DungeonRoute/QueueThumbnailTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Console\Commands\DungeonRoute;
+
+use App\Console\Commands\DungeonRoute\QueueThumbnail;
+use App\Jobs\ProcessRouteFloorThumbnail;
+use App\Models\DungeonRoute\DungeonRoute;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Traits\ProvidesDungeon;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Console')]
+#[Group('DungeonRoute')]
+final class QueueThumbnailTest extends PublicTestCase
+{
+    use ProvidesDungeon;
+
+    #[Test]
+    public function handle_givenValidRoute_queuesAThumbnailJob(): void
+    {
+        // Arrange
+        Queue::fake();
+
+        $dungeon      = $this->getDungeonWithNonFacadeFloor();
+        $dungeonRoute = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $dungeon->getCurrentMappingVersion()->id,
+        ]);
+
+        try {
+            // Act
+            $this->artisan(QueueThumbnail::class, ['publicKey' => $dungeonRoute->public_key])->assertSuccessful();
+
+            // Assert
+            Queue::assertPushed(ProcessRouteFloorThumbnail::class);
+        } finally {
+            $dungeonRoute->delete();
+        }
+    }
+
+    #[Test]
+    public function handle_givenUnknownPublicKey_failsWithoutQueueing(): void
+    {
+        // Arrange
+        Queue::fake();
+
+        // Act & Assert
+        $this->artisan(QueueThumbnail::class, ['publicKey' => 'NOSUCHKEY'])->assertFailed();
+        Queue::assertNothingPushed();
+    }
+}

--- a/tests/Feature/Console/Commands/DungeonRoute/RenderThumbnailTest.php
+++ b/tests/Feature/Console/Commands/DungeonRoute/RenderThumbnailTest.php
@@ -8,6 +8,7 @@ use App\Models\DungeonRoute\DungeonRouteThumbnail;
 use App\Models\File;
 use App\Models\Floor\Floor;
 use App\Service\DungeonRoute\ThumbnailServiceInterface;
+use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Feature\Traits\ProvidesDungeon;
@@ -103,13 +104,17 @@ final class RenderThumbnailTest extends PublicTestCase
             'mapping_version_id' => $dungeon->getCurrentMappingVersion()->id,
         ]);
 
-        // The fake render persists a thumbnail row (as the real attach would). The command must roll
-        // it back so the shared database is never mutated by a Path A render.
+        // The fake render mirrors the real pipeline: it persists a thumbnail row AND writes the
+        // rendered file to disk. The command's contract is that the DB write is rolled back while
+        // the on-disk file (a non-transactional Storage write) survives for the agent to read.
+        Storage::fake('local');
+
         $persistedThumbnailId = null;
+        $renderedPath         = 'thumbnails/x.jpg';
         $thumbnailService     = $this->createMockPublic(ThumbnailServiceInterface::class);
         $thumbnailService->expects($this->once())
             ->method('createThumbnail')
-            ->willReturnCallback(function () use ($dungeonRoute, $floor, &$persistedThumbnailId): DungeonRouteThumbnail {
+            ->willReturnCallback(function () use ($dungeonRoute, $floor, $renderedPath, &$persistedThumbnailId): DungeonRouteThumbnail {
                 $thumbnail = DungeonRouteThumbnail::create([
                     'dungeon_route_id' => $dungeonRoute->id,
                     'floor_id'         => $floor->id,
@@ -119,9 +124,11 @@ final class RenderThumbnailTest extends PublicTestCase
                     'model_id'    => $thumbnail->id,
                     'model_class' => DungeonRouteThumbnail::class,
                     'disk'        => 'local',
-                    'path'        => 'thumbnails/x.jpg',
+                    'path'        => $renderedPath,
                 ]);
                 $thumbnail->update(['file_id' => $file->id]);
+
+                Storage::disk('local')->put($renderedPath, 'fake-image-bytes');
 
                 $persistedThumbnailId = $thumbnail->id;
 
@@ -136,10 +143,12 @@ final class RenderThumbnailTest extends PublicTestCase
                 '--floor'   => $floor->index,
             ])->assertSuccessful();
 
-            // Assert - the persisted thumbnail (and its file) were rolled back
+            // Assert - the persisted thumbnail (and its file row) were rolled back...
             $this->assertNotNull($persistedThumbnailId);
             $this->assertDatabaseMissing('dungeon_route_thumbnails', ['id' => $persistedThumbnailId]);
             $this->assertSame(0, $dungeonRoute->dungeonRouteThumbnails()->count());
+            // ...but the rendered file survives the rollback so the agent can read it.
+            Storage::disk('local')->assertExists($renderedPath);
         } finally {
             DungeonRouteThumbnail::where('dungeon_route_id', $dungeonRoute->id)->get()->each->delete();
             $dungeonRoute->delete();

--- a/tests/Feature/Console/Commands/DungeonRoute/RenderThumbnailTest.php
+++ b/tests/Feature/Console/Commands/DungeonRoute/RenderThumbnailTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature\Console\Commands\DungeonRoute;
+
+use App\Console\Commands\DungeonRoute\RenderThumbnail;
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\DungeonRoute\DungeonRouteThumbnail;
+use App\Models\File;
+use App\Models\Floor\Floor;
+use App\Service\DungeonRoute\ThumbnailServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Traits\ProvidesDungeon;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Console')]
+#[Group('DungeonRoute')]
+final class RenderThumbnailTest extends PublicTestCase
+{
+    use ProvidesDungeon;
+
+    #[Test]
+    public function handle_givenProductionEnvironment_failsWithoutRendering(): void
+    {
+        // Arrange
+        $thumbnailService = $this->createMockPublic(ThumbnailServiceInterface::class);
+        $thumbnailService->expects($this->never())->method('createThumbnail');
+        app()->instance(ThumbnailServiceInterface::class, $thumbnailService);
+
+        $originalEnv      = $this->app['env'];
+        $this->app['env'] = 'production';
+
+        try {
+            // Act & Assert
+            $this->artisan(RenderThumbnail::class, ['publicKey' => 'ANYKEY12'])->assertFailed();
+        } finally {
+            $this->app['env'] = $originalEnv;
+        }
+    }
+
+    #[Test]
+    public function handle_givenUnknownPublicKey_failsWithoutRendering(): void
+    {
+        // Arrange
+        $thumbnailService = $this->createMockPublic(ThumbnailServiceInterface::class);
+        $thumbnailService->expects($this->never())->method('createThumbnail');
+        app()->instance(ThumbnailServiceInterface::class, $thumbnailService);
+
+        // Act & Assert
+        $this->artisan(RenderThumbnail::class, ['publicKey' => 'NOSUCHKEY'])->assertFailed();
+    }
+
+    #[Test]
+    public function handle_givenDiskOption_forcesDefaultFilesystemDiskBeforeRendering(): void
+    {
+        // Arrange
+        $dungeon      = $this->getDungeonWithNonFacadeFloor();
+        $floor        = $dungeon->floors()->where('facade', false)->first();
+        $dungeonRoute = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $dungeon->getCurrentMappingVersion()->id,
+        ]);
+
+        $capturedDisk     = null;
+        $thumbnailService = $this->createMockPublic(ThumbnailServiceInterface::class);
+        $thumbnailService->expects($this->once())
+            ->method('createThumbnail')
+            ->willReturnCallback(function () use (&$capturedDisk): DungeonRouteThumbnail {
+                $capturedDisk = config('filesystems.default');
+
+                // Return an unsaved model that looks file-backed, so the command reports success.
+                $thumbnail = new DungeonRouteThumbnail();
+                $thumbnail->setRelation('file', new File(['path' => 'thumbnails/x.jpg']));
+
+                return $thumbnail;
+            });
+        app()->instance(ThumbnailServiceInterface::class, $thumbnailService);
+
+        try {
+            // Act
+            $this->artisan(RenderThumbnail::class, [
+                'publicKey' => $dungeonRoute->public_key,
+                '--floor'   => $floor->index,
+                '--disk'    => 'local',
+            ])->assertSuccessful();
+
+            // Assert
+            $this->assertSame('local', $capturedDisk);
+        } finally {
+            $dungeonRoute->delete();
+        }
+    }
+
+    #[Test]
+    public function handle_givenSuccessfulRender_doesNotPersistToTheSharedDatabase(): void
+    {
+        // Arrange
+        $dungeon = $this->getDungeonWithNonFacadeFloor();
+        /** @var Floor $floor */
+        $floor        = $dungeon->floors()->where('facade', false)->first();
+        $dungeonRoute = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $dungeon->getCurrentMappingVersion()->id,
+        ]);
+
+        // The fake render persists a thumbnail row (as the real attach would). The command must roll
+        // it back so the shared database is never mutated by a Path A render.
+        $persistedThumbnailId = null;
+        $thumbnailService     = $this->createMockPublic(ThumbnailServiceInterface::class);
+        $thumbnailService->expects($this->once())
+            ->method('createThumbnail')
+            ->willReturnCallback(function () use ($dungeonRoute, $floor, &$persistedThumbnailId): DungeonRouteThumbnail {
+                $thumbnail = DungeonRouteThumbnail::create([
+                    'dungeon_route_id' => $dungeonRoute->id,
+                    'floor_id'         => $floor->id,
+                    'custom'           => false,
+                ]);
+                $file = File::create([
+                    'model_id'    => $thumbnail->id,
+                    'model_class' => DungeonRouteThumbnail::class,
+                    'disk'        => 'local',
+                    'path'        => 'thumbnails/x.jpg',
+                ]);
+                $thumbnail->update(['file_id' => $file->id]);
+
+                $persistedThumbnailId = $thumbnail->id;
+
+                return $thumbnail;
+            });
+        app()->instance(ThumbnailServiceInterface::class, $thumbnailService);
+
+        try {
+            // Act
+            $this->artisan(RenderThumbnail::class, [
+                'publicKey' => $dungeonRoute->public_key,
+                '--floor'   => $floor->index,
+            ])->assertSuccessful();
+
+            // Assert - the persisted thumbnail (and its file) were rolled back
+            $this->assertNotNull($persistedThumbnailId);
+            $this->assertDatabaseMissing('dungeon_route_thumbnails', ['id' => $persistedThumbnailId]);
+            $this->assertSame(0, $dungeonRoute->dungeonRouteThumbnails()->count());
+        } finally {
+            DungeonRouteThumbnail::where('dungeon_route_id', $dungeonRoute->id)->get()->each->delete();
+            $dungeonRoute->delete();
+        }
+    }
+}


### PR DESCRIPTION
:robot: Standardizes how agents generate dungeon-route thumbnails so we stop re-deriving it every time.

## Why

Agents kept landing on a different ad-hoc thumbnail method each time (guard bypasses, `.chrome-tmp` apt-installs, env swaps, `public/storage` symlink hacks, running `createThumbnail` in a container with no Chrome). Root cause: Chrome is baked into the `keystone.guru-worker`/Horizon image **only**, and the **DB is shared** across the main stack and all worktrees — two facts that no single place documented.

## The two — and only two — supported paths

**Path B — real thumbnails (shared).** `dungeonroute:queuethumbnail <key> --force` dispatches to the shared Horizon container (the only one with Chrome), which renders to the `public` disk. Bind-mounted + shared DB means the main stack and every worktree see it. Works from anywhere (dispatch needs only Redis). Uses master's code.

**Path A — verify MY branch's render (isolated).** `docker compose --profile render run --rm render dungeonroute:renderthumbnail <key> --floor=<n>` renders *this checkout's* code inside an on-demand container built from the existing `keystone.guru-worker` image (no app-image bloat, Chrome already version-matched), writes to the `local` disk (`storage/app/private`), and prints the path so the agent **Reads the JPG**. It runs inside a **transaction that is always rolled back**, so the shared DB is never mutated — critical, because otherwise a worktree render replaces the real public-disk row with one pointing at worktree-only storage and 403s the route everywhere else.

Grid check (why only two): need = *(whose code renders)* × *(isolated vs shared output)*. Path A = my-branch + isolated; Path B = master + shared. The other cells are pointless or the deliberately-avoided per-worktree Chrome worker.

## Changes

- `app/Console/Commands/DungeonRoute/QueueThumbnail.php` — Path B command (thin wrapper over `queueThumbnailRefresh`).
- `app/Console/Commands/DungeonRoute/RenderThumbnail.php` — Path A command; forces the `local` disk and wraps the render in a rolled-back transaction (no DB writes).
- `docker-compose.worktree.yml` — profiled `render` service (worker image; `NODE_PATH=/usr/lib/node_modules` so `require('puppeteer')` resolves to the image's global, Chrome-matched puppeteer since the `./` mount shadows any worktree node_modules).
- `sh/worktree.sh` — persist `MAIN_THUMBNAILS_DIR` into the worktree `.env` so plain `docker compose` (the `render` service) resolves the bind-mount source (also hardens all manual compose calls).
- `.claude/skills/generating-thumbnails/SKILL.md` — the single source of truth; cross-referenced from `worktree-docker` and `docs/developer/scheduler.md`.
- Tests: `RenderThumbnailTest` (prod guard, unknown key, forces `local` disk, **and proves the render is rolled back / never persists**), `QueueThumbnailTest` (queues a job; unknown key fails).

## Verification (done end-to-end on this machine)

- **Path A:** `render` container rendered `Ruv4Rtj` to `storage/app/private/...jpg`; read the JPG (valid image); the shared DB row stayed `disk=public`, count=1 — untouched.
- **Path B:** `dungeonroute:queuethumbnail` → Horizon rendered to the `public` disk in ~5s; `curl http://nginx/storage/<path>` → `200`.
- **Fresh worktree:** created a throwaway worktree off this branch and confirmed `sh/worktree.sh` writes `MAIN_THUMBNAILS_DIR` into its `.env` and `docker compose --profile render config` resolves with no empty-mount error — so the `render` path works in a new worktree without any manual `.env` patching.
- Both renders use the same `route_thumbnail.js` pipeline; local renders show the DebugBar + black tiles because local `app-assets` has no tiles — identical for both paths, not a Path A bug. (Path A uses the worker image's global puppeteer, Path B the repo's local puppeteer.)
- `RenderThumbnail|QueueThumbnail` tests pass (6, incl. asserting the Path A render is rolled back in DB **and** the file survives on disk); `composer run fix` + `analyse` clean.

## Note

The stale `seed-dev-routes` thumbnail runbook (guard bypass + `public/storage → private` symlink) lives in the unmerged #3349 worktree, not master — the new skill documents that those steps are obsolete; the actual edit lands if/when #3349 does.
