### PR TITLE
#3590 Audit bundled jQuery plugins for other jQuery-4 removals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
                 "intro.js": "github:Wotuu/intro.js",
                 "ion-rangeslider": "^2.3.1",
                 "jquery-bar-rating": "^1.2.2",
-                "jquery-mousewheel": "^3.2.2",
                 "jquery-visible": "^1.2.0",
                 "js-cookie": "^3.0.8",
                 "lang.js": "^1.1.14",
@@ -3014,15 +3013,6 @@
             "integrity": "sha512-0OtYCrgDzyc3FQ6r08Twns35t1bKd4V/9+Nberg3Idg3ZpBw2dVre8Hut0w3sbekm391desWxpbKFKSPzuk81w==",
             "dependencies": {
                 "jquery": ">=1.7.2"
-            }
-        },
-        "node_modules/jquery-mousewheel": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jquery-mousewheel/-/jquery-mousewheel-3.2.2.tgz",
-            "integrity": "sha512-JP71xTAg08ZY3hcs9ZbYUZ5i+dkSsz4yRl/zpWkAmtzc+kMs5EfPkpkINSidiLYMaR0MTo3DfFGF9WIezMsFQQ==",
-            "license": "MIT",
-            "dependencies": {
-                "jquery": ">=1.2.6"
             }
         },
         "node_modules/jquery-visible": {
@@ -6469,14 +6459,6 @@
             "integrity": "sha512-0OtYCrgDzyc3FQ6r08Twns35t1bKd4V/9+Nberg3Idg3ZpBw2dVre8Hut0w3sbekm391desWxpbKFKSPzuk81w==",
             "requires": {
                 "jquery": ">=1.7.2"
-            }
-        },
-        "jquery-mousewheel": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jquery-mousewheel/-/jquery-mousewheel-3.2.2.tgz",
-            "integrity": "sha512-JP71xTAg08ZY3hcs9ZbYUZ5i+dkSsz4yRl/zpWkAmtzc+kMs5EfPkpkINSidiLYMaR0MTo3DfFGF9WIezMsFQQ==",
-            "requires": {
-                "jquery": ">=1.2.6"
             }
         },
         "jquery-visible": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
                 "ion-rangeslider": "^2.3.1",
                 "jquery-bar-rating": "^1.2.2",
                 "jquery-mousewheel": "^3.2.2",
-                "jquery-touchswipe": "^1.6.19",
                 "jquery-visible": "^1.2.0",
                 "js-cookie": "^3.0.8",
                 "lang.js": "^1.1.14",
@@ -1482,15 +1481,6 @@
                 "nanopop": "2.4.2"
             }
         },
-        "node_modules/@socket.io/component-emitter": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1533,17 +1523,6 @@
             "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/node": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-            "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "undici-types": "~8.3.0"
-            }
         },
         "node_modules/@vitest/expect": {
             "version": "4.1.10",
@@ -2522,87 +2501,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
         },
-        "node_modules/engine.io-client": {
-            "version": "6.6.3",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
-            "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.2.1",
-                "ws": "~8.17.1",
-                "xmlhttprequest-ssl": "~2.1.1"
-            }
-        },
-        "node_modules/engine.io-client/node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/engine.io-client/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/engine.io-client/node_modules/ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/engine.io-parser": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -3126,11 +3024,6 @@
             "dependencies": {
                 "jquery": ">=1.2.6"
             }
-        },
-        "node_modules/jquery-touchswipe": {
-            "version": "1.6.19",
-            "resolved": "https://registry.npmjs.org/jquery-touchswipe/-/jquery-touchswipe-1.6.19.tgz",
-            "integrity": "sha512-b0BGje9reNRU3u6ksAK9QqnX7yBRgLNe/wYG7DOfyDlhBlYjayIT8bSOHmcuvptIDW/ubM9CTW/mnZf9Rohuow=="
         },
         "node_modules/jquery-visible": {
             "version": "1.2.0",
@@ -4194,98 +4087,6 @@
                 "lodash-es": "^4.17.21"
             }
         },
