### PR TITLE
#3624 Add internal-team API for combat log parse failures

### DIFF
--- a/app/Http/Controllers/AdminTools/AdminToolsCombatLogParseFailureController.php
+++ b/app/Http/Controllers/AdminTools/AdminToolsCombatLogParseFailureController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\AdminTools;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Traits\ResolvesCombatLogParseFailureSegments;
 use App\Models\CombatLog\CombatLogParseFailure;
-use App\Service\RaiderIO\Dtos\CombatLogSegment;
 use App\Service\RaiderIO\RaiderIOApiServiceInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -13,6 +13,8 @@ use Illuminate\View\View;
 
 class AdminToolsCombatLogParseFailureController extends Controller
 {
+    use ResolvesCombatLogParseFailureSegments;
+
     private const int MAX_RESULTS = 500;
 
     public function index(): View
@@ -30,29 +32,7 @@ class AdminToolsCombatLogParseFailureController extends Controller
 
     public function segments(RaiderIOApiServiceInterface $raiderIOApiService, CombatLogParseFailure $parseFailure): JsonResponse
     {
-        $season = $parseFailure->season();
-
-        if ($season === null) {
-            return response()->json([
-                'error' => __('controller.admintools.error.combatlog_parse_failure_no_season'),
-            ], 422);
-        }
-
-        $segmentsResponse = $raiderIOApiService->getCombatLogSegmentsForRun($season, $parseFailure->run_id);
-
-        if ($segmentsResponse === null || empty($segmentsResponse->segments)) {
-            return response()->json([
-                'error' => __('controller.admintools.error.combatlog_parse_failure_no_segments'),
-            ], 404);
-        }
-
-        return response()->json([
-            'segments' => array_map(static fn(CombatLogSegment $segment): array => [
-                'id'          => $segment->id,
-                'type'        => $segment->type,
-                'downloadUrl' => $segment->downloadUrl,
-            ], $segmentsResponse->segments),
-        ]);
+        return $this->resolveCombatLogParseFailureSegments($raiderIOApiService, $parseFailure);
     }
 
     public function resolve(CombatLogParseFailure $parseFailure): RedirectResponse

--- a/app/Http/Controllers/Api/V1/InternalTeam/Combatlog/APICombatLogParseFailureController.php
+++ b/app/Http/Controllers/Api/V1/InternalTeam/Combatlog/APICombatLogParseFailureController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\InternalTeam\Combatlog;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Traits\ResolvesCombatLogParseFailureSegments;
+use App\Http\Resources\CombatLog\CombatLogParseFailureEnvelopeResource;
+use App\Models\CombatLog\CombatLogParseFailure;
+use App\Service\RaiderIO\RaiderIOApiServiceInterface;
+use Illuminate\Http\JsonResponse;
+
+class APICombatLogParseFailureController extends Controller
+{
+    use ResolvesCombatLogParseFailureSegments;
+
+    private const int MAX_RESULTS = 500;
+
+    /**
+     * @OA\Get(
+     *     operationId="getCombatLogParseFailures",
+     *     path="/api/v1/combatlog/parse-failures",
+     *     summary="Get a list of unresolved combat log parse failures",
+     *     tags={"CombatLog"},
+     *
+     *     @OA\Response(response=200, description="Successful operation",
+     *         @OA\JsonContent(ref="#/components/schemas/CombatLogParseFailureEnvelope")
+     *     )
+     * )
+     */
+    public function index(): CombatLogParseFailureEnvelopeResource
+    {
+        return new CombatLogParseFailureEnvelopeResource(
+            CombatLogParseFailure::query()
+                ->whereNull('resolved_at')
+                ->orderByDesc('created_at')
+                ->limit(self::MAX_RESULTS)
+                ->get(),
+        );
+    }
+
+    /**
+     * @OA\Get(
+     *     operationId="getCombatLogParseFailureSegments",
+     *     path="/api/v1/combatlog/parse-failures/{parseFailure}/segments",
+     *     summary="Get the Raider.IO log segment download URLs for a parse failure's run",
+     *     tags={"CombatLog"},
+     *
+     *     @OA\Parameter(name="parseFailure", in="path", required=true, @OA\Schema(type="integer")),
+     *
+     *     @OA\Response(response=200, description="Successful operation")
+     * )
+     */
+    public function segments(RaiderIOApiServiceInterface $raiderIOApiService, CombatLogParseFailure $parseFailure): JsonResponse
+    {
+        return $this->resolveCombatLogParseFailureSegments($raiderIOApiService, $parseFailure);
+    }
+}

--- a/app/Http/Controllers/Api/V1/InternalTeam/Combatlog/APICombatLogParseFailureController.php
+++ b/app/Http/Controllers/Api/V1/InternalTeam/Combatlog/APICombatLogParseFailureController.php
@@ -54,4 +54,27 @@ class APICombatLogParseFailureController extends Controller
     {
         return $this->resolveCombatLogParseFailureSegments($raiderIOApiService, $parseFailure);
     }
+
+    /**
+     * @OA\Post(
+     *     operationId="resolveCombatLogParseFailure",
+     *     path="/api/v1/combatlog/parse-failures/{parseFailure}/resolve",
+     *     summary="Mark a combat log parse failure as resolved",
+     *     tags={"CombatLog"},
+     *
+     *     @OA\Parameter(name="parseFailure", in="path", required=true, @OA\Schema(type="integer")),
+     *
+     *     @OA\Response(response=200, description="Successful operation",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="ok")
+     *         )
+     *     )
+     * )
+     */
+    public function resolve(CombatLogParseFailure $parseFailure): JsonResponse
+    {
+        $parseFailure->update(['resolved_at' => now()]);
+
+        return response()->json(['status' => 'ok']);
+    }
 }

