### PR TITLE
#3612 Seed CI caches from master pushes

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,9 +1,14 @@
 name: JavaScript Tests
 
 # No base-branch filter: stacked MRs (one stage targeting another stage's branch) must run the
-# same tests and build as MRs against master
+# same tests and build as MRs against master.
+# The push trigger seeds the branch-scoped npm cache from master; without it every new PR's
+# first run is fully cold (#3612).
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,9 +1,14 @@
 name: PHP CS Fixer
 
 # No base-branch filter: stacked MRs (one stage targeting another stage's branch) must pass the
-# same style gate as MRs against master
+# same style gate as MRs against master.
+# The push trigger exists to seed branch-scoped caches from master: PR branches can only inherit
+# caches created on master, so without it every new PR's first run is fully cold (#3612).
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,7 +1,13 @@
 name: PHPStan
 
+# The push trigger seeds branch-scoped caches from master (composer + Lua ext + cargo via
+# php-ci-setup — the same keys the php-tests shards restore); without it every new PR's first
+# run is fully cold (#3612).
 on:
   pull_request:
+    branches:
+      - master
+  push:
     branches:
       - master
 


### PR DESCRIPTION
Closes #3612

:robot: Follow-up to #3606, from an empirical check of the new php-cs-fixer workflow's cache behavior.

## Problem

GitHub Actions caches are branch-scoped: a PR branch can only inherit caches created **on master**. All CI workflows trigger on `pull_request` only, so a master-scoped cache never exists — verified by the job logs of PRs #3608 and #3611, where identical composer cache keys both logged `Cache not found`. Every new PR's first run pays a fully cold cache (composer download, Lua ext build, cargo build, npm install).

## Change

`push: branches: [master]` triggers on the three cheap workflows, so every merge to master seeds the shared caches:

| Workflow | Cost per merge | Seeds |
|---|---|---|
| `php-cs-fixer.yml` | ~1 min | composer files cache |
| `phpstan.yml` | ~3 min | composer + Lua ext + cargo (same keys the php-tests shards restore, via shared `php-ci-setup`) |
| `js-tests.yml` | ~45 s/job | npm cache |

`php-tests.yml` deliberately excluded: the 5-shard matrix is too expensive per merge, and everything it caches is already seeded by phpstan's master run.

## Verification

- All three YAMLs parse; trigger blocks validated (`pull_request` retained, `push` limited to master).
- This PR's own runs prove the `pull_request` path still works.
- The push path can only fire **after merge**: whoever merges should see three workflow runs on the master push (`gh run list --branch master`), and the next PR opened afterwards should log `Cache restored from key: composer-...` instead of `Cache not found`. (Follow-up session has this on its checklist.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)