### PR TITLE
#3602 Verification screenshots: hide debugbar + cookie banner, skip Discord ping

### DIFF
--- a/.claude/skills/headless-browser-verify/SKILL.md
+++ b/.claude/skills/headless-browser-verify/SKILL.md
@@ -40,6 +40,10 @@ docker compose exec -T app sh -c 'cd /var/www && node .chrome-tmp/browse.js http
   for mobile UAs - and curl without a desktop UA is treated as mobile too (a trap when grepping for
   sidebar markup).
 - `puppeteer` resolves from `/var/www/node_modules` (run with cwd `/var/www`).
+- **Debugbar and cookie banner are auto-suppressed** so they never pollute screenshots: browse.js
+  sets the `cookieconsent_status=dismiss` cookie before navigating (the server then omits the
+  banner) and strips `.phpdebugbar` / `.cc-window` from the DOM before every screenshot. No flags
+  needed; this applies to the master baseline origin too.
 
 ## Baseline comparison — always A/B against master for visual changes
 

--- a/.claude/skills/headless-browser-verify/browse.js
+++ b/.claude/skills/headless-browser-verify/browse.js
@@ -38,6 +38,16 @@ function args(name) {
 }
 
 /**
+ * Remove overlays that should never appear in a verification screenshot: the Laravel Debugbar and
+ * the cookie-consent window. Safe to call repeatedly (e.g. again after a --click navigation).
+ */
+async function stripOverlays(page) {
+    await page.evaluate(() => {
+        document.querySelectorAll('.phpdebugbar, [id^="phpdebugbar"], .cc-window').forEach(el => el.remove());
+    }).catch(() => {});
+}
+
+/**
  * Connect to the compose chrome service. Chrome's DevTools endpoint rejects Host headers that are
  * not an IP or localhost, so resolve the service name to an IP first and connect through that.
  */
@@ -97,9 +107,17 @@ async function connectToService(host, port) {
         if (msg.type() === 'error') consoleErrors.push(msg.text().substring(0, 300));
     });
 
+    // Suppress the cookie-consent banner: the server omits it entirely when this cookie is set to
+    // 'dismiss' (see resources/views/layouts/app.blade.php), so it never appears in screenshots.
+    await page.setCookie({name: 'cookieconsent_status', value: 'dismiss', url}).catch(() => {});
+
     const response = await page.goto(url, {waitUntil: 'networkidle2', timeout: 60000});
     const waitMs = parseInt(arg('wait', '1500'), 10);
     await new Promise(r => setTimeout(r, waitMs));
