### PR TITLE
#3629 Generalize mapping:assignmdtids to run for all dungeons

### DIFF
--- a/app/Console/Commands/Mapping/AssignMDTIDs.php
+++ b/app/Console/Commands/Mapping/AssignMDTIDs.php
@@ -15,75 +15,91 @@ class AssignMDTIDs extends Command
      *
      * @var string
      */
-    protected $signature = 'mapping:assignmdtids';
+    protected $signature = 'mapping:assignmdtids {--dungeon= : Only process this dungeon (by key); omit to process every dungeon}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = "Assigns MDT IDs to a mapping that doesn't have them yet.";
+    protected $description = "Assigns MDT IDs to enemies that don't have one yet, so they stay identifiable across a mapping version upgrade.";
 
     /**
      * Execute the console command.
      */
     public function handle(): int
     {
+        $dungeonKey = $this->option('dungeon');
+
+        $mappingVersionsQuery = MappingVersion::with(['enemies', 'dungeon']);
+        if ($dungeonKey !== null) {
+            $dungeon = Dungeon::where('key', $dungeonKey)->firstOrFail();
+            $mappingVersionsQuery->where('dungeon_id', $dungeon->id);
+        }
+
         /** @var Collection<int, MappingVersion> $mappingVersions */
-        $mappingVersions = MappingVersion::with([
-            'enemies',
-            'dungeon',
-        ])->get();
+        $mappingVersions = $mappingVersionsQuery->get();
 
-        $dungeonWhitelist = [
-            Dungeon::RAID_THE_EYE,
-            Dungeon::RAID_SERPENTSHRINE_CAVERN,
-            //            Dungeon::DUNGEON_MOGU_SHAN_PALACE,
-            //            Dungeon::DUNGEON_SCARLET_HALLS_MOP,
-            //            Dungeon::DUNGEON_SCARLET_MONASTERY_MOP,
-            //            Dungeon::DUNGEON_SCHOLOMANCE_MOP,
-            //            Dungeon::DUNGEON_SHADO_PAN_MONASTERY,
-            //            Dungeon::DUNGEON_SIEGE_OF_NIUZAO_TEMPLE,
-            //            Dungeon::DUNGEON_STORMSTOUT_BREWERY,
-            //            Dungeon::DUNGEON_TEMPLE_OF_THE_JADE_SERPENT,
-        ];
+        $rows       = [];
+        $totalCount = 0;
 
-        $count = 0;
         foreach ($mappingVersions as $mappingVersion) {
-            if (empty($dungeonWhitelist) || in_array($mappingVersion->dungeon->key, $dungeonWhitelist)) { // @phpstan-ignore empty.variable
-                $enemies = $mappingVersion->enemies()
-                    ->orderBy('npc_id')
-                    ->orderBy('id')
-                    ->get();
+            if ($mappingVersion->dungeon === null) {
+                // Dangling mapping_version (no foreign keys in this app) - nothing sensible to report
+                continue;
+            }
 
-                if ($enemies->isEmpty()) {
-                    // We don't care for empty mapping versions
-                    continue;
+            $enemies = $mappingVersion->enemies()
+                ->orderBy('npc_id')
+                ->orderBy('id')
+                ->get();
+
+            $missingBefore = $enemies->whereNull('mdt_id')->count();
+            if ($missingBefore === 0) {
+                // Nothing to do for this mapping version
+                continue;
+            }
+
+            $assigned = 0;
+            foreach ($enemies->groupBy('npc_id') as $enemiesByNpcId) {
+                /** @var Collection<int, Enemy> $enemiesByNpcId */
+                $enemiesByNpcId = $enemiesByNpcId->sortBy('id');
+                $maxId          = 0;
+                // Determine the max ID first, then assign the max ID to any NPCs that don't have an ID yet
+                foreach ($enemiesByNpcId as $enemy) {
+                    if ($enemy->mdt_id > 0 && $maxId <= $enemy->mdt_id) {
+                        $maxId = $enemy->mdt_id;
+                    }
                 }
 
-                foreach ($enemies->groupBy('npc_id') as $npcId => $enemiesByNpcId) {
-                    /** @var Collection<int, Enemy> $enemiesByNpcId */
-                    $enemiesByNpcId = $enemiesByNpcId->sortBy('id');
-                    $maxId          = 0;
-                    // Determine the max ID first, then assign the max ID to any NPCs that don't have an ID yet
-                    foreach ($enemiesByNpcId as $enemy) {
-                        if ($enemy->mdt_id > 0 && $maxId <= $enemy->mdt_id) {
-                            $maxId = $enemy->mdt_id;
-                        }
-                    }
-
-                    foreach ($enemiesByNpcId as $enemy) {
-                        if (empty($enemy->mdt_id)) {
-                            // Increment first, then write
-                            $enemy->update(['mdt_id' => ++$maxId]);
-                            $count++;
-                        }
+                foreach ($enemiesByNpcId as $enemy) {
+                    if (empty($enemy->mdt_id)) {
+                        // Increment first, then write
+                        $enemy->update(['mdt_id' => ++$maxId]);
+                        $assigned++;
                     }
                 }
             }
+
+            $totalCount += $assigned;
+            $rows[] = [
+                __($mappingVersion->dungeon->name),
+                $mappingVersion->dungeon_id,
+                $mappingVersion->id,
+                $mappingVersion->version,
+                $missingBefore,
+                $missingBefore - $assigned,
+            ];
         }
 
-        $this->info(sprintf('Assigned MDT IDs to %d enemies', $count));
+        if (count($rows) > 0) {
+            $this->table(
+                ['Dungeon', 'Dungeon ID', 'Mapping Version ID', 'Version', 'Missing before', 'Missing after'],
+                $rows,
+            );
+        }
+
+        $this->info(sprintf('Assigned MDT IDs to %d enemies', $totalCount));
 
         return 0;
     }

--- a/tests/Feature/Console/Commands/Mapping/AssignMDTIDsTest.php
+++ b/tests/Feature/Console/Commands/Mapping/AssignMDTIDsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Console\Commands\Mapping;
+
+use App\Console\Commands\Mapping\AssignMDTIDs;
+use App\Models\Enemy;
+use App\Models\Faction;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Traits\ProvidesDungeon;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Console')]
+#[Group('Mapping')]
+final class AssignMDTIDsTest extends PublicTestCase
+{
+    use ProvidesDungeon;
+
+    #[Test]
+    public function handle_givenEnemiesMissingMdtId_assignsIncrementingIdsPerNpc(): void
+    {
+        // Arrange
+        $dungeon        = $this->getDungeonWithNonFacadeFloor();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $floorId        = $dungeon->floors()->where('facade', false)->value('id');
+
+        $npcId          = 999999001;
+        $existingEnemy  = $this->createEnemy($mappingVersion->id, $floorId, $npcId, 5);
+        $missingEnemyA  = $this->createEnemy($mappingVersion->id, $floorId, $npcId, null);
+        $missingEnemyB  = $this->createEnemy($mappingVersion->id, $floorId, $npcId, null);
+        $otherNpcEnemy  = $this->createEnemy($mappingVersion->id, $floorId, 999999002, null);
+
+        try {
+            // Act
+            $this->artisan(AssignMDTIDs::class, ['--dungeon' => $dungeon->key])->assertSuccessful();
+
+            // Assert - the two enemies missing an mdt_id for npc 999999001 get incrementing
+            // values continuing from the existing max (5), the pre-existing one is untouched,
+            // and a different npc_id gets its own independent sequence starting at 1
+            $this->assertEquals(5, $existingEnemy->fresh()->mdt_id);
+            $this->assertEquals(6, $missingEnemyA->fresh()->mdt_id);
+            $this->assertEquals(7, $missingEnemyB->fresh()->mdt_id);
+            $this->assertEquals(1, $otherNpcEnemy->fresh()->mdt_id);
+        } finally {
+            Enemy::whereIn('id', [$existingEnemy->id, $missingEnemyA->id, $missingEnemyB->id, $otherNpcEnemy->id])->delete();
+        }
+    }
+
+    #[Test]
+    public function handle_givenDungeonOption_onlyProcessesThatDungeon(): void
+    {
+        // Arrange
+        $dungeons = $this->getTwoDungeonsWithNonFacadeFloors();
+        [$targetDungeon, $otherDungeon] = $dungeons;
+
+        $targetMappingVersion = $targetDungeon->getCurrentMappingVersion();
+        $targetFloorId        = $targetDungeon->floors()->where('facade', false)->value('id');
+        $otherMappingVersion  = $otherDungeon->getCurrentMappingVersion();
+        $otherFloorId         = $otherDungeon->floors()->where('facade', false)->value('id');
+
+        $targetEnemy = $this->createEnemy($targetMappingVersion->id, $targetFloorId, 999999003, null);
+        $otherEnemy  = $this->createEnemy($otherMappingVersion->id, $otherFloorId, 999999004, null);
+
+        try {
+            // Act
+            $this->artisan(AssignMDTIDs::class, ['--dungeon' => $targetDungeon->key])->assertSuccessful();
+
+            // Assert
+            $this->assertNotNull($targetEnemy->fresh()->mdt_id);
+            $this->assertNull($otherEnemy->fresh()->mdt_id);
+        } finally {
+            Enemy::whereIn('id', [$targetEnemy->id, $otherEnemy->id])->delete();
+        }
+    }
+
+    private function createEnemy(int $mappingVersionId, int $floorId, int $npcId, ?int $mdtId): Enemy
+    {
+        return Enemy::create([
+            'mapping_version_id' => $mappingVersionId,
+            'floor_id'           => $floorId,
+            'npc_id'             => $npcId,
+            'mdt_id'             => $mdtId,
+            'faction'            => Faction::ALL[Faction::FACTION_UNSPECIFIED],
+            'lat'                => -100.0,
+            'lng'                => 100.0,
+        ]);
+    }
+
+    /**
+     * @return array{0: \App\Models\Dungeon, 1: \App\Models\Dungeon}
+     */
+    private function getTwoDungeonsWithNonFacadeFloors(): array
+    {
+        $first  = $this->getDungeonWithNonFacadeFloor();
+        $second = $this->getDungeonWithNonFacadeFloor(fn($query) => $query->where('id', '!=', $first->id));
+
+        return [$first, $second];
+    }
+}

--- a/tests/Feature/Console/Commands/Mapping/AssignMDTIDsTest.php
+++ b/tests/Feature/Console/Commands/Mapping/AssignMDTIDsTest.php
@@ -24,11 +24,11 @@ final class AssignMDTIDsTest extends PublicTestCase
         $mappingVersion = $dungeon->getCurrentMappingVersion();
         $floorId        = $dungeon->floors()->where('facade', false)->value('id');
 
-        $npcId          = 999999001;
-        $existingEnemy  = $this->createEnemy($mappingVersion->id, $floorId, $npcId, 5);
-        $missingEnemyA  = $this->createEnemy($mappingVersion->id, $floorId, $npcId, null);
-        $missingEnemyB  = $this->createEnemy($mappingVersion->id, $floorId, $npcId, null);
-        $otherNpcEnemy  = $this->createEnemy($mappingVersion->id, $floorId, 999999002, null);
+        $npcId         = 999999001;
+        $existingEnemy = $this->createEnemy($mappingVersion->id, $floorId, $npcId, 5);
+        $missingEnemyA = $this->createEnemy($mappingVersion->id, $floorId, $npcId, null);
+        $missingEnemyB = $this->createEnemy($mappingVersion->id, $floorId, $npcId, null);
+        $otherNpcEnemy = $this->createEnemy($mappingVersion->id, $floorId, 999999002, null);
 
         try {
             // Act
@@ -50,7 +50,7 @@ final class AssignMDTIDsTest extends PublicTestCase
     public function handle_givenDungeonOption_onlyProcessesThatDungeon(): void
     {
         // Arrange
-        $dungeons = $this->getTwoDungeonsWithNonFacadeFloors();
+        $dungeons                       = $this->getTwoDungeonsWithNonFacadeFloors();
         [$targetDungeon, $otherDungeon] = $dungeons;
 
         $targetMappingVersion = $targetDungeon->getCurrentMappingVersion();


### PR DESCRIPTION
:robot:

Closes #3629

## Summary

`app/Console/Commands/Mapping/AssignMDTIDs.php` hardcoded a `$dungeonWhitelist` array of one or
two active dungeons with ~8 more commented out, so despite its own description ("Assigns MDT IDs
to a mapping that doesn't have them yet") it only ever processed whichever entries happened to be
uncommented - requiring a source edit + rerun to cover a different dungeon.

- Replaced the whitelist with an optional `--dungeon=<key>` option (omit to process every
  dungeon), matching the existing `{--dungeon=}` convention used by `mdt:importnpcs`.
- Added a per-dungeon/mapping-version table reporting missing-before/missing-after `mdt_id` counts,
  so a run's effect is visible without a manual query afterward.
- Added feature test coverage (`AssignMDTIDsTest`): incrementing assignment continues from the
  existing max per `npc_id`, and `--dungeon` correctly scopes the run.

The assignment approach itself (group by `npc_id` within a mapping version, assign incrementing
values to enemies missing one) is unchanged - confirmed via `app/Service/MDT/Import/PullImporter.php`
that `mdt_id` is only ever read/matched against already-persisted values during an MDT string
import, never auto-derived, so this heuristic doesn't need to reproduce MDT's own clone numbering -
it only needs to be internally stable and unique per NPC within a mapping version (the actual need,
surfaced while fixing #1431/#1453's mapping-version-upgrade identity resolution).

## Before/after

Ran the improved command against every dungeon in the dev DB:

- **Before**: 259 enemies across 36 dungeon+mapping-version combinations had `mdt_id IS NULL`
  (two much larger outliers, Naxxramas and Karazhan Crypts (SoD) at ~250-350 each, had already been
  hand-fixed locally before this PR using the old whitelist mechanism).
- **After**: 0 remaining anywhere - every dungeon/mapping-version resolved fully in one run.

## Test plan

- [x] `composer run analyse` clean
- [x] `composer run fix` clean (no unrelated reformats)
- [x] `AssignMDTIDsTest` passes (2 tests, 8 assertions)
- [x] Ran `php artisan mapping:assignmdtids` against all dungeons in the dev DB; verified
      `Enemy::whereNull('mdt_id')->count()` dropped to 0