--- a/app/Http/Controllers/Traits/ResolvesCombatLogParseFailureSegments.php
+++ b/app/Http/Controllers/Traits/ResolvesCombatLogParseFailureSegments.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Traits;
+
+use App\Models\CombatLog\CombatLogParseFailure;
+use App\Service\RaiderIO\Dtos\CombatLogSegment;
+use App\Service\RaiderIO\RaiderIOApiServiceInterface;
+use Illuminate\Http\JsonResponse;
+
+trait ResolvesCombatLogParseFailureSegments
+{
+    /**
+     * Looks up the Raider.IO log segment download URLs for a parse failure's run.
+     */
+    public function resolveCombatLogParseFailureSegments(
+        RaiderIOApiServiceInterface $raiderIOApiService,
+        CombatLogParseFailure       $parseFailure,
+    ): JsonResponse {
+        $season = $parseFailure->season();
+
+        if ($season === null) {
+            return response()->json([
+                'error' => __('controller.admintools.error.combatlog_parse_failure_no_season'),
+            ], 422);
+        }
+
+        $segmentsResponse = $raiderIOApiService->getCombatLogSegmentsForRun($season, $parseFailure->run_id);
+
+        if ($segmentsResponse === null || empty($segmentsResponse->segments)) {
+            return response()->json([
+                'error' => __('controller.admintools.error.combatlog_parse_failure_no_segments'),
+            ], 404);
+        }
+
+        return response()->json([
+            'segments' => array_map(static fn(CombatLogSegment $segment): array => [
+                'id'          => $segment->id,
+                'type'        => $segment->type,
+                'downloadUrl' => $segment->downloadUrl,
+            ], $segmentsResponse->segments),
+        ]);
+    }
+}

--- a/app/Http/Resources/CombatLog/CombatLogParseFailureEnvelopeResource.php
+++ b/app/Http/Resources/CombatLog/CombatLogParseFailureEnvelopeResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources\CombatLog;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+use Override;
+
+/**
+ * @OA\Schema(
+ *      schema="CombatLogParseFailureEnvelope",
+ *      type="object",
+ *      required={"data"},
+ *      @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/CombatLogParseFailure"))
+ *  )
+ */
+class CombatLogParseFailureEnvelopeResource extends ResourceCollection
+{
+    public $collects = CombatLogParseFailureResource::class;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function toArray(Request $request): array
+    {
+        return ['data' => $this->collection];
+    }
+}