+
+    // Keep screenshots clean: strip the Laravel Debugbar, and any cookie-consent window that still
+    // slipped through (e.g. a baseline origin where the cookie above wasn't honoured).
+    await stripOverlays(page);
 
     for (const selector of args('click')) {
         const clicked = await page.evaluate(sel => {
@@ -123,6 +141,8 @@ async function connectToService(host, port) {
 
     const screenshot = arg('screenshot');
     if (screenshot) {
+        // Re-strip in case a --click navigated to a fresh page that re-injected the overlays.
+        await stripOverlays(page);
         await page.screenshot({path: screenshot, fullPage: !arg('viewport')});
     }
 

--- a/app/Http/Controllers/Webhook/GithubWebhookController.php
+++ b/app/Http/Controllers/Webhook/GithubWebhookController.php
@@ -43,8 +43,12 @@ class GithubWebhookController extends Controller
         $ref     = $request->get('ref');
         $branch  = str_replace('refs/heads/', '', (string)$ref);
 
-        // We don't need duplicate messages in Discord since mapping is automatically managed
-        if ($branch !== 'mapping') {
+        // Branches carrying automated, non-code pushes we never announce in Discord: 'mapping' is
+        // automatically managed (duplicate noise), and 'verification-screenshots' is the orphan
+        // branch the headless-browser-verify tooling pushes PR screenshots to.
+        $ignoredBranches = ['mapping', 'verification-screenshots'];
+
+        if (!in_array($branch, $ignoredBranches, true)) {
             $embeds = [];
 
             // https://discord.com/developers/docs/resources/channel#embed-object-embed-limits

--- a/tests/Feature/Controller/Webhook/GithubWebhookControllerTest.php
+++ b/tests/Feature/Controller/Webhook/GithubWebhookControllerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature\Controller\Webhook;
+
+use App\Service\Discord\DiscordApiServiceInterface;
+use Illuminate\Testing\TestResponse;
+use Mockery;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+#[Group('Controller')]
+#[Group('Webhook')]
+final class GithubWebhookControllerTest extends TestCase
+{
+    private const string SECRET = 'test-webhook-secret';
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'keystoneguru.webhook.github.secret' => self::SECRET,
+            'keystoneguru.webhook.github.url'    => 'https://discord.example/webhook',
+        ]);
+    }
+
+    #[Test]
+    public function github_givenDistinctCommitOnNormalBranch_sendsDiscordEmbeds(): void
+    {
+        // Arrange
+        $this->expectDiscordEmbeds(1);
+
+        // Act
+        $response = $this->postWebhook('refs/heads/master', [$this->distinctCommit()]);
+
+        // Assert
+        $response->assertNoContent();
+    }
+
+    #[Test]
+    public function github_givenMappingBranch_doesNotSendDiscordEmbeds(): void
+    {
+        // Arrange
+        $this->expectDiscordEmbeds(0);
+
+        // Act
+        $response = $this->postWebhook('refs/heads/mapping', [$this->distinctCommit()]);
+
+        // Assert
+        $response->assertNoContent();
+    }
+
+    #[Test]
+    public function github_givenVerificationScreenshotsBranch_doesNotSendDiscordEmbeds(): void
+    {
+        // Arrange
+        $this->expectDiscordEmbeds(0);
+
+        // Act
+        $response = $this->postWebhook('refs/heads/verification-screenshots', [$this->distinctCommit()]);
+
+        // Assert
+        $response->assertNoContent();
+    }
+
+    #[Test]
+    public function github_givenInvalidSignature_doesNotSendDiscordEmbeds(): void
+    {
+        // Arrange
+        $this->expectDiscordEmbeds(0);
+        $payload = json_encode(['ref' => 'refs/heads/master', 'commits' => [$this->distinctCommit()]], JSON_THROW_ON_ERROR);
+
+        // Act
+        $response = $this->call(
+            'POST',
+            route('webhook.github'),
+            [],
+            [],
+            [],
+            $this->transformHeadersToServerVars([
+                'X-Hub-Signature' => 'sha1=deadbeef',
+                'Content-Type'    => 'application/json',
+            ]),
+            $payload,
+        );
+
+        // Assert
+        $this->assertNotSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+    }
+
+    /**
+     * Bind a mocked Discord service that expects `sendEmbeds` to be called exactly $times (0 = never).
+     */
+    private function expectDiscordEmbeds(int $times): void
+    {
+        $mock = Mockery::mock(DiscordApiServiceInterface::class);
+        $this->instance(DiscordApiServiceInterface::class, $mock);
+
+        /** @var \Mockery\Expectation $expectation */
+        $expectation = $mock->shouldReceive('sendEmbeds');
+        $expectation->times($times)->andReturnTrue();
+    }
+
+    /**
+     * POST a GitHub push webhook with a valid HMAC signature computed over the raw JSON body, mirroring
+     * how GitHub signs the request (content_type: json).
+     *
+     * @param array<int, array<string, mixed>> $commits
+     *
+     * @return TestResponse<Response>
+     */
+    private function postWebhook(string $ref, array $commits): TestResponse
+    {
+        $payload   = json_encode(['ref' => $ref, 'commits' => $commits], JSON_THROW_ON_ERROR);
+        $signature = 'sha1=' . hash_hmac('sha1', $payload, self::SECRET);
+
+        return $this->call(
+            'POST',
+            route('webhook.github'),
+            [],
+            [],
+            [],
+            $this->transformHeadersToServerVars([
+                'X-Hub-Signature' => $signature,
+                'Content-Type'    => 'application/json',
+            ]),
+            $payload,
+        );
+    }
+
+    /**
+     * A commit that passes every skip filter in the controller (distinct, not a system/merge commit), so
+     * it would normally produce a Discord embed.
+     *
+     * @return array<string, mixed>
+     */
+    private function distinctCommit(): array
+    {
+        return [
+            'message'   => 'Add a thing',
+            'distinct'  => true,
+            'url'       => 'https://github.com/RaiderIO/keystone.guru/commit/deadbeef',
+            'timestamp' => '2026-07-17T12:00:00+00:00',
+            'committer' => ['name' => 'Wouter', 'email' => 'wouter@example.com'],
+            'added'     => [],
+            'modified'  => [],
+            'removed'   => [],
+        ];
+    }
+}


### PR DESCRIPTION
:robot: Closes #3602

Improvements to the `headless-browser-verify` screenshot tooling and the GitHub push webhook.

## Changes
- **browse.js** — sets the `cookieconsent_status=dismiss` cookie before navigating (the server then omits the banner, see `layouts/app.blade.php`) and strips the `.phpdebugbar` root container plus any `.cc-window` before every screenshot, via a reusable `stripOverlays()` helper that also re-runs after `--click` navigations.
- **headless-browser-verify skill** — documents the auto-suppression.
- **GithubWebhookController::github** — ignores the `verification-screenshots` branch (alongside `mapping`), so pushing PR screenshots no longer pings Discord.
- **GithubWebhookControllerTest** (new) — normal branch sends embeds; `mapping` and `verification-screenshots` do not; invalid signature does not.

## Verification
- `php artisan test` — `GithubWebhookControllerTest` 4/4 passing.
- `composer run analyse` clean; changed PHP conforms to `composer run fix`.
- browse.js selectors verified against the installed `fruitcake/laravel-debugbar` package and the server-side `cookieconsent_status` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)