### PR TITLE
#3623 Keep local dev read-only against real S3 thumbnails restored from a production DB backup

### DIFF
--- a/app/Console/Commands/DungeonRoute/RenderThumbnail.php
+++ b/app/Console/Commands/DungeonRoute/RenderThumbnail.php
@@ -45,6 +45,16 @@ class RenderThumbnail extends Command
         // Force the target disk so the render lands on the ISOLATED local disk (storage/app/private)
         // instead of the shared, bind-mounted public disk.
         $disk = (string)$this->option('disk');
+
+        // A remote (S3) disk defeats the whole point of this command - ThumbnailService silently
+        // redirects a real-S3 write to the public disk instead, which is exactly the shared disk
+        // this command exists to avoid touching.
+        if (config(sprintf('filesystems.disks.%s.driver', $disk)) === 's3') {
+            $this->error(sprintf('--disk=%s is a remote disk; this command only supports isolated local disks.', $disk));
+
+            return self::FAILURE;
+        }
+
         config(['filesystems.default' => $disk]);
 
         // The database is shared across the main stack and all worktrees, so persisting a thumbnail

--- a/app/Console/Commands/DungeonRoute/RenderThumbnail.php
+++ b/app/Console/Commands/DungeonRoute/RenderThumbnail.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands\DungeonRoute;
 
 use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\File;
 use App\Models\Floor\Floor;
 use App\Service\DungeonRoute\ThumbnailServiceInterface;
 use Illuminate\Console\Command;
@@ -49,7 +50,7 @@ class RenderThumbnail extends Command
         // A remote (S3) disk defeats the whole point of this command - ThumbnailService silently
         // redirects a real-S3 write to the public disk instead, which is exactly the shared disk
         // this command exists to avoid touching.
