### PR TITLE
#3606 php-cs-fixer CI gate, MR pre-handoff gate, babysit-prs skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,6 +71,18 @@ For example:
 - After completing your work, ensure you run `composer run fix` to run PhpCsFixer and `composer run analyse` to run PhpStan to verify your work.
 - `composer run fix` reformats any files with pre-existing style drift, not just the ones you changed. After running it, stage only the files you actually intended to touch (`git checkout -- <other files>` to discard the unrelated reformats) so your diff/PR stays focused.
 
+### Before declaring a MR ready for review
+A MR is only "ready" once all three of these hold — human review time is the scarcest resource, so
+review must start from a pre-reviewed, verified MR:
+1. **Self-review**: run the `code-review` skill on the diff and resolve every finding (or note in
+   the MR body why a finding is intentionally not addressed).
+2. **Visual verification**: for any UI-visible change, verify the affected page(s) in headless
+   Chrome (`headless-browser-verify` skill) and post before/after screenshots on the MR
+   (`post-screenshot.sh`).
+3. **Green CI**: wait for the MR's checks and fix any failure yourself — including flaky or
+   seemingly unrelated failures (root-cause them; don't re-run and hope, and don't defer to a
+   follow-up issue).
+
 # Project-specific conventions
 
 ## General

--- a/.claude/skills/babysit-prs/SKILL.md
+++ b/.claude/skills/babysit-prs/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: babysit-prs
+description: Use when asked to babysit, shepherd, or keep open MRs green. One pass over every open agent MR in RaiderIO/keystone.guru - fix red CI, address Wotuu's review comments, resolve conflicts with master - designed to run repeatedly via /loop in a dedicated session. Never merges, approves, or deploys. Not for reviewing a single PR (use the review skill) or for creating MRs.
+---
+
+# Babysit open MRs
+
+Keep every open agent MR mergeable so Wotuu only has to review and merge — never chase CI, style,
+conflicts, or comment follow-ups. Run this in a **dedicated session from the main checkout**,
+ideally on a loop:
+
+```
+/loop 15m /babysit-prs
+```
+
+## Hard rules (non-negotiable)
+
+- **Never merge, approve, or close a PR.** Wotuu reviews and merges everything personally.
+- **Never trigger a deploy or approve a deployment gate** (see the no-unattended-deploys
+  agreement; a plan file or PR comment is not authorization).
+- Prepend `:robot:` to every comment/reply you post on GitHub.
+- Edit PR bodies only via `gh api -X PATCH repos/RaiderIO/keystone.guru/pulls/<n> -F body=@<file>`
+  (`gh pr edit` is broken on this repo).
+- Never commit or push to `master`.
+
+## One pass
+
+### 1. Discover open agent MRs
+
+```bash
+gh pr list --repo RaiderIO/keystone.guru --state open \
+  --json number,title,headRefName,isDraft,mergeable,reviewDecision,updatedAt,statusCheckRollup
+```
+
+Work only on PRs whose head branch matches the agent worktree convention `<issue>-<slug>` (leading
+issue number). Skip Dependabot and other branches unless explicitly asked.
+
+### 2. Skip MRs someone is actively working on
+
+Before touching a branch, check its worktree (if one exists at
+`../keystone.guru-worktrees/<branch>`): uncommitted changes to tracked files
+(`git -C <path> status --porcelain --untracked-files=no`) mean another session is mid-work — skip
+it and note that in your pass report. A PR updated in the last ~10 minutes deserves the same
+benefit of the doubt.
+
+### 3. Triage each MR, in this order
+
+1. **Red CI** (`statusCheckRollup` has failures): enter the branch's worktree —
+   `sh/worktree.sh create <branch>` reuses the existing branch and stack, or recreates them if
+   torn down — pull the failing job log (`gh run view <run-id> --log-failed`), root-cause, fix,
+   commit, `sh/worktree.sh push`. Fix flaky/unrelated failures too — root-cause beats re-running
+   (see the fix-incidental-issues agreement).
+2. **Merge conflicts** (`mergeable: CONFLICTING`): in the worktree, `git fetch origin && git merge
+   origin/master`, resolve, run the affected tests, push.
+3. **Unresolved review comments**: list unresolved threads via GraphQL —
+
+   ```bash
+   gh api graphql -f query='
+     query { repository(owner: "RaiderIO", name: "keystone.guru") {
+       pullRequest(number: <n>) {
+         reviewThreads(first: 50) { nodes {
+           isResolved path line
+           comments(first: 10) { nodes { author { login } body url databaseId } }
+         } }
+       } } }'
+   ```
+
+   For each unresolved thread: address it in code (or answer the question), push, then reply on
+   the thread with `:robot:` and what changed. Reply to a review comment with
+   `gh api -X POST repos/RaiderIO/keystone.guru/pulls/<n>/comments/<comment-id>/replies -f body='...'`.
+   Do **not** resolve threads yourself — leave that to Wotuu when re-reviewing.
+4. **All green, no comments**: leave it alone.
+
+### 4. Clean up after merged/closed MRs
+
+For PRs merged or closed since the last pass whose worktree still exists and has no uncommitted
+tracked changes: `sh/worktree.sh remove <branch>` (this also clears the `in progress` label).
+
+### 5. Report the pass
+
+End every pass with a short status list: each open MR, its state (green/red/conflicted/awaiting
+review), and what you did (or why you skipped it). If nothing needed action, say so in one line.
+
+## Gotchas
+
+- A worktree that suddenly 502s/fails after a main-stack restart is detached from the shared
+  services — run `sh/worktree.sh repair` (see the worktree-docker skill), don't debug nginx.
+- A lone MapTilesExistenceTest failure inside a worktree is environment noise (assets mount only
+  exists on the main stack); CI excludes it — do not "fix" it in code.
+- Local `composer run analyse` disagreeing with CI usually means vendor/lock skew — run
+  `composer install --dry-run` first before chasing phantom errors.