-        "node_modules/socket.io-client": {
-            "version": "4.8.1",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
-            "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.2",
-                "engine.io-client": "~6.6.1",
-                "socket.io-parser": "~4.2.4"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/socket.io-client/node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/socket.io-client/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/socket.io-parser": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-            "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/socket.io-parser/node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/socket.io-parser/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4558,14 +4359,6 @@
             "engines": {
                 "node": ">=20.18.1"
             }
-        },
-        "node_modules/undici-types": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "node_modules/vite": {
             "version": "8.1.4",
@@ -4903,17 +4696,6 @@
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/xmlhttprequest-ssl": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
-            "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
         },
         "node_modules/y18n": {
             "version": "5.0.8",
@@ -5638,14 +5420,6 @@
                 "nanopop": "2.4.2"
             }
         },
-        "@socket.io/component-emitter": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "@standard-schema/spec": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -5683,17 +5457,6 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
             "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "dev": true
-        },
-        "@types/node": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-            "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "requires": {
-                "undici-types": "~8.3.0"
-            }
         },
         "@vitest/expect": {
             "version": "4.1.10",
@@ -6353,59 +6116,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
         },
-        "engine.io-client": {
-            "version": "6.6.3",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
-            "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "requires": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.2.1",
-                "ws": "~8.17.1",
-                "xmlhttprequest-ssl": "~2.1.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-                    "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true,
-                    "requires": {
-                        "ms": "^2.1.3"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
-                },
-                "ws": {
-                    "version": "8.17.1",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-                    "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true,
-                    "requires": {}
-                }
-            }
-        },
-        "engine.io-parser": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -6768,11 +6478,6 @@
             "requires": {
                 "jquery": ">=1.2.6"
             }
-        },
-        "jquery-touchswipe": {
-            "version": "1.6.19",
-            "resolved": "https://registry.npmjs.org/jquery-touchswipe/-/jquery-touchswipe-1.6.19.tgz",
-            "integrity": "sha512-b0BGje9reNRU3u6ksAK9QqnX7yBRgLNe/wYG7DOfyDlhBlYjayIT8bSOHmcuvptIDW/ubM9CTW/mnZf9Rohuow=="
         },
         "jquery-visible": {
             "version": "1.2.0",
@@ -7426,74 +7131,6 @@
                 "lodash-es": "^4.17.21"
             }
         },
-        "socket.io-client": {
-            "version": "4.8.1",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
-            "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "requires": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.2",
-                "engine.io-client": "~6.6.1",
-                "socket.io-parser": "~4.2.4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-                    "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true,
-                    "requires": {
-                        "ms": "^2.1.3"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
-                }
-            }
-        },
-        "socket.io-parser": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-            "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "requires": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.7",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-                    "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true,
-                    "requires": {
-                        "ms": "^2.1.3"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
-                }
-            }
-        },
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7672,14 +7309,6 @@
             "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
             "dev": true
         },
-        "undici-types": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "vite": {
             "version": "8.1.4",
             "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
@@ -7826,14 +7455,6 @@
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
-        },
-        "xmlhttprequest-ssl": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
-            "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true
         },
         "y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
         "intro.js": "github:Wotuu/intro.js",
         "ion-rangeslider": "^2.3.1",
         "jquery-bar-rating": "^1.2.2",
-        "jquery-mousewheel": "^3.2.2",
         "jquery-visible": "^1.2.0",
         "js-cookie": "^3.0.8",
         "lang.js": "^1.1.14",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
         "ion-rangeslider": "^2.3.1",
         "jquery-bar-rating": "^1.2.2",
         "jquery-mousewheel": "^3.2.2",
-        "jquery-touchswipe": "^1.6.19",
         "jquery-visible": "^1.2.0",
         "js-cookie": "^3.0.8",
         "lang.js": "^1.1.14",

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -123,7 +123,6 @@ window.jqueryVisible = require('jquery-visible');
 window.simplebar = require('simplebar');
 window.Draggable = require('@shopify/draggable');
 require('bootstrap5-toggle/js/bootstrap5-toggle.jquery.min.js');
