### PR TITLE
#3598 Fix footer link list left indent

### DIFF
--- a/resources/assets/sass/theme/_footer.scss
+++ b/resources/assets/sass/theme/_footer.scss
@@ -37,7 +37,6 @@
 
     &__list {
         list-style: none;
-        padding-left: 0;
         color: #bbbbbb;
         font-size: 1.1rem;
         line-height: 1.5;
@@ -112,4 +111,11 @@
         color: #ffc107;
         font-weight: 700;
     }
+}
+
+// Bootstrap 5's reboot rule (`ul, ol { padding-left: 2rem }`) is theme-scoped as `.darkly ul`
+// (specificity 0,1,1), which out-specifies the plain `.site-footer__list` class (0,1,0) above.
+// Match element + class here to win the cascade and actually zero out the indent.
+.site-footer ul.site-footer__list {
+    padding-left: 0;
 }


### PR DESCRIPTION
:robot: Closes #3598

## Summary
The footer's `.site-footer__list` reset never won the cascade: the darkly theme's Bootstrap 5
reboot rule (`.darkly ul`, specificity 0,1,1) out-specified the plain `.site-footer__list` class
(0,1,0), so every footer column kept a 32px left indent — off-center on mobile where the footer
is centered.

## Fix
`resources/assets/sass/theme/_footer.scss`: moved the `padding-left: 0` reset into a
higher-specificity `.site-footer ul.site-footer__list` rule (0,2,1) that wins over `.darkly ul`.

## Verification
Computed `padding-left` on `.site-footer__list`, master vs branch:
- Desktop: `32px` → `0px`
- 390px viewport: `32px` → `0px`

Desktop:
![master desktop](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3598-master-desktop.png)
![branch desktop](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3598-branch-desktop.png)

Mobile (390px):
![master mobile](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3598-master-mobile.png)
![branch mobile](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3598-branch-mobile.png)

## Test plan
- [x] Rebuilt assets (`npm run dev`) and verified in headless Chrome against a master baseline
- [x] Desktop: lists align with their column headings, no left indent
- [x] Mobile (390px): lists are properly centered under their headings
- [x] CSS-only change; no PHP touched, so `composer run fix`/`analyse` not applicable