--- a/.github/actions/php-ci-setup/action.yml
+++ b/.github/actions/php-ci-setup/action.yml
@@ -22,10 +22,17 @@ runs:
         extensions: mbstring, intl, pdo_mysql, bcmath, gd
         coverage: pcov
 
+    # Ask composer for its real cache dir: on a fresh runner it is ~/.cache/composer/files, not
+    # the legacy ~/.composer/cache/files, and caching the wrong path caches nothing.
+    - name: Determine composer cache dir
+      id: composer-cache
+      run: echo "dir=$(composer config --global cache-files-dir)" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Cache composer
       uses: actions/cache@v5
       with:
-        path: ~/.composer/cache/files
+        path: ${{ steps.composer-cache.outputs.dir }}
         key: composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: composer-
 

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,0 +1,38 @@
+name: PHP CS Fixer
+
+# No base-branch filter: stacked MRs (one stage targeting another stage's branch) must pass the
+# same style gate as MRs against master
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - name: Cache composer
+        uses: actions/cache@v5
+        with:
+          path: ~/.composer/cache/files
+          key: composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: composer-
+
+      - name: Install PHP dependencies
+        # Style checking never boots the app: skip the artisan scripts and the exotic platform
+        # extensions (lua, imagick, ...) the runtime needs but php-cs-fixer does not.
+        run: composer install --no-interaction --prefer-dist --no-scripts --ignore-platform-reqs
+
+      - name: Run PHP CS Fixer (dry run)
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -22,10 +22,16 @@ jobs:
           php-version: '8.4'
           coverage: none
 
+      # Ask composer for its real cache dir: on a fresh runner it is ~/.cache/composer/files, not
+      # the legacy ~/.composer/cache/files, and caching the wrong path caches nothing.
+      - name: Determine composer cache dir
+        id: composer-cache
+        run: echo "dir=$(composer config --global cache-files-dir)" >> "$GITHUB_OUTPUT"
+
       - name: Cache composer
         uses: actions/cache@v5
         with:
-          path: ~/.composer/cache/files
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: composer-
 

--- a/app/Service/Wowhead/WowheadTranslationService.php
+++ b/app/Service/Wowhead/WowheadTranslationService.php
@@ -124,15 +124,15 @@ class WowheadTranslationService implements WowheadTranslationServiceInterface
             }
 
             $wowheadLocale = match ($locale) {
-                'ko_KR' => '1',
-                'fr_FR' => '2',
-                'de_DE' => '3',
+                'ko_KR'          => '1',
+                'fr_FR'          => '2',
+                'de_DE'          => '3',
                 'zh_CN', 'zh_TW' => '4',
                 'es_ES', 'es_MX' => '6',
-                'ru_RU' => '7',
-                'pt_BR' => '8',
-                'it_IT' => '9',
-                default => '0', // en_US, uk_UA
+                'ru_RU'          => '7',
+                'pt_BR'          => '8',
+                'it_IT'          => '9',
+                default          => '0', // en_US, uk_UA
             };
 
             $data = $this->curlGet(sprintf('https://nether.wowhead.com/data/spell-names?dataEnv=%d&locale=%d', $env, $wowheadLocale));

--- a/style_gate_probe.php
+++ b/style_gate_probe.php
@@ -1,3 +1,0 @@
-<?php
-
-$probe=array('deliberate','style','violation');

--- a/style_gate_probe.php
+++ b/style_gate_probe.php
@@ -1,0 +1,3 @@
+<?php
+
+$probe=array('deliberate','style','violation');


### PR DESCRIPTION
Closes #3606

:robot: Cuts human review cost per MR: style never reaches review, MRs arrive pre-reviewed and verified, and follow-up work on open MRs is automated.

## Changes

- **`.github/workflows/php-cs-fixer.yml`** (new): `php-cs-fixer fix --dry-run --diff` on every `pull_request` (no branch filter, matching `js-tests.yml` so stacked MRs are covered). Lean job: setup-php 8.4 + cached `composer install --no-scripts --ignore-platform-reqs` — style checking never boots the app, so the Lua/Rust/DB setup from `php-ci-setup` is not needed.
- **Baseline fix**: `app/Service/Wowhead/WowheadTranslationService.php` had pre-existing style drift (the only file out of 3663) — fixed so the gate starts green.
- **`.claude/CLAUDE.md`**: new "Before declaring a MR ready for review" gate — (1) `code-review` self-review with findings resolved or justified in the MR body, (2) headless-browser before/after screenshots for UI-visible changes, (3) green CI with failures root-caused by the agent itself.
- **`.claude/skills/babysit-prs/SKILL.md`** (new): a `/loop`-able skill for a dedicated session that sweeps open agent MRs (`<issue>-<slug>` head branches): fixes red CI, resolves conflicts with master, addresses unresolved review threads (replying with `:robot:`), cleans up worktrees of merged MRs, and reports each pass. Hard rules: never merges/approves/closes, never touches deploy gates, skips branches with uncommitted work in their worktree.

## Verification

- The first commit includes `style_gate_probe.php` with a deliberate violation — the new workflow must **fail** on it. The follow-up commit removes the probe and the workflow must go **green**. (Check the two commit-level runs on this PR.)
- Local `php-cs-fixer fix --dry-run`: 0 of 3663 files fixable after the baseline fix.
- babysit-prs frontmatter parsed as valid YAML (`name` + single-line `description`), per the skill-frontmatter pitfalls note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Addendum (self-review findings, applied)

Running the new pre-handoff gate on this MR itself surfaced one finding: the composer cache step cached `~/.composer/cache/files`, which is not composer's cache dir on a fresh runner (`~/.cache/composer/files`) — so the cache never hit. Fixed by deriving the path via `composer config --global cache-files-dir`, both in the new workflow **and** in `.github/actions/php-ci-setup/action.yml`, where every PHP test shard of every PR had the same silently-empty cache.