-window.swipe = require('jquery-touchswipe');
 window.lazysizes = require('lazysizes');
 window.ionRangeSlider = require('ion-rangeslider');
 

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -107,7 +107,6 @@ window.polylinedecorator = require('leaflet-polylinedecorator');
 window.lightCarousel = require('lightslider');
 window.introjs = require('intro.js');
 window.pwstrengthmeter = require('password-strength-meter');
-window.jqueryMousewheel = require('jquery-mousewheel');
 window.Cookies = require('js-cookie');
 window.hull = require('hull.js'); // Find the 'hull' of a random set of points
 const offsetPolygon = require("offset-polygon");

--- a/resources/assets/js/jquery4-plugin-audit.test.js
+++ b/resources/assets/js/jquery4-plugin-audit.test.js
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------
+// Regression coverage for #3590, a follow-up audit to #3588/#3589. jQuery 4.0
+// (#3560 bumped jQuery 3.6.1 -> 4.0.0) removed several long-deprecated global
+// helpers, and one bundled plugin (`jquery-bar-rating`) still called one of
+// them (`$.isNumeric`), breaking pull lists in production. #3589 shimmed that
+// specific call and added a regression test for it
+// (jquery-isnumeric-shim.test.js).
+//
+// A static grep audit for #3590 found no other bundled plugin calling a
+// removed jQuery-4 API. To actually close the loop the way #3589's test did -
+// by exercising the real code path instead of just grepping for names - this
+// file requires each other actively-used bundled plugin against the real
+// jQuery 4 package and initialises it the same way the app does, asserting it
+// doesn't throw. This is what should catch a future plugin-version bump that
+// reintroduces a removed-API call, before it reaches production.
+//
+// Each plugin is required via the exact same module specifier used in
+// resources/assets/js/bootstrap.js, since some packages (e.g. bootstrap5-toggle)
+// resolve to a different, non-jQuery build via their bare package name.
+// ---------------------------------------------------------------------------
+
+const $ = require('jquery');
+global.$ = global.jQuery = $;
+
+describe('jquery-visible (#3590)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('visible_givenElementInDom_returnsBooleanWithoutThrowing', () => {
+        require('jquery-visible');
+        document.body.innerHTML = '<div id="killzone"></div>';
+
+        let result;
+        expect(() => {
+            result = $('#killzone').visible();
+        }).not.toThrow();
+        expect(typeof result).toBe('boolean');
+    });
+});
+
+describe('lightslider (#3590)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('lightSlider_givenSlideList_initialisesWithoutThrowing', () => {
+        require('lightslider');
+        document.body.innerHTML = `<ul class="light-slider">
+            <li><img src="1.jpg" /></li>
+            <li><img src="2.jpg" /></li>
+            <li><img src="3.jpg" /></li>
+        </ul>`;
+
+        expect(() => $('.light-slider').lightSlider({loop: false, controls: false, pager: false}))
+            .not.toThrow();
+    });
+});
+
+describe('bootstrap5-toggle (#3590)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('bootstrapToggle_givenCheckbox_initialisesWithoutThrowing', () => {
+        // jsdom doesn't implement ResizeObserver, which the plugin uses to react to its
+        // container becoming visible; stub it so this test exercises the jQuery/plugin
+        // code path rather than failing on an unrelated jsdom environment gap.
+        global.ResizeObserver = global.ResizeObserver ?? class {
+            observe() {
+            }
+
+            unobserve() {
+            }
+
+            disconnect() {
+            }
+        };
+
+        // Same deep import as bootstrap.js - the package's bare "main" resolves to a
+        // different, non-jQuery build.
+        require('bootstrap5-toggle/js/bootstrap5-toggle.jquery.min.js');
+        document.body.innerHTML = '<input type="checkbox" data-toggle="toggle">';
+
+        expect(() => $('input[type=checkbox]').bootstrapToggle()).not.toThrow();
+    });
+});
+
+describe('ion-rangeslider (#3590)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('ionRangeSlider_givenInput_initialisesWithoutThrowing', () => {
+        require('ion-rangeslider');
+        document.body.innerHTML = '<input id="rating-slider" />';
+
+        expect(() => $('#rating-slider').ionRangeSlider({grid: true, min: 1, max: 10}))
+            .not.toThrow();
+    });
+});
+
+describe('password-strength-meter (#3590)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('password_givenPasswordInput_initialisesWithoutThrowing', () => {
+        require('password-strength-meter');
+        document.body.innerHTML = '<input type="password" id="register_password" />';
+
+        expect(() => $('#register_password').password({showText: true})).not.toThrow();
+    });
+});
+
+describe('intro.js (#3590)', () => {
+    test('introJs_givenStart_doesNotThrowSynchronously', () => {
+        const introJs = require('intro.js');
+
+        expect(() => introJs().start()).not.toThrow();
+    });
+});


### PR DESCRIPTION
:robot: Closes #3590

## Summary

Follow-up audit to #3588/#3589. Cross-referenced the real installed jQuery
4.0.0 source against the issue's list of removed/changed APIs, then grepped
every bundled plugin (`jquery-bar-rating`, `jquery-mousewheel`,
`jquery-visible`, `jquery-touchswipe`, `bootstrap5-toggle`, `lightslider`,
`intro.js`, `password-strength-meter`, `ion-rangeslider`) and our own code for
calls to them.

**Result:** the already-fixed `$.isNumeric` call in `jquery-bar-rating`
(#3589) was the only real exposure. No other plugin, and none of our own
code, calls a removed jQuery-4 API. `$.fn.bind/unbind/delegate/undelegate/hover`
are also still present in jQuery 4.0 (kept for back-compat), contrary to the
issue's listed concern. **Recommendation: stay on jQuery 4.0** rather than
pinning back to 3.x.

## Changes

- **Add `resources/assets/js/jquery4-plugin-audit.test.js`** — a Vitest smoke
  test that actually initialises each other actively-used bundled plugin
  (`jquery-visible`, `lightslider`, `bootstrap5-toggle`, `ion-rangeslider`,
  `password-strength-meter`, `intro.js`) against the real jQuery 4 package in
  jsdom, mirroring how the app invokes it. This exercises the real code path
  instead of just grepping for names, so a future plugin-version bump that
  reintroduces a removed API gets caught before release — the same way
  #3589's isNumeric test would have caught the original break.
- **Remove the dead `jquery-touchswipe` and `jquery-mousewheel` requires** from
  `bootstrap.js` (+ `package.json`/`package-lock.json`). Both have zero call
  sites anywhere in the app. `git log` shows `jquery-touchswipe` was added in
  `0acd9b40` for the old front-page rework (#667), which has since been
  reworked/removed, orphaning it — it's also unmaintained (no release since
  2018). `jquery-mousewheel` was added separately in `07d899c7` (2018, sidebar
  scrollbar fix, unrelated to the front page) and is actively maintained
  upstream, but that doesn't matter if nothing uses it — removed too.

## Maintenance audit (bonus finding)

Checked npm last-publish + GitHub last-push for every bundled plugin. Five
more actively-used plugins are unmaintained and worth migrating away from;
filing one follow-up issue per plugin to track that separately:

| Plugin | Last release | Last repo push | Usage |
|---|---|---|---|
| jquery-bar-rating | 2017 | 2021 | Pull-list star ratings |
| jquery-visible | 2017 | 2019 | Killzone sidebar visibility |
| lightslider | 2016 | 2022 (280 open issues) | Dungeon-route carousels |
| ion-rangeslider | 2019 | 2023 | Heaviest usage — every heat-option/search-filter/dungeon-route numeric slider (~15 call sites) |
| password-strength-meter | 2020 | 2022 | Registration password strength meter |

## Test plan

- [x] `npm test` — 213/213 tests pass, including the 6 new plugin smoke tests
- [x] `npm run production` — build succeeds; the freshly built bundle has zero
      references to `touchSwipe`/`jquery-touchswipe` or `jquery-mousewheel`

