### PR TITLE
#3594 Migrate away from unmaintained jquery-visible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
                 "hull.js": "^1.0.2",
                 "intro.js": "github:Wotuu/intro.js",
                 "ion-rangeslider": "^2.3.1",
-                "jquery-visible": "^1.2.0",
                 "js-cookie": "^3.0.8",
                 "lang.js": "^1.1.14",
                 "lazysizes": "^5.3.2",
@@ -3004,11 +3003,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
             "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg=="
-        },
-        "node_modules/jquery-visible": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/jquery-visible/-/jquery-visible-1.2.0.tgz",
-            "integrity": "sha512-lj6Xqy7GYEwTD1audFYdv7SrBM6z7icPXNvRpS4e15RXtDksjgU7YF7EKrsqF5rCUZA99OqF+d5H8BGdcwMr+w=="
         },
         "node_modules/js-cookie": {
             "version": "3.0.8",
@@ -6442,11 +6436,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
             "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg=="
-        },
-        "jquery-visible": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/jquery-visible/-/jquery-visible-1.2.0.tgz",
-            "integrity": "sha512-lj6Xqy7GYEwTD1audFYdv7SrBM6z7icPXNvRpS4e15RXtDksjgU7YF7EKrsqF5rCUZA99OqF+d5H8BGdcwMr+w=="
         },
         "js-cookie": {
             "version": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "hull.js": "^1.0.2",
         "intro.js": "github:Wotuu/intro.js",
         "ion-rangeslider": "^2.3.1",
-        "jquery-visible": "^1.2.0",
         "js-cookie": "^3.0.8",
         "lang.js": "^1.1.14",
         "lazysizes": "^5.3.2",

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -110,7 +110,6 @@ window.Noty = require('noty');
 window.Pickr = require('@simonwep/pickr');
 window.AntPath = require('leaflet-ant-path');
 window.Grapick = require('grapick');
-window.jqueryVisible = require('jquery-visible');
 window.simplebar = require('simplebar');
 window.Draggable = require('@shopify/draggable');
 require('bootstrap5-toggle/js/bootstrap5-toggle.jquery.min.js');

--- a/resources/assets/js/custom/inline/common/maps/killzonessidebar/rowelementkillzone.js
+++ b/resources/assets/js/custom/inline/common/maps/killzonessidebar/rowelementkillzone.js
@@ -364,7 +364,7 @@ class RowElementKillZone extends RowElement {
 
             // Make sure we can see the killzone in the sidebar
             let $killzone = $(`#map_killzonessidebar_killzone_${this.killZone.id}`);
-            if ($killzone.length > 0 && !$killzone.visible()) {
+            if ($killzone.length > 0 && !isElementFullyVisible($killzone[0])) {
                 $killzone[0].scrollIntoView({behavior: 'smooth'});
             }
 

--- a/resources/assets/js/custom/util.js
+++ b/resources/assets/js/custom/util.js
@@ -432,6 +432,19 @@ $.fn.isInViewport = function () {
 };
 
 /**
+ * Checks whether an element is entirely within the browser's visible viewport, both
+ * vertically and horizontally.
+ * @param element {Element}
+ * @returns {Boolean}
+ */
+function isElementFullyVisible(element) {
+    let rect = element.getBoundingClientRect();
+
+    return rect.top >= 0 && rect.left >= 0 &&
+        rect.bottom <= window.innerHeight && rect.right <= window.innerWidth;
+}
+
+/**
  * @see https://stackoverflow.com/a/1099670/771270
  * @returns {{}}
  */
@@ -473,5 +486,6 @@ if (typeof module !== 'undefined' && module.exports) {
         rotateLatLng,
         getCenteroid,
         getQueryParams,
+        isElementFullyVisible,
     };
 }

--- a/resources/assets/js/custom/util.test.js
+++ b/resources/assets/js/custom/util.test.js
@@ -16,6 +16,7 @@ const {
     rotateLatLng,
     getCenteroid,
     getQueryParams,
+    isElementFullyVisible,
 } = require('./util');
 
 describe('convertToSlug', () => {
@@ -210,5 +211,34 @@ describe('getQueryParams', () => {
     it('returns an empty object when there is no query string', () => {
         window.history.replaceState({}, '', '/');
         expect(getQueryParams()).toEqual({});
+    });
+});
+
+describe('isElementFullyVisible', () => {
+    const makeElement = (rect) => ({getBoundingClientRect: () => rect});
+
+    it('returns true when the element is fully within the viewport', () => {
+        let element = makeElement({top: 10, left: 10, bottom: 100, right: 100});
+        expect(isElementFullyVisible(element)).toBe(true);
+    });
+
+    it('returns false when the element is above the viewport', () => {
+        let element = makeElement({top: -10, left: 10, bottom: 100, right: 100});
+        expect(isElementFullyVisible(element)).toBe(false);
+    });
+
+    it('returns false when the element is below the viewport', () => {
+        let element = makeElement({top: 10, left: 10, bottom: window.innerHeight + 10, right: 100});
+        expect(isElementFullyVisible(element)).toBe(false);
+    });
+
+    it('returns false when the element is left of the viewport', () => {
+        let element = makeElement({top: 10, left: -10, bottom: 100, right: 100});
+        expect(isElementFullyVisible(element)).toBe(false);
+    });
+
+    it('returns false when the element is right of the viewport', () => {
+        let element = makeElement({top: 10, left: 10, bottom: 100, right: window.innerWidth + 10});
+        expect(isElementFullyVisible(element)).toBe(false);
     });
 });

--- a/resources/assets/js/jquery4-plugin-audit.test.js
+++ b/resources/assets/js/jquery4-plugin-audit.test.js
@@ -4,7 +4,9 @@
 // helpers, and one bundled plugin (`jquery-bar-rating`) still called one of
 // them (`$.isNumeric`), breaking pull lists in production. That plugin has since
 // been replaced by a self-owned widget and its `$.isNumeric` shim removed
-// (#3593); this audit remains to guard the OTHER bundled plugins below.
+// (#3593), and `jquery-visible` has since been replaced by a native
+// `getBoundingClientRect()` check and dropped entirely (#3594); this audit
+// remains to guard the OTHER bundled plugins below.
 //
 // A static grep audit for #3590 found no other bundled plugin calling a
 // removed jQuery-4 API. To actually close the loop the way #3589's test did -
@@ -21,23 +23,6 @@
 
 const $ = require('jquery');
 global.$ = global.jQuery = $;
-
-describe('jquery-visible (#3590)', () => {
-    afterEach(() => {
-        document.body.innerHTML = '';
-    });
-
-    test('visible_givenElementInDom_returnsBooleanWithoutThrowing', () => {
-        require('jquery-visible');
-        document.body.innerHTML = '<div id="killzone"></div>';
-
-        let result;
-        expect(() => {
-            result = $('#killzone').visible();
-        }).not.toThrow();
-        expect(typeof result).toBe('boolean');
-    });
-});
 
 describe('lightslider (#3590)', () => {
     afterEach(() => {


### PR DESCRIPTION
:robot: Closes #3594

## Summary
- `jquery-visible` is abandoned (last release 2017). Its only live usage was a full-viewport visibility check before smooth-scrolling a selected killzone row into view in the pull sidebar.
- Replaced with `isElementFullyVisible()`, a small native `getBoundingClientRect()`-based helper added to `util.js` next to the existing `$.fn.isInViewport` (same pattern, different semantics: full containment both vertically and horizontally, matching the default `jquery-visible` call this replaces).
- Dropped the `jquery-visible` require from `bootstrap.js` and the npm dependency from `package.json`/`package-lock.json`.
- Removed the `jquery-visible` coverage block from `jquery4-plugin-audit.test.js` (#3590) and refreshed its header comment.

## Test plan
- [x] `npx vitest run` — all 219 tests pass (including new `isElementFullyVisible` unit tests)
- [x] `npm run production` — asset build succeeds with the dependency removed
- [x] Verified in headless Chrome: opened a route with 37 pulls, clicked the last (off-screen) pull row, confirmed the sidebar smooth-scrolled it into view with no console/page errors