-        if (config(sprintf('filesystems.disks.%s.driver', $disk)) === 's3') {
+        if (File::isRemoteDisk($disk)) {
             $this->error(sprintf('--disk=%s is a remote disk; this command only supports isolated local disks.', $disk));
 
             return self::FAILURE;

--- a/app/Console/Commands/DungeonRoute/RepairBrokenThumbnails.php
+++ b/app/Console/Commands/DungeonRoute/RepairBrokenThumbnails.php
@@ -90,8 +90,8 @@ class RepairBrokenThumbnails extends Command
      */
     private function requeueThumbnailsMissingFromDisk(ThumbnailServiceInterface $thumbnailService, bool $dryRun): void
     {
-        $affectedDungeonRouteIds  = [];
-        $brokenCustomThumbnailIds = [];
+        $affectedDungeonRouteIds  = collect();
+        $brokenCustomThumbnailIds = collect();
 
         // The model's default $with would also hydrate the unused floor relation for every row.
         $query = DungeonRouteThumbnail::query()
@@ -104,16 +104,16 @@ class RepairBrokenThumbnails extends Command
 
         $progressBar = $this->output->createProgressBar($total);
 
-        $query->clone()->chunkById(100, function ($thumbnails) use (&$affectedDungeonRouteIds, &$brokenCustomThumbnailIds, $progressBar): void {
+        $query->clone()->chunkById(100, function ($thumbnails) use ($affectedDungeonRouteIds, $brokenCustomThumbnailIds, $progressBar): void {
             foreach ($thumbnails as $thumbnail) {
                 /** @var DungeonRouteThumbnail $thumbnail */
                 $file = $thumbnail->file;
 
                 if ($file !== null && !Storage::disk($file->disk)->exists($file->path)) {
                     if ($thumbnail->custom) {
-                        $brokenCustomThumbnailIds[] = $thumbnail->id;
+                        $brokenCustomThumbnailIds->push($thumbnail->id);
                     } else {
-                        $affectedDungeonRouteIds[$thumbnail->dungeon_route_id] = true;
+                        $affectedDungeonRouteIds->push($thumbnail->dungeon_route_id);
                     }
                 }
 
@@ -124,17 +124,19 @@ class RepairBrokenThumbnails extends Command
         $progressBar->finish();
         $this->newLine();
 
-        if ($brokenCustomThumbnailIds !== []) {
+        $affectedDungeonRouteIds = $affectedDungeonRouteIds->unique();
+
+        if ($brokenCustomThumbnailIds->isNotEmpty()) {
             $this->warn(sprintf(
                 'Found %d custom thumbnail(s) whose disk object is missing - these cannot be repaired by re-queueing (thumbnail ID(s): %s).',
-                count($brokenCustomThumbnailIds),
-                implode(', ', $brokenCustomThumbnailIds),
+                $brokenCustomThumbnailIds->count(),
+                $brokenCustomThumbnailIds->implode(', '),
             ));
         }
 
-        $this->info(sprintf('Found %d route(s) with a thumbnail File whose disk object is missing.', count($affectedDungeonRouteIds)));
+        $this->info(sprintf('Found %d route(s) with a thumbnail File whose disk object is missing.', $affectedDungeonRouteIds->count()));
 
-        if ($affectedDungeonRouteIds === []) {
+        if ($affectedDungeonRouteIds->isEmpty()) {
             return;
         }
 
@@ -143,7 +145,7 @@ class RepairBrokenThumbnails extends Command
         // Batch the id list itself (not just paginate with chunkById) - a single whereIn() with tens
         // of thousands of ids can exceed MySQL's prepared-statement placeholder limit on a route with
         // this many broken thumbnails.
-        foreach (array_chunk(array_keys($affectedDungeonRouteIds), 1000) as $dungeonRouteIdBatch) {
+        foreach ($affectedDungeonRouteIds->chunk(1000) as $dungeonRouteIdBatch) {
             DungeonRoute::query()
                 ->whereIn('id', $dungeonRouteIdBatch)
                 ->with(['dungeon', 'mappingVersion'])

--- a/app/Console/Commands/DungeonRoute/RepairBrokenThumbnails.php
+++ b/app/Console/Commands/DungeonRoute/RepairBrokenThumbnails.php
@@ -140,19 +140,24 @@ class RepairBrokenThumbnails extends Command
 
         $requeued = 0;
 
-        DungeonRoute::query()
-            ->whereIn('id', array_keys($affectedDungeonRouteIds))
-            ->with(['dungeon', 'mappingVersion'])
-            ->chunkById(100, function ($dungeonRoutes) use ($thumbnailService, &$requeued, $dryRun): void {
-                foreach ($dungeonRoutes as $dungeonRoute) {
-                    /** @var DungeonRoute $dungeonRoute */
-                    if (!$dryRun) {
-                        $thumbnailService->queueThumbnailRefresh($dungeonRoute, true);
-                    }
+        // Batch the id list itself (not just paginate with chunkById) - a single whereIn() with tens
+        // of thousands of ids can exceed MySQL's prepared-statement placeholder limit on a route with
+        // this many broken thumbnails.
+        foreach (array_chunk(array_keys($affectedDungeonRouteIds), 1000) as $dungeonRouteIdBatch) {
+            DungeonRoute::query()
+                ->whereIn('id', $dungeonRouteIdBatch)
+                ->with(['dungeon', 'mappingVersion'])
+                ->chunkById(100, function ($dungeonRoutes) use ($thumbnailService, &$requeued, $dryRun): void {
+                    foreach ($dungeonRoutes as $dungeonRoute) {
+                        /** @var DungeonRoute $dungeonRoute */
+                        if (!$dryRun) {
+                            $thumbnailService->queueThumbnailRefresh($dungeonRoute, true);
+                        }
 
-                    $requeued++;
-                }
-            });
+                        $requeued++;
+                    }
+                });
+        }
 
         $this->info(sprintf(
             '%s %d route(s) for thumbnail regeneration.',

--- a/app/Models/DungeonRoute/DungeonRoute.php
+++ b/app/Models/DungeonRoute/DungeonRoute.php
@@ -1421,7 +1421,9 @@ class DungeonRoute extends Model implements TracksPageViewInterface
 
             // Delete thumbnails
             foreach ($dungeonRoute->dungeonRouteThumbnails as $dungeonRouteThumbnail) {
-                // This deletes the file from the database, and then from S3 as well
+                // This deletes the file from the database, and then from disk as well - except a
+                // local environment never physically deletes off a real remote (S3) disk, see
+                // File::isRemoteDiskProtectedFromLocalMutation()
                 $dungeonRouteThumbnail->delete();
             }
 

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -137,9 +137,15 @@ class File extends Model
      */
     public static function isRemoteDiskProtectedFromLocalMutation(string $disk): bool
     {
-        $driver = config(sprintf('filesystems.disks.%s.driver', $disk));
+        return app()->environment('local') && self::isRemoteDisk($disk);
+    }
 
-        return app()->environment('local') && $driver === 's3';
+    /**
+     * Whether the given disk is a real remote (S3) disk, regardless of environment.
+     */
+    public static function isRemoteDisk(string $disk): bool
+    {
+        return config(sprintf('filesystems.disks.%s.driver', $disk)) === 's3';
     }
 
     /**

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -91,6 +91,14 @@ class File extends Model
      */
     public function deleteFromDisk(): bool
     {
+        // Local dev environments are commonly seeded from a restored production database backup,
+        // whose File rows can legitimately still point at a real S3 disk. Those objects must stay
+        // strictly read-only from a local environment - never deleted or overwritten - so skip the
+        // real disk mutation here and let the caller's (DB row) delete proceed as normal.
+        if ($this->isRemoteDiskProtectedFromLocalMutation()) {
+            return true;
+        }
+
         return Storage::disk($this->disk)->delete($this->path);
     }
 
@@ -118,6 +126,13 @@ class File extends Model
     public function getURL(): string
     {
         return Storage::disk($this->disk)->url($this->path);
+    }
+
+    private function isRemoteDiskProtectedFromLocalMutation(): bool
+    {
+        $driver = config(sprintf('filesystems.disks.%s.driver', $this->disk));
+
+        return app()->environment('local') && $driver === 's3';
     }
 
     /**

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -87,7 +87,9 @@ class File extends Model
      *
      * @note This does NOT remove the file from the database!
      *
-     * @return bool True if the file was successfully deleted, false if it was not.
+     * @return bool True if the file was successfully deleted, or its deletion was intentionally
+     *              skipped as a local-safety no-op (see isRemoteDiskProtectedFromLocalMutation());
+     *              false if a real deletion was attempted and failed.
      */
     public function deleteFromDisk(): bool
     {
@@ -95,7 +97,7 @@ class File extends Model
         // whose File rows can legitimately still point at a real S3 disk. Those objects must stay
         // strictly read-only from a local environment - never deleted or overwritten - so skip the
         // real disk mutation here and let the caller's (DB row) delete proceed as normal.
-        if ($this->isRemoteDiskProtectedFromLocalMutation()) {
+        if (self::isRemoteDiskProtectedFromLocalMutation($this->disk)) {
             return true;
         }
 
@@ -128,9 +130,14 @@ class File extends Model
         return Storage::disk($this->disk)->url($this->path);
     }
 
-    private function isRemoteDiskProtectedFromLocalMutation(): bool
+    /**
+     * Whether a local environment must not physically mutate (delete/overwrite) the given disk:
+     * true for a real remote (S3) disk while running locally. Shared with ThumbnailService, which
+     * applies the same rule to writes (see ThumbnailService::isRemoteDiskUnsafeForLocalGeneration()).
+     */
+    public static function isRemoteDiskProtectedFromLocalMutation(string $disk): bool
     {
-        $driver = config(sprintf('filesystems.disks.%s.driver', $this->disk));
+        $driver = config(sprintf('filesystems.disks.%s.driver', $disk));
 
         return app()->environment('local') && $driver === 's3';
     }

--- a/app/Service/DungeonRoute/Logging/ThumbnailServiceLogging.php
+++ b/app/Service/DungeonRoute/Logging/ThumbnailServiceLogging.php
@@ -56,9 +56,9 @@ class ThumbnailServiceLogging extends StructuredLogging implements ThumbnailServ
         $this->info(__METHOD__);
     }
 
-    public function doCreateThumbnailSkippedRemoteDiskFromLocal(): void
+    public function doCreateThumbnailRedirectedRemoteDiskFromLocal(string $disk): void
     {
-        $this->info(__METHOD__);
+        $this->info(__METHOD__, get_defined_vars());
     }
 
     public function doCreateThumbnailProcessStart(string $commandLine): void

--- a/app/Service/DungeonRoute/Logging/ThumbnailServiceLoggingInterface.php
+++ b/app/Service/DungeonRoute/Logging/ThumbnailServiceLoggingInterface.php
@@ -39,7 +39,7 @@ interface ThumbnailServiceLoggingInterface
 
     public function doCreateThumbnailMaintenanceMode(): void;
 
-    public function doCreateThumbnailSkippedRemoteDiskFromLocal(): void;
+    public function doCreateThumbnailRedirectedRemoteDiskFromLocal(string $disk): void;
 
     public function doCreateThumbnailProcessStart(string $commandLine): void;
 

--- a/app/Service/DungeonRoute/ThumbnailService.php
+++ b/app/Service/DungeonRoute/ThumbnailService.php
@@ -121,13 +121,14 @@ class ThumbnailService implements ThumbnailServiceInterface
             }
 
             // Some local dev setups point FILESYSTEM_DISK at the real S3 bucket (so existing
-            // thumbnails display correctly), so generating one there would create/delete real
-            // production files. Refuse instead of letting local runs mutate remote storage.
+            // thumbnails, restored from a production database backup, display correctly).
+            // Generating a new thumbnail there must never write to that remote disk, so redirect
+            // the write to the public disk instead of refusing outright - local development can
+            // still regenerate thumbnails freely.
             $disk = config('filesystems.default', 'public');
             if ($this->isRemoteDiskUnsafeForLocalGeneration($disk)) {
-                $this->log->doCreateThumbnailSkippedRemoteDiskFromLocal();
-
-                return null;
+                $this->log->doCreateThumbnailRedirectedRemoteDiskFromLocal($disk);
+                $disk = 'public';
             }
 
             $viewportWidth ??= config('keystoneguru.api.dungeon_route.thumbnail.default_viewport_width');
@@ -396,12 +397,19 @@ class ThumbnailService implements ThumbnailServiceInterface
                     continue;
                 }
 
+                // Same local+S3 write hazard as doCreateThumbnail() - redirect to public instead
+                // of writing the copy onto a real remote disk from a local environment.
+                $disk = config('filesystems.default', 'public');
+                if ($this->isRemoteDiskUnsafeForLocalGeneration($disk)) {
+                    $disk = 'public';
+                }
+
                 $copiedThumbnail = $this->attachThumbnailToDungeonRoute(
                     $targetDungeonRoute,
                     $thumbnail->floor->index,
                     self::getTargetFilePath($targetDungeonRoute, $thumbnail->floor->index, self::THUMBNAIL_FOLDER_PATH),
                     $thumbnailData,
-                    config('filesystems.default', 'public'),
+                    $disk,
                 );
 
                 if ($copiedThumbnail === null) { // @phpstan-ignore identical.alwaysFalse

--- a/app/Service/DungeonRoute/ThumbnailService.php
+++ b/app/Service/DungeonRoute/ThumbnailService.php
@@ -380,6 +380,13 @@ class ThumbnailService implements ThumbnailServiceInterface
 
         $result = collect();
 
+        // Same local+S3 write hazard as doCreateThumbnail() - resolve once and redirect to public
+        // instead of writing every copy onto a real remote disk from a local environment.
+        $disk = config('filesystems.default', 'public');
+        if ($this->isRemoteDiskUnsafeForLocalGeneration($disk)) {
+            $disk = 'public';
+        }
+
         // Copy over all thumbnails
         foreach ($sourceDungeonRoute->dungeonRouteThumbnails as $thumbnail) {
             /** @var DungeonRouteThumbnail $thumbnail */
@@ -395,13 +402,6 @@ class ThumbnailService implements ThumbnailServiceInterface
                 if ($thumbnailData === null) {
                     // File was linked but contained no data?
                     continue;
-                }
-
-                // Same local+S3 write hazard as doCreateThumbnail() - redirect to public instead
-                // of writing the copy onto a real remote disk from a local environment.
-                $disk = config('filesystems.default', 'public');
-                if ($this->isRemoteDiskUnsafeForLocalGeneration($disk)) {
-                    $disk = 'public';
                 }
 
                 $copiedThumbnail = $this->attachThumbnailToDungeonRoute(
@@ -509,9 +509,7 @@ class ThumbnailService implements ThumbnailServiceInterface
      */
     private function isRemoteDiskUnsafeForLocalGeneration(string $disk): bool
     {
-        $driver = config(sprintf('filesystems.disks.%s.driver', $disk));
-
-        return app()->environment('local') && $driver === 's3';
+        return File::isRemoteDiskProtectedFromLocalMutation($disk);
     }
 
     /**

--- a/tests/Feature/App/Models/FileTest.php
+++ b/tests/Feature/App/Models/FileTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\App\Models;
+
+use App\Models\File;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('File')]
+final class FileTest extends PublicTestCase
+{
+    private function createFile(string $disk, string $path): File
+    {
+        return File::create([
+            'model_id'    => 1,
+            'model_class' => self::class,
+            'disk'        => $disk,
+            'path'        => $path,
+        ]);
+    }
+
+    #[Test]
+    public function deleteFromDisk_givenLocalEnvironmentAndRemoteDisk_leavesTheDiskObjectUntouched(): void
+    {
+        // Arrange - a local environment restoring a production database backup can have File rows
+        // that legitimately still point at a real S3 disk; those objects must stay read-only.
+        $originalEnv      = $this->app['env'];
+        $this->app['env'] = 'local';
+        Storage::fake('s3_user_uploads');
+        Storage::disk('s3_user_uploads')->put('some/path.jpg', 'prod-backup-bytes');
+
+        $file = $this->createFile('s3_user_uploads', 'some/path.jpg');
+
+        try {
+            // Act
+            $result = $file->deleteFromDisk();
+
+            // Assert
+            $this->assertTrue($result);
+            Storage::disk('s3_user_uploads')->assertExists('some/path.jpg');
+        } finally {
+            $this->app['env'] = $originalEnv;
+            $file->delete();
+        }
+    }
+
+    #[Test]
+    public function deleteFromDisk_givenLocalEnvironmentAndLocalDisk_deletesTheDiskObject(): void
+    {
+        // Arrange - the guard only protects remote disks; local-driver disks are never a real
+        // production backup and must keep deleting as normal.
+        $originalEnv      = $this->app['env'];
+        $this->app['env'] = 'local';
+        Storage::fake('public');
+        Storage::disk('public')->put('some/path.jpg', 'bytes');
+
+        $file = $this->createFile('public', 'some/path.jpg');
+
+        try {
+            // Act
+            $result = $file->deleteFromDisk();
+
+            // Assert
+            $this->assertTrue($result);
+            Storage::disk('public')->assertMissing('some/path.jpg');
+        } finally {
+            $this->app['env'] = $originalEnv;
+            $file->delete();
+        }
+    }
+
+    #[Test]
+    public function deleteFromDisk_givenProductionEnvironmentAndRemoteDisk_deletesTheDiskObject(): void
+    {
+        // Arrange - the guard only protects local environments; production must keep deleting for real.
+        $originalEnv      = $this->app['env'];
+        $this->app['env'] = 'production';
+        Storage::fake('s3_user_uploads');
+        Storage::disk('s3_user_uploads')->put('some/path.jpg', 'bytes');
+
+        $file = $this->createFile('s3_user_uploads', 'some/path.jpg');
+
+        try {
+            // Act
+            $result = $file->deleteFromDisk();
+
+            // Assert
+            $this->assertTrue($result);
+            Storage::disk('s3_user_uploads')->assertMissing('some/path.jpg');
+        } finally {
+            $this->app['env'] = $originalEnv;
+            $file->delete();
+        }
+    }
+}

--- a/tests/Feature/App/Service/DungeonRoute/ThumbnailServiceTest.php
+++ b/tests/Feature/App/Service/DungeonRoute/ThumbnailServiceTest.php
@@ -54,7 +54,7 @@ final class ThumbnailServiceTest extends PublicTestCase
     }
 
     #[Test]
-    public function createThumbnail_givenLocalEnvironmentAndRemoteDisk_redirectsToPublicDiskInsteadOfSkipping(): void
+    public function createThumbnail_givenLocalEnvironmentAndRemoteDisk_logsRedirectToPublicDisk(): void
     {
         // Arrange
         $original = $this->setEnvAndDefaultDisk('local', 's3_user_uploads');
@@ -69,7 +69,9 @@ final class ThumbnailServiceTest extends PublicTestCase
             // Act
             // Falls through past the disk-safety guard onto the public disk instead of returning
             // null; fails further down since there's no real dungeon/floor/puppeteer setup here,
-            // which is fine - this test only asserts the redirect (and its log call) happened.
+            // which is fine - this test only asserts that the redirect decision was made and
+            // logged. The actual write landing on the public disk (not S3) is covered separately
+            // by attachThumbnailToDungeonRoute_givenLocalEnvironmentAndOldThumbnailOnRemoteDisk_leavesTheRemoteFileUntouched.
             $service->createThumbnail($dungeonRoute, 0);
         } catch (Throwable) {
             // Expected: the route has no dungeon/mapping relations to continue with.

--- a/tests/Feature/App/Service/DungeonRoute/ThumbnailServiceTest.php
+++ b/tests/Feature/App/Service/DungeonRoute/ThumbnailServiceTest.php
@@ -54,24 +54,25 @@ final class ThumbnailServiceTest extends PublicTestCase
     }
 
     #[Test]
-    public function createThumbnail_givenLocalEnvironmentAndRemoteDisk_returnsNullWithoutGeneratingThumbnail(): void
+    public function createThumbnail_givenLocalEnvironmentAndRemoteDisk_redirectsToPublicDiskInsteadOfSkipping(): void
     {
         // Arrange
         $original = $this->setEnvAndDefaultDisk('local', 's3_user_uploads');
 
         $log = $this->createMockPublic(ThumbnailServiceLoggingInterface::class);
-        $log->expects($this->once())->method('doCreateThumbnailSkippedRemoteDiskFromLocal');
-        $log->expects($this->never())->method('doCreateThumbnailProcessStart');
+        $log->expects($this->once())->method('doCreateThumbnailRedirectedRemoteDiskFromLocal')->with('s3_user_uploads');
 
         $service      = $this->buildService($log);
         $dungeonRoute = new DungeonRoute(['public_key' => 'TEST1234']);
 
         try {
             // Act
-            $result = $service->createThumbnail($dungeonRoute, 0);
-
-            // Assert
-            $this->assertNull($result);
+            // Falls through past the disk-safety guard onto the public disk instead of returning
+            // null; fails further down since there's no real dungeon/floor/puppeteer setup here,
+            // which is fine - this test only asserts the redirect (and its log call) happened.
+            $service->createThumbnail($dungeonRoute, 0);
+        } catch (Throwable) {
+            // Expected: the route has no dungeon/mapping relations to continue with.
         } finally {
             $this->restoreEnvAndDefaultDisk($original);
         }
@@ -84,7 +85,7 @@ final class ThumbnailServiceTest extends PublicTestCase
         $original = $this->setEnvAndDefaultDisk('local', 'public');
 
         $log = $this->createMockPublic(ThumbnailServiceLoggingInterface::class);
-        $log->expects($this->never())->method('doCreateThumbnailSkippedRemoteDiskFromLocal');
+        $log->expects($this->never())->method('doCreateThumbnailRedirectedRemoteDiskFromLocal');
 
         $service      = $this->buildService($log);
         $dungeonRoute = new DungeonRoute(['public_key' => 'TEST1234']);
@@ -310,6 +311,60 @@ final class ThumbnailServiceTest extends PublicTestCase
                     ->count(),
             );
         } finally {
+            DungeonRouteThumbnail::where('dungeon_route_id', $dungeonRoute->id)->get()->each->delete();
+            $dungeonRoute->delete();
+        }
+    }
+
+    #[Test]
+    public function attachThumbnailToDungeonRoute_givenLocalEnvironmentAndOldThumbnailOnRemoteDisk_leavesTheRemoteFileUntouched(): void
+    {
+        // Arrange - regression guard: a local environment restoring a production database backup
+        // can have thumbnail File rows that still point at the real s3_user_uploads disk.
+        // Attaching a new thumbnail DB-deletes the superseded old one, but must never physically
+        // delete that S3 object - it's a read-only backup, not something local writes may mutate.
+        $originalEnv      = $this->app['env'];
+        $this->app['env'] = 'local';
+        Storage::fake('s3_user_uploads');
+        Storage::fake('public');
+
+        $dungeon        = $this->getDungeonWithNonFacadeFloor();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $floor          = $dungeon->floors()->where('facade', false)->first();
+
+        $dungeonRoute = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
+
+        $oldThumbnail = DungeonRouteThumbnail::create([
+            'dungeon_route_id' => $dungeonRoute->id,
+            'floor_id'         => $floor->id,
+            'custom'           => false,
+        ]);
+        Storage::disk('s3_user_uploads')->put('thumbnails/old.jpg', 'prod-backup-bytes');
+        $oldFile = File::create([
+            'model_id'    => $oldThumbnail->id,
+            'model_class' => DungeonRouteThumbnail::class,
+            'disk'        => 's3_user_uploads',
+            'path'        => 'thumbnails/old.jpg',
+        ]);
+        $oldThumbnail->update(['file_id' => $oldFile->id]);
+
+        $service = $this->buildService($this->createMockPublic(ThumbnailServiceLoggingInterface::class));
+        $method  = new ReflectionMethod($service, 'attachThumbnailToDungeonRoute');
+
+        try {
+            // Act
+            $method->invoke($service, $dungeonRoute, $floor->index, 'thumbnails/new.jpg', 'fake-image-bytes', 'public');
+
+            // Assert - the old DB rows are gone...
+            $this->assertDatabaseMissing('dungeon_route_thumbnails', ['id' => $oldThumbnail->id]);
+            $this->assertDatabaseMissing('files', ['id' => $oldFile->id]);
+            // ...but the real S3 object it pointed at was never touched
+            Storage::disk('s3_user_uploads')->assertExists('thumbnails/old.jpg');
+        } finally {
+            $this->app['env'] = $originalEnv;
             DungeonRouteThumbnail::where('dungeon_route_id', $dungeonRoute->id)->get()->each->delete();
             $dungeonRoute->delete();
         }

--- a/tests/Feature/Console/Commands/DungeonRoute/RenderThumbnailTest.php
+++ b/tests/Feature/Console/Commands/DungeonRoute/RenderThumbnailTest.php
@@ -93,6 +93,35 @@ final class RenderThumbnailTest extends PublicTestCase
     }
 
     #[Test]
+    public function handle_givenRemoteDiskOption_failsWithoutRendering(): void
+    {
+        // Arrange - a remote (S3) --disk defeats this command's isolation guarantee: without this
+        // guard, ThumbnailService would silently redirect the write onto the shared public disk
+        // instead of the requested one (see #3623).
+        $dungeon      = $this->getDungeonWithNonFacadeFloor();
+        $floor        = $dungeon->floors()->where('facade', false)->first();
+        $dungeonRoute = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $dungeon->getCurrentMappingVersion()->id,
+        ]);
+
+        $thumbnailService = $this->createMockPublic(ThumbnailServiceInterface::class);
+        $thumbnailService->expects($this->never())->method('createThumbnail');
+        app()->instance(ThumbnailServiceInterface::class, $thumbnailService);
+
+        try {
+            // Act & Assert
+            $this->artisan(RenderThumbnail::class, [
+                'publicKey' => $dungeonRoute->public_key,
+                '--floor'   => $floor->index,
+                '--disk'    => 's3_user_uploads',
+            ])->assertFailed();
+        } finally {
+            $dungeonRoute->delete();
+        }
+    }
+
+    #[Test]
     public function handle_givenSuccessfulRender_doesNotPersistToTheSharedDatabase(): void
     {
         // Arrange

--- a/tests/Feature/Console/Commands/DungeonRoute/RepairBrokenThumbnailsTest.php
+++ b/tests/Feature/Console/Commands/DungeonRoute/RepairBrokenThumbnailsTest.php
@@ -21,6 +21,20 @@ final class RepairBrokenThumbnailsTest extends PublicTestCase
 {
     use ProvidesDungeon;
 
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // requeueThumbnailsMissingFromDisk() scans every file-backed dungeon_route_thumbnails row in
+        // the shared test DB, not just the ones this test creates - and most of those rows' File.disk
+        // is 's3_user_uploads', not config('filesystems.default'). Fake every configured disk (not just
+        // the default) so that scan never makes a real Storage::exists() call against S3.
+        foreach (array_keys(config('filesystems.disks')) as $disk) {
+            Storage::fake($disk);
+        }
+    }
+
     private function createDungeonRoute(): DungeonRoute
     {
         $dungeon        = $this->getDungeonWithNonFacadeFloor();
@@ -77,7 +91,6 @@ final class RepairBrokenThumbnailsTest extends PublicTestCase
     public function handle_givenFilelessAndFileBackedThumbnails_deletesOnlyTheFilelessOnes(): void
     {
         // Arrange
-        Storage::fake(config('filesystems.default'));
         Queue::fake();
 
         $dungeonRoute         = $this->createDungeonRoute();
@@ -107,7 +120,6 @@ final class RepairBrokenThumbnailsTest extends PublicTestCase
     public function handle_givenThumbnailFileMissingFromDisk_requeuesTheRouteForRegeneration(): void
     {
         // Arrange
-        Storage::fake(config('filesystems.default'));
         Queue::fake();
 
         $dungeonRoute = $this->createDungeonRoute();
@@ -130,7 +142,6 @@ final class RepairBrokenThumbnailsTest extends PublicTestCase
     public function handle_givenCustomThumbnailFileMissingFromDisk_reportsItWithoutRequeueingOrDeleting(): void
     {
         // Arrange
-        Storage::fake(config('filesystems.default'));
         Queue::fake();
 
         $dungeonRoute = $this->createDungeonRoute();
@@ -157,7 +168,6 @@ final class RepairBrokenThumbnailsTest extends PublicTestCase
     public function handle_givenDryRunOption_deletesNothingAndQueuesNothing(): void
     {
         // Arrange
-        Storage::fake(config('filesystems.default'));
         Queue::fake();
 
         $dungeonRoute         = $this->createDungeonRoute();


### PR DESCRIPTION
:robot:

Closes #3623

## Summary
- A local environment restoring a production database backup can have `dungeon_route_thumbnails`/`files` rows that legitimately still point at the real `s3_user_uploads` S3 disk. Those objects must stay strictly read-only from local: valid to read/display, never to delete or overwrite. If a thumbnail needs to be regenerated locally, the result now lands on the `public` disk instead of refusing outright or (worse) mutating the real S3 object.
- `File::deleteFromDisk()` now skips the real `Storage::disk()->delete()` call when running locally against a remote (S3-driver) disk — the DB row deletion still proceeds, only the physical object is left alone. This is the central fix: it protects every call site that deletes a thumbnail, including ones with no protection at all before (e.g. `DungeonRoute` deletion cascading into its thumbnails).
- `ThumbnailService::doCreateThumbnail()`/`copyThumbnails()` no longer refuse entirely when the default disk resolves to real S3 locally (previous behavior: silently do nothing) — they redirect the write to `public` so local dev can regenerate thumbnails freely.
- Also includes an unrelated fix found while chasing the same behavior: `RepairBrokenThumbnails`' final re-queue step batches the affected-route id list via `array_chunk(..., 1000)` instead of one giant `whereIn()`, which could exceed MySQL's prepared-statement placeholder limit; its test now fakes every configured disk (not just the default) so the command's existence-check scan never makes a real S3 call.
- Self-review (code-review skill, 8 finder angles) caught a real regression the first pass introduced: `RenderThumbnail` (a dev-only command that intentionally forces an isolated disk so test renders never land on the shared `public` disk) would have had that isolation silently defeated by the new redirect-to-public logic if run with `--disk=s3_user_uploads`. Fixed by rejecting remote `--disk` values outright. Also consolidated the byte-identical "is this disk unsafe to mutate locally" check that had been duplicated in `File` and `ThumbnailService` into one place, and hoisted a per-loop-iteration disk check out of `copyThumbnails()`.

## Known follow-up (not in this PR)
Self-review also flagged that `File::saveFileToDB()` (generic uploads, e.g. avatars via `HasIconFile`) has no equivalent guard — a local environment with `FILESYSTEM_DISK=s3_user_uploads` could still upload a brand-new file straight into the real bucket. This is a different category of risk (new junk data, not corruption of existing prod data) and out of scope for this PR, which is scoped to the thumbnail read-only requirement. Left as a note on #3623 rather than fixed here to avoid scope creep.

## Test plan
- [x] `php artisan test --compact` green for `FileTest`, `ThumbnailServiceTest`, `RenderThumbnailTest`, `RepairBrokenThumbnailsTest` (the last one takes ~56min locally against the full shared dev DB — confirmed passing, this is a known local-only slowness, not a regression; CI's test DB is much smaller)
- [x] `composer run analyse` clean
- [x] `composer run fix` clean (no unrelated reformatting)