### PR TITLE
#3588 Fix pull lists not showing: restore $.isNumeric for jquery-bar-rating

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -7,6 +7,16 @@ window._ = require('lodash');
  */
 
 window.$ = window.jQuery = require('jquery');
+
+// jQuery 4.0 removed $.isNumeric (#3560 bumped jQuery 3.6.1 -> 4.0.0), but the bundled
+// jquery-bar-rating plugin still calls it. Restore it before any jQuery plugin loads.
+if (typeof window.$.isNumeric !== 'function') {
+    window.$.isNumeric = function (obj) {
+        const type = typeof obj;
+        return (type === 'number' || type === 'string') && !isNaN(obj - parseFloat(obj));
+    };
+}
+
 window.offsetPolygon = require('offset-polygon').default;
 
 // Bootstrap 5 no longer registers jQuery plugins; expose the API globally because the

--- a/resources/assets/js/custom/inline/common/maps/map.js
+++ b/resources/assets/js/custom/inline/common/maps/map.js
@@ -160,12 +160,14 @@ class CommonMapsMap extends InlineCode {
             });
 
             // Live sessions
-            $('#stop_live_session_modal select').barrating({
-                theme: 'fontawesome-stars',
-                onSelect: function (value) {
-                    self._rate(value);
-                }
-            });
+            if (getState().getMapContext() instanceof MapContextLiveSession) {
+                $('#stop_live_session_modal select').barrating({
+                    theme: 'fontawesome-stars',
+                    onSelect: function (value) {
+                        self._rate(value);
+                    }
+                });
+            }
         }
     }
 

--- a/resources/assets/js/jquery-isnumeric-shim.test.js
+++ b/resources/assets/js/jquery-isnumeric-shim.test.js
@@ -1,0 +1,94 @@
+// ---------------------------------------------------------------------------
+// Regression test for #3588. Dependabot bumped jQuery 3.6.1 -> 4.0.0 (#3560),
+// and jQuery 4.0 removed the deprecated `$.isNumeric()`. The bundled
+// `jquery-bar-rating` plugin still calls `$.isNumeric()` internally, so it threw
+// "t.isNumeric is not a function" during map activation, aborting map init and
+// leaving the pull lists unrendered on production (v15.6.0).
+//
+// The fix installs a `$.isNumeric` shim in resources/assets/js/bootstrap.js
+// before any jQuery plugin loads. This test mirrors that shim and asserts, against
+// the real jQuery 4 + jquery-bar-rating, that the plugin throws without it and
+// initialises cleanly with it.
+// ---------------------------------------------------------------------------
+
+const $ = require('jquery');
+require('jquery-bar-rating');
+
+/**
+ * Mirrors the `$.isNumeric` shim installed in resources/assets/js/bootstrap.js.
+ *
+ * @param {*} obj
+ * @returns {boolean}
+ */
+function isNumericShim(obj) {
+    const type = typeof obj;
+
+    return (type === 'number' || type === 'string') && !isNaN(obj - parseFloat(obj));
+}
+
+/**
+ * @param {string} id
+ * @returns {HTMLSelectElement}
+ */
+function createRatingSelect(id) {
+    document.body.innerHTML = `<select id="${id}">
+        <option value="1">1</option>
+        <option value="2" selected>2</option>
+        <option value="3">3</option>
+    </select>`;
+
+    return document.querySelector(`#${id}`);
+}
+
+describe('jQuery $.isNumeric shim (#3588)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('isNumericShim_givenVariousInputs_matchesJQuerySemantics', () => {
+        expect(isNumericShim(5)).toBe(true);
+        expect(isNumericShim('5')).toBe(true);
+        expect(isNumericShim(-1.5)).toBe(true);
+        expect(isNumericShim('5px')).toBe(false);
+        expect(isNumericShim('')).toBe(false);
+        expect(isNumericShim(NaN)).toBe(false);
+        expect(isNumericShim(Infinity)).toBe(false);
+        expect(isNumericShim(null)).toBe(false);
+        expect(isNumericShim(true)).toBe(false);
+    });
+
+    test('isNumeric_givenJQuery4_isRemoved', () => {
+        // Documents the root cause: jQuery 4.0 no longer ships $.isNumeric.
+        expect(typeof $.fn.jquery).toBe('string');
+        expect($.fn.jquery.startsWith('4.')).toBe(true);
+    });
+
+    test('barrating_givenNoIsNumeric_throwsIsNotAFunction', () => {
+        const original = $.isNumeric;
+        delete $.isNumeric;
+        createRatingSelect('rating_without_shim');
+
+        try {
+            expect(() => $('#rating_without_shim').barrating({theme: 'fontawesome-stars'}))
+                .toThrow(/isNumeric is not a function/);
+        } finally {
+            if (original !== undefined) {
+                $.isNumeric = original;
+            }
+        }
+    });
+
+    test('barrating_givenIsNumericShim_initialisesWithoutThrowing', () => {
+        $.isNumeric = isNumericShim;
+        const select = createRatingSelect('rating_with_shim');
+
+        try {
+            expect(() => $('#rating_with_shim').barrating({theme: 'fontawesome-stars'})).not.toThrow();
+            // The plugin replaces the <select> with its own widget wrapper on success.
+            expect(document.querySelector('.br-widget')).not.toBeNull();
+        } finally {
+            $(select).barrating('destroy');
+            delete $.isNumeric;
+        }
+    });
+});