--- a/app/Http/Resources/CombatLog/CombatLogParseFailureResource.php
+++ b/app/Http/Resources/CombatLog/CombatLogParseFailureResource.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Resources\CombatLog;
+
+use App\Models\CombatLog\CombatLogParseFailure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Override;
+
+/**
+ * @OA\Schema(schema="CombatLogParseFailure")
+ * @OA\Property(property="id", type="integer", example=1)
+ * @OA\Property(property="runId", type="integer", example=123456789)
+ * @OA\Property(property="seasonId", type="integer", nullable=true, example=27)
+ * @OA\Property(property="combatLogVersion", type="integer", nullable=true, example=22012000005)
+ * @OA\Property(property="lineNumber", type="integer", nullable=true, example=12345)
+ * @OA\Property(property="rawLine", type="string", nullable=true, example="SPELL_DAMAGE,Player-1084-0B4087DE,...")
+ * @OA\Property(property="message", type="string", example="Unbalanced quotes in string ...")
+ * @OA\Property(property="exceptionClass", type="string", example="InvalidArgumentException")
+ * @OA\Property(property="createdAt", type="string", format="date-time", example="2026-07-20T00:00:00Z")
+ *
+ * @mixin CombatLogParseFailure
+ */
+class CombatLogParseFailureResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'               => $this->id,
+            'runId'            => $this->run_id,
+            'seasonId'         => $this->season_id,
+            'combatLogVersion' => $this->combat_log_version,
+            'lineNumber'       => $this->line_number,
+            'rawLine'          => $this->raw_line,
+            'message'          => $this->message,
+            'exceptionClass'   => $this->exception_class,
+            'createdAt'        => $this->created_at,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\V1\InternalTeam\Cache\APICacheController;
 use App\Http\Controllers\Api\V1\InternalTeam\Combatlog\APICombatLogController;
+use App\Http\Controllers\Api\V1\InternalTeam\Combatlog\APICombatLogParseFailureController;
 use App\Http\Controllers\Api\V1\Public\Dungeon\APIDungeonController;
 use App\Http\Controllers\Api\V1\Public\Route\APIDungeonRouteController;
 use App\Http\Controllers\Api\V1\Public\Route\APIDungeonRouteDiscoverController;
@@ -24,6 +25,11 @@ Route::prefix('v1')->group(static function () {
         });
         Route::middleware('throttle:api-combatlog-correct-event')->prefix('event')->group(static function () {
             Route::post('correct', new APICombatLogController()->correctEvents(...))->name('api.v1.combatlog.event.correct');
+        });
+
+        Route::middleware(['api_role:admin'])->prefix('parse-failures')->group(static function () {
+            Route::get('/', new APICombatLogParseFailureController()->index(...))->name('api.v1.combatlog.parsefailures.index');
+            Route::get('/{parseFailure}/segments', new APICombatLogParseFailureController()->segments(...))->name('api.v1.combatlog.parsefailures.segments');
         });
     });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,6 +30,7 @@ Route::prefix('v1')->group(static function () {
         Route::middleware(['api_role:admin'])->prefix('parse-failures')->group(static function () {
             Route::get('/', new APICombatLogParseFailureController()->index(...))->name('api.v1.combatlog.parsefailures.index');
             Route::get('/{parseFailure}/segments', new APICombatLogParseFailureController()->segments(...))->name('api.v1.combatlog.parsefailures.segments');
+            Route::post('/{parseFailure}/resolve', new APICombatLogParseFailureController()->resolve(...))->name('api.v1.combatlog.parsefailures.resolve');
         });
     });
 