### PR DESCRIPTION
:robot: Closes #3588

## Problem

On production (v15.6.0) the pull lists stopped rendering on dungeon map pages. The console showed:

```
Uncaught TypeError: t.isNumeric is not a function
    at t.fn.barrating (app-v15.6.0.js)
    ... activate (custom-v15.6.0.js:1658)
```

**Root cause:** Dependabot bumped **jQuery 3.6.1 → 4.0.0** (#3560, `39be777c0`), merged before the v15.6.0 tag. jQuery 4.0 **removed the deprecated `$.isNumeric()`**. The bundled `jquery-bar-rating@1.2.2` plugin still calls `$.isNumeric()` internally ([upstream bug antennaio/jquery-bar-rating#129](https://github.com/antennaio/jquery-bar-rating/issues/129)), so it throws the moment `.barrating()` runs during map activation. That exception aborts the rest of map init, so downstream rendering — including the pull lists — never runs.

`git tag --contains 39be777c0` = **v15.6.0, v15.6.1, v15.6.2**, so staging (v15.6.2) has the identical bug; it was not already fixed. It doesn't reproduce locally only because local compiled bundles predate the jQuery-4 install.

## Fix

1. **`bootstrap.js`** — restore a guarded `$.isNumeric` shim (using jQuery's own numeric semantics) immediately after jQuery is required and before any jQuery plugin loads.
2. **`map.js`** — guard the live-session `.barrating()` call behind a `MapContextLiveSession` check so it only runs for live sessions (matches the existing `getState().getMapContext() instanceof MapContextLiveSession` pattern used throughout the codebase).

## Tests

Added `resources/assets/js/jquery-isnumeric-shim.test.js` (vitest), which against the real jQuery 4 + jquery-bar-rating:
- reproduces the exact `isNumeric is not a function` error **without** the shim,
- confirms the widget initialises (`.br-widget`) **with** the shim,
- asserts the shim's numeric semantics.

Full JS suite green (20 files / 207 tests). The shim was verified present in the freshly-built production bundle, ahead of the plugin's `isNumeric` calls.

> ⚠️ This is a **compiled-asset** change, so it needs a **new release** (not an S3 hotfix). The release will fix both production and staging.

## Follow-up

A separate issue should audit the other bundled legacy jQuery plugins for further jQuery-4 removals (`$.trim`, `$.isFunction`, `$.type`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