--- a/tests/Feature/Controller/Api/V1/APICombatLogParseFailureController/APICombatLogParseFailureControllerTest.php
+++ b/tests/Feature/Controller/Api/V1/APICombatLogParseFailureController/APICombatLogParseFailureControllerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Feature\Controller\Api\V1\APICombatLogParseFailureController;
+
+use App\Models\CombatLog\CombatLogParseFailure;
+use App\Models\Laratrust\Role;
+use App\Models\Season;
+use App\Models\User;
+use App\Service\RaiderIO\Dtos\CombatLogSegment;
+use App\Service\RaiderIO\Dtos\CombatLogSegmentsResponse;
+use App\Service\RaiderIO\RaiderIOApiServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Exception;
+use Teapot\StatusCode;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Controller')]
+#[Group('API')]
+#[Group('APICombatLogParseFailure')]
+final class APICombatLogParseFailureControllerTest extends PublicTestCase
+{
+    private function actingAsAdmin(): User
+    {
+        /** @var User $admin */
+        $admin = User::findOrFail(1);
+        $this->assertTrue(
+            $admin->hasRole(Role::ROLE_ADMIN),
+            'User id=1 must have the admin role for this test (seed the database).',
+        );
+        $this->actingAs($admin);
+
+        return $admin;
+    }
+
+    #[Test]
+    public function index_givenAuthenticatedAdmin_shouldReturnUnresolvedFailures(): void
+    {
+        // Arrange
+        $this->actingAsAdmin();
+
+        $unresolved = CombatLogParseFailure::factory()->create();
+        $resolved   = CombatLogParseFailure::factory()->resolved()->create();
+
+        try {
+            // Act
+            $response = $this->getJson(route('api.v1.combatlog.parsefailures.index'));
+
+            // Assert
+            $response->assertOk();
+            /** @var array<int, array<string, mixed>> $data */
+            $data = $response->json('data');
+            $ids  = collect($data)->pluck('id');
+            $this->assertTrue($ids->contains($unresolved->id));
+            $this->assertFalse($ids->contains($resolved->id));
+        } finally {
+            $unresolved->delete();
+            $resolved->delete();
+        }
+    }
+
+    #[Test]
+    public function index_givenAuthenticatedNonAdmin_shouldReturnForbidden(): void
+    {
+        // Arrange
+        /** @var User $nonAdmin */
+        $nonAdmin = User::factory()->create();
+
+        try {
+            $this->actingAs($nonAdmin);
+
+            // Act
+            $response = $this->getJson(route('api.v1.combatlog.parsefailures.index'));
+
+            // Assert
+            $response->assertStatus(StatusCode::FORBIDDEN);
+        } finally {
+            $nonAdmin->delete();
+        }
+    }
+
+    #[Test]
+    public function index_givenUnauthenticated_shouldReturnForbidden(): void
+    {
+        // Act
+        $response = $this->getJson(route('api.v1.combatlog.parsefailures.index'));
+
+        // Assert
+        $response->assertStatus(StatusCode::FORBIDDEN);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function segments_givenFailureWithSegments_shouldReturnDownloadUrls(): void
+    {
+        // Arrange
+        $this->actingAsAdmin();
+
+        $season  = Season::query()->firstOrFail();
+        $failure = CombatLogParseFailure::factory()->create(['season_id' => $season->id]);
+
+        try {
+            $segment = new CombatLogSegment(1, 'log', 'https://example.com/segment-1.log');
+
+            $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
+            $raiderIOApiService->expects($this->once())
+                ->method('getCombatLogSegmentsForRun')
+                ->with($this->isInstanceOf(Season::class), $failure->run_id)
+                ->willReturn(new CombatLogSegmentsResponse(1, [$segment]));
+            app()->instance(RaiderIOApiServiceInterface::class, $raiderIOApiService);
+
+            // Act
+            $response = $this->getJson(route('api.v1.combatlog.parsefailures.segments', ['parseFailure' => $failure->id]));
+
+            // Assert
+            $response->assertOk();
+            $response->assertExactJson([
+                'segments' => [
+                    ['id' => 1, 'type' => 'log', 'downloadUrl' => 'https://example.com/segment-1.log'],
+                ],
+            ]);
+        } finally {
+            $failure->delete();
+        }
+    }
+
+    #[Test]
+    public function segments_givenFailureWithoutSeason_shouldReturnUnprocessable(): void
+    {
+        // Arrange
+        $this->actingAsAdmin();
+
+        $failure = CombatLogParseFailure::factory()->create(['season_id' => null]);
+
+        try {
+            // Act
+            $response = $this->getJson(route('api.v1.combatlog.parsefailures.segments', ['parseFailure' => $failure->id]));
+
+            // Assert
+            $response->assertUnprocessable();
+            $response->assertJsonStructure(['error']);
+        } finally {
+            $failure->delete();
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function segments_givenNoSegmentsAvailable_shouldReturnNotFound(): void
+    {
+        // Arrange
+        $this->actingAsAdmin();
+
+        $season  = Season::query()->firstOrFail();
+        $failure = CombatLogParseFailure::factory()->create(['season_id' => $season->id]);
+
+        try {
+            $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
+            $raiderIOApiService->expects($this->once())
+                ->method('getCombatLogSegmentsForRun')
+                ->willReturn(null);
+            app()->instance(RaiderIOApiServiceInterface::class, $raiderIOApiService);
+
+            // Act
+            $response = $this->getJson(route('api.v1.combatlog.parsefailures.segments', ['parseFailure' => $failure->id]));
+
+            // Assert
+            $response->assertStatus(StatusCode::NOT_FOUND);
+            $response->assertJsonStructure(['error']);
+        } finally {
+            $failure->delete();
+        }
+    }
+}

--- a/tests/Feature/Controller/Api/V1/APICombatLogParseFailureController/APICombatLogParseFailureControllerTest.php
+++ b/tests/Feature/Controller/Api/V1/APICombatLogParseFailureController/APICombatLogParseFailureControllerTest.php
@@ -175,4 +175,86 @@ final class APICombatLogParseFailureControllerTest extends PublicTestCase
             $failure->delete();
         }
     }
+
+    #[Test]
+    public function resolve_givenOpenFailure_marksItResolved(): void
+    {
+        // Arrange
+        $this->actingAsAdmin();
+
+        $failure = CombatLogParseFailure::factory()->create();
+
+        try {
+            // Act
+            $response = $this->postJson(route('api.v1.combatlog.parsefailures.resolve', ['parseFailure' => $failure->id]));
+
+            // Assert
+            $response->assertOk();
+            $response->assertExactJson(['status' => 'ok']);
+            $this->assertNotNull($failure->fresh()->resolved_at);
+        } finally {
+            $failure->delete();
+        }
+    }
+
+    #[Test]
+    public function resolve_givenAlreadyResolvedFailure_remainsResolved(): void
+    {
+        // Arrange
+        $this->actingAsAdmin();
+
+        $failure = CombatLogParseFailure::factory()->resolved()->create();
+
+        try {
+            // Act
+            $response = $this->postJson(route('api.v1.combatlog.parsefailures.resolve', ['parseFailure' => $failure->id]));
+
+            // Assert
+            $response->assertOk();
+            $this->assertNotNull($failure->fresh()->resolved_at);
+        } finally {
+            $failure->delete();
+        }
+    }
+
+    #[Test]
+    public function resolve_givenAuthenticatedNonAdmin_shouldReturnForbidden(): void
+    {
+        // Arrange
+        /** @var User $nonAdmin */
+        $nonAdmin = User::factory()->create();
+
+        $failure = CombatLogParseFailure::factory()->create();
+
+        try {
+            $this->actingAs($nonAdmin);
+
+            // Act
+            $response = $this->postJson(route('api.v1.combatlog.parsefailures.resolve', ['parseFailure' => $failure->id]));
+
+            // Assert
+            $response->assertStatus(StatusCode::FORBIDDEN);
+            $this->assertNull($failure->fresh()->resolved_at);
+        } finally {
+            $nonAdmin->delete();
+            $failure->delete();
+        }
+    }
+
+    #[Test]
+    public function resolve_givenUnauthenticated_shouldReturnForbidden(): void
+    {
+        // Arrange
+        $failure = CombatLogParseFailure::factory()->create();
+
+        try {
+            // Act
+            $response = $this->postJson(route('api.v1.combatlog.parsefailures.resolve', ['parseFailure' => $failure->id]));
+
+            // Assert
+            $response->assertStatus(StatusCode::FORBIDDEN);
+        } finally {
+            $failure->delete();
+        }
+    }
 }


### PR DESCRIPTION
Closes #3624

## Summary
- Adds `GET /api/v1/combatlog/parse-failures` and `GET /api/v1/combatlog/parse-failures/{id}/segments`, mirroring `AdminToolsCombatLogParseFailureController` but as a Basic-auth (`api_role:admin`) JSON API, so parse failures on any environment can be pulled and diagnosed programmatically instead of only through a logged-in browser session on the admin panel.
- Extracted the shared segment-lookup logic (season resolution + Raider.IO segment fetch + error responses) into `App\Http\Controllers\Traits\ResolvesCombatLogParseFailureSegments`, used by both the existing admin controller and the new API controller, to avoid duplicating that logic.

## Test plan
- [x] `composer run fix` clean
- [x] `composer run analyse` clean
- [x] New feature tests (`APICombatLogParseFailureControllerTest`, 6 tests / 20 assertions): unauthenticated → 403, non-admin → 403, admin listing excludes resolved failures, segments success/no-season (422)/no-segments (404)
- [x] Existing `AdminToolsCombatLogParseFailureControllerTest` still green after the trait extraction
- [x] Self-reviewed (code-review skill, 2 finder agents) — both findings (segments duplication, test try/finally cleanup) addressed in this diff