### PR TITLE
#3632 Register combat log version 12.0.7

### DIFF
--- a/.claude/skills/combatlog-parse-failure-triage/SKILL.md
+++ b/.claude/skills/combatlog-parse-failure-triage/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: combatlog-parse-failure-triage
+description: Operational runbook to find, download, and reproduce real Staging/Production combat log parse failures before fixing them — the internal-team API endpoints, how to pull a failure's real Raider.IO log segments, the gzip/docker-cp reproduction recipe, and the safety checklist for shipping a fix. Use when triaging CombatLogParseFailure rows, chasing a "combat log parses are failing" report, or verifying a combatlog-parsing-internals fix against real production data. Pairs with combatlog-parsing-internals (how the parser itself works) and create-github-issue / worktree-docker (how to turn a diagnosis into a shipped MR).
+---
+
+# Combat Log Parse-Failure Triage
+
+Runbook for turning "some combat logs are failing to parse in Staging/Production" into a diagnosed,
+locally-reproduced, tested fix. Read `combatlog-parsing-internals` first if you haven't — this skill
+assumes you know the parser architecture and focuses on the *operational* loop: find → download →
+reproduce → fix → verify → ship.
+
+## 0. Credentials — get them fresh, never persist them
+
+The parse-failure API lives behind `api_role:admin` (HTTP Basic auth, Laratrust). **This repo is
+public** — never write a real username/password into a skill file, a commit, a script, or anywhere
+else that gets checked in. Each session, ask Wotuu for a current Staging (or Production, if that's
+what's being triaged) admin API service-account credential, use it only for that session, and remind
+him to rotate/delete it once you're done. Treat it like any other secret: environment/conversation
+only, never `.env`, never a file under version control (see `feedback_no_env_file` in memory).
+
+## 1. List unresolved failures
+
+```
+GET https://staging.keystone.guru/api/v1/combatlog/parse-failures
+```
+
+(swap the host for `keystone.guru` / whatever the production host is, for a prod triage). HTTP Basic
+auth, `api_role:admin`. Returns up to 500 unresolved rows (`whereNull('resolved_at')`, newest first) —
+`app/Http/Controllers/Api/V1/InternalTeam/Combatlog/APICombatLogParseFailureController.php`. Each row:
+
+```json
+{
+  "id": 651, "runId": 40653052, "seasonId": 17, "combatLogVersion": 22012000005,
+  "lineNumber": 8, "rawLine": "...", "message": "...", "exceptionClass": "Exception",
+  "createdAt": "..."
+}
+```
+
+```bash
+curl -s -u 'user@example.com:PASSWORD' \
+  'https://staging.keystone.guru/api/v1/combatlog/parse-failures' -o parse_failures.json
+```
+
+The response is wrapped in a Resource envelope — the rows are under `.data`, not the top level:
+
+```python
+import json
+rows = json.load(open('parse_failures.json'))['data']
+```
+
+**Cluster first, don't fix the first row you see.** Group by `message` (strip the specific numeric ID
+out of it) to find the dominant failure mode before picking a repro target — one root cause is
+typically 90%+ of the rows. `exception_class` + the stable part of `message` is the cluster key.
+
+## 2. Get a failing run's log segments
+
+```
+GET https://staging.keystone.guru/api/v1/combatlog/parse-failures/{id}/segments
+```
+
+Reuses `RaiderIOApiServiceInterface::getCombatLogSegmentsForRun()` (the same logic the admin panel
+and the ingestion job use) to return **presigned S3 URLs, valid ~5 minutes** — download promptly,
+don't cache the URLs. Response:
+
+```json
+{"segments": [{"id": 1, "type": "trash", "downloadUrl": "https://s3..."}, ...]}
+```
+
+If it 404s with `combatlog_parse_failure_no_segments`, or 422s with `..._no_season`, that run's
+segments aren't available (Raider.IO expired them, or the failure predates season resolution) — pick
+a different row from the cluster.
+
+## 3. Download and decompress
+
+The URLs point at `.txt.gz` bodies. `curl -s <url> -o file.gz` saves the raw gzip bytes (no
+`Content-Encoding` transparent decoding without `--compressed`) — either add `--compressed`, or just
+`gunzip` afterward:
+
+```bash
+mkdir -p run_<runId> && cd run_<runId>
+python3 -c "
+import json, subprocess
+segs = json.load(open('../segments_<id>.json'))['segments']
+for s in segs:
+    subprocess.run(['curl', '-s', s['downloadUrl'], '-o', f\"{s['id']:02d}_{s['type']}.txt.gz\"], check=True)
+"
+gunzip -k *.gz   # -k keeps the .gz too, harmless
+```
+
+A single M+ run typically has 5-10 segments (trash/boss alternating), 10K-200K lines each.
+
+## 4. Reproduce locally against the real segment
+
+Use a worktree's `app` container (create one with `sh/worktree.sh create <issue>-<slug>` per
+`worktree-docker` if you don't have one open already). Copy the decompressed `.txt` files in and
+re-parse them with `CombatLogService::parseCombatLogToEvents()` — **read-only, no DB writes**, the
+right tool for reproduction (see `combatlog-parsing-internals`):
+
+```bash
+docker cp run_<runId>/. <container>:/tmp/run_<runId>/
+docker exec <container> php artisan tinker --execute '
+$service = app(\App\Service\CombatLog\CombatLogServiceInterface::class);
+$files = glob("/tmp/run_<runId>/*.txt");
+sort($files);
+$total = 0; $fail = 0;
+foreach ($files as $f) {
+    try {
+        $events = $service->parseCombatLogToEvents($f);
+        $total += $events->count();
+        echo basename($f) . ": OK " . $events->count() . " events\n";
+    } catch (\Throwable $e) {
+        $fail++;
+        echo basename($f) . ": FAIL " . get_class($e) . ": " . $e->getMessage() . "\n";
+    }
+}
+echo "TOTAL: $total events, $fail failures\n";
+'
+```
+
+This baseline-reproduces the exact failure from the API row. Once you have a candidate fix, edit the
+file **in the worktree** (bind-mounted into the container — no rebuild needed) and re-run the same
+command: a clean fix turns every segment `OK`.
+
+**Do this against at least two distinct failing runs before trusting a fix** — one run passing could
+be luck; the point is confidence that the fix generalizes, not just that it satisfies one sample line.
+
+## 5. Diagnose, don't just patch the symptom
+
+- Read the exception message/class carefully — `"Invalid parameter count ... wanted X-Y, got Z"`
+  tells you exactly how many fields were present vs expected; compare the failing `raw_line` against a
+  known-good line of the same event type to see what's structurally different (missing trailing
+  fields → truncation; different field *count* patterns across failures of the same message → genuine
+  truncation, not a clean version/format difference — different failures missing a *consistent* set of
+  fields → an actual structural difference worth its own handler).
+- For "unknown combat log version" failures specifically, follow the registration procedure in
+  `combatlog-parsing-internals` — including its safety-check step (confirm the `default =>` fallback
+  pattern still holds) before touching the registry.
+- Don't assume all failures in a session share one cause. Re-cluster after fixing the dominant one —
+  a secondary cluster (different `exceptionClass`/message shape) needs its own separate diagnosis and,
+  usually, its own issue/MR rather than being bundled in.
+
+## 6. Ship it
+
+Follow the project's normal worktree/issue workflow (`worktree-docker`, `create-github-issue`,
+root `CLAUDE.md`'s git conventions):
+
+1. If the diagnosis is out of scope of whatever issue you were originally working (e.g. you were
+   building the triage API and found an unrelated parser bug), **file a new issue** rather than
+   scope-creeping the current MR — reference the real Staging data (failure counts, example raw
+   lines, which runs you reproduced against) in the issue body so it's resumable cold.
+2. `sh/worktree.sh create <new-issue>-<slug>`, make the fix there, add/update a unit test that
+   encodes the specific case (see `combatlog-parsing-internals`'s test file pointers).
+3. Re-run the real-data reproduction from step 4 against the properly-committed fix (not just your
+   throwaway edit) as a final sanity check — cheap insurance against a copy-paste slip between
+   experimentation and the real commit.
+4. `composer run fix` / `composer run analyse`, run the affected test file plus the broader
+   `--group=CombatLog` suite for regressions, commit, `sh/worktree.sh push`, open an MR with
+   `Closes #<issue>` and a summary that includes the real-data verification numbers (segments/events
+   tested, zero-failures claim) — that's the evidence a human reviewer needs to trust a parser change
+   without re-deriving it themselves.
+
+## Resolving `CombatLogParseFailure` rows
+
+There is currently **no API endpoint** to mark a failure resolved — only the admin panel
+(`POST /admin/tools/combatlog/parse-failures/{id}/resolve`, session-auth only). Marking rows resolved
+is a production data mutation and doesn't by itself confirm anything was actually fixed (the failing
+run doesn't get automatically reprocessed) — **don't do this without being explicitly told to**, and
+even then only after the fix has actually shipped, not just been merged. This mirrors the project's
+general "no unattended prod actions without a human saying so in the current conversation" norm.
+
+## Toward full autonomy — what's still a manual gate
+
+The user's end goal is running this loop unattended as new failures show up. What's still manual
+today, and why it's not automated yet:
+
+- **Credentials**: no durable secret storage in-repo (by design — public repo). A fully autonomous
+  loop needs its own credential-provisioning story (e.g. a scheduled agent with its own vaulted
+  secret) that doesn't yet exist here.
+- **Shipping**: MRs still go through normal review per this repo's `CLAUDE.md` — nothing here should
+  bypass that, even if the agent is confident in a fix.
+- **Resolving failure rows**: a production data mutation; keep requiring an explicit go-ahead per the
+  paragraph above until there's a clearer signal (e.g. automatic reprocessing) that a resolve is safe
+  to make unattended.
+
+If/when the user wants to close these gaps (e.g. via `/schedule` or a cron-based agent), that's a
+separate, explicit setup step — don't wire it up implicitly while just doing triage.
+
+## Gotchas
+
+- `docker exec -T <container> ...` can fail with `unknown shorthand flag: 'T'` on some hosts' docker
+  CLI — drop `-T` for direct `docker exec` (unlike `docker compose exec -T`, which is fine and used
+  throughout this repo's `CLAUDE.md`).
+- The scratchpad directory isn't guaranteed to already exist — `mkdir -p` it before first use.
+- Presigned segment URLs expire in ~5 minutes — download all segments for a run in one batch
+  immediately after fetching `/segments`, don't fetch-then-pause.
+- A single M+ run's segments can total 50-200K+ lines / tens of MB gzipped — fine to download, just
+  don't be surprised by the size.

--- a/.claude/skills/combatlog-parsing-internals/SKILL.md
+++ b/.claude/skills/combatlog-parsing-internals/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: combatlog-parsing-internals
+description: How a single raw WoW combat log line becomes a parsed event object — CombatLogEntry's dispatch logic, the BaseEvent/SpecialEvent/CombatEvent class hierarchy, the CombatLogVersion registry and its getVersionLong() formula, the builder-with-default-fallback pattern every version-gated class uses, and the safe procedure for registering a new WoW client build. Use when a combat log line fails to parse, when a new WoW patch needs its version registered, or when touching CombatLogEntry/CombatLogVersion/SpecialEvent/Prefix/Suffix classes. For what happens AFTER a line becomes an event (NPC/spell mapping extraction, NPC Compendium) use combatlog-data-pipeline instead. For the operational runbook to find/download/reproduce real failing logs from Staging, use combatlog-parse-failure-triage.
+---
+
+# Combat Log Parsing Internals
+
+How `app/Logic/CombatLog/*` turns one raw text line into a typed event object. This is the layer
+*upstream* of the data-extraction pipeline described in `combatlog-data-pipeline` — everything here
+happens before any NPC/spell mapping data is touched.
+
+## Entry point: `CombatLogEntry::parseEvent()`
+
+`app/Logic/CombatLog/CombatLogEntry.php`. Given one raw line plus the *currently active*
+`$combatLogVersion` (an `int`, threaded through by the caller — see below):
+
+1. Regex-splits the line into a timestamp and the rest (`m/d[/Y] H:i:s.v[-tz]  EVENT_NAME,params...`).
+   Lines that don't match and aren't in the hardcoded `RAW_EVENT_IGNORE` allowlist throw
+   `InvalidArgumentException`.
+2. Parses the timestamp against `DATE_FORMATS` (13 timezone offset variants); remembers which format
+   matched last time (`self::$previousDateFormat`, a **static**, process-lifetime cache) and tries
+   that one first.
+3. Splits the rest into `$eventName` + `$parameters` via `CombatLogStringParser::parseCombatLogLine`
+   (handles quoted/bracketed/nested WoW log syntax).
+4. Dispatches on `$eventName`, in this order:
+   - In `SpecialEvent::SPECIAL_EVENT_ALL` → `SpecialEvent::createFromEventName(...)`.
+   - Else `count($parameters) > 23` → `new AdvancedCombatLogEvent(...)` (advanced combat logging
+     adds a fixed block of extra fields; 23 is the max param count for a *non*-advanced line per
+     [wowpedia](https://wowpedia.fandom.com/wiki/COMBAT_LOG_EVENT)).
+   - Else → `new CombatLogEvent(...)` (basic/non-advanced).
+
+## Class hierarchy
+
+```
+BaseEvent (combatLogVersion, timestamp, eventName, rawEvent)
+├── SpecialEvent (abstract)                 — one-off events: COMBAT_LOG_VERSION, RIO_LOG_VERSION,
+│     │                                        ZONE_CHANGE, ENCOUNTER_START/END, COMBATANT_INFO, ...
+│     └── (one concrete class per SPECIAL_EVENT_* constant, or built via a *Builder for
+│          version-varying ones — see below)
+└── CombatEvents\CombatLogEvent              — the generic SWING_/SPELL_/RANGE_* combat line,
+      └── CombatEvents\AdvancedCombatLogEvent   made of a Prefix + a Suffix + GenericData(+AdvancedData)
+```
+
+`CombatLogEvent`/`AdvancedCombatLogEvent` build themselves from three independently-versioned pieces:
+`Prefix::createFromEventName()` (dispatches on event-name *prefix*, e.g. `SWING_`, `SPELL_`) + a
+matching `Suffix::createFromEventName()` (dispatches on event-name *suffix*, e.g. `_DAMAGE`,
+`_AURA_APPLIED`) + `GenericDataBuilder::create()` (ignores version entirely — one shape for all
+versions) +, for advanced events, `AdvancedDataBuilder::create()`.
+
+## `CombatLogVersion` — the version registry
+
+`app/Logic/CombatLog/CombatLogVersion.php`. A flat list of known client builds as `int` constants
+(`RETAIL_12_0_5 = 22_012_000_005`) plus two lookup tables keyed by those constants:
+
+- `RETAIL_ALL` — retail only, value = a small sequential "revision number".
+- `ALL` — retail + classic + SoD + TBC, value = a small sequential "revision number" (separate
+  numbering from `RETAIL_ALL`).
+
+**The revision numbers in these tables are not used as a schema-revision switch anywhere in the
+codebase.** They only exist so `PollCombatLogRunsCommand` can find "the newest known version" via
+`array_key_last(RETAIL_ALL)` for Raider.IO polling eligibility. Don't confuse them with
+`getVersionLong()` below, which is what everything else actually keys on.
+
+### The `getVersionLong()` formula
+
+`SpecialEvents\Traits\ComputesVersionLong` (mixed into `CombatLogVersion` and `RioLogVersion`, the
+two special events that carry version info):
+
+```
+getVersionLong() = getVersionNumber() * 1_000_000_000 + major * 1_000_000 + minor * 1_000 + patch
+```
+
+where `getVersionNumber()` is the small int at the start of the `COMBAT_LOG_VERSION`/`RIO_LOG_VERSION`
+line (e.g. `22`) and `major.minor.patch` comes from the line's `BUILD_VERSION` field (e.g. `12.0.7`).
+So `COMBAT_LOG_VERSION,22,...,BUILD_VERSION,12.0.7,...` → `22_012_000_007`. **This** is the value that
+gets registered as a `CombatLogVersion::RETAIL_*` constant and looked up in `ALL`/`RETAIL_ALL`.
+
+### What `ALL`/`RETAIL_ALL` actually gates
+
+Exactly two places, both an allowlist check that throws if the version is unregistered:
+
+- `SpecialEvents\CombatLogVersion::setParameters()` (the event that starts a line-stream's active
+  version) — line ~70: `if (!isset(CombatLogVersionConstant::ALL[$this->getVersionLong()])) { throw }`.
+- `Service\CombatLog\ResultEvents\CombatLogVersion` — a duplicate of the same check, further downstream.
+
+**That's it.** No builder anywhere switches behaviour based on whether a version is "known" — see next
+section.
+
+## The pattern every version-gated builder follows: `match` with `default`
+
+Every class whose behaviour genuinely differs per client build (`DamageBuilder`, `AuraAppliedBuilder`,
+`AuraRemovedBuilder`, `CombatantInfoBuilder`, `AdvancedDataBuilder`, `EncounterStartBuilder`,
+`EncounterEndBuilder`, `DamageShieldBuilder`, `DamageShieldMissedBuilder`, `DamageSplitBuilder`,
+`SpellAbsorbedBuilder`, `SpellAbsorbedSupportBuilder`, `EnvironmentalDamageBuilder`,
+`EnergizeBuilder`, `MissedBuilder`, ...) implements `create(int $combatLogVersion): X` as:
+
+```php
+return match ($combatLogVersion) {
+    CombatLogVersion::CLASSIC, CombatLogVersion::RETAIL_10_1_0 => new SomeOldVersion(...),
+    default                                                    => new SomeNewestVersion(...),
+};
+```
+
+**Any unlisted `combatLogVersion` int — registered or not — already falls into `default`, which is
+always the newest handler.** `Prefix`/`Suffix::createFromEventName()` dispatch on event *name*, not
+version, so they're unaffected entirely. `GenericDataBuilder::create()` ignores the version argument.
+
+This is the fact that makes registering a new version low-risk *for parsing dispatch*: a brand-new
+build was already being routed through the newest handler before you registered it (it just never got
+past the `ALL`/`RETAIL_ALL` allowlist throw to reach that point). Registering the version doesn't
+change *where* it's routed — it only lets it through the gate.
+
+**What registering a version can't tell you**: whether that newest handler's *field layout*
+actually matches the new build's real output. A new WoW patch occasionally does change a field
+count/shape even without bumping past what the newest handler expects. Code-reading alone can't rule
+that out — you have to re-parse real logs from that build. See `combatlog-parse-failure-triage` for
+how to pull real failing logs from Staging and replay them locally before shipping a version fix.
+
+## Parameter count validation
+
+`CombatEvents\Traits\ValidatesParameterCount` (mixed into `Prefix`, `Suffix`, and every `SpecialEvent`):
+each class declares `getParameterCount()` (max) and optionally `getOptionalParameterCount()` (default
+`0`); `validateParameters()` throws `InvalidArgumentException` if the actual count falls outside
+`[max - optional, max]`. The exception message format is `"Invalid parameter count for %s - wanted
+%d-%d, got %d"` — the "got" number tells you exactly how many fields were present, useful for
+diagnosing truncated/malformed lines (see `combatlog-parse-failure-triage`'s RioLogVersion example).
+
+## Registering a new WoW combat log version — the procedure
+
+1. **Get the real version-long value.** Pull a real `COMBAT_LOG_VERSION,...,BUILD_VERSION,X.Y.Z,...`
+   line from an actual failing log (see `combatlog-parse-failure-triage`) — don't guess the format.
+2. **Confirm the safety property above still holds** — `grep -rn "RETAIL_<latest>\b" app/` and check
+   every match's builder has a `default =>` arm (it should; this has held for every version to date).
+   If you find one *without* a default (an exhaustive `match` with no fallback), that class needs an
+   explicit new case, not just a registry entry — treat it as a bigger change and investigate that
+   class's newest handler's real field layout first.
+3. Add `public const int RETAIL_X_Y_Z = <versionLong>;` to `CombatLogVersion.php`, plus an entry in
+   both `RETAIL_ALL` and `ALL` with the next sequential revision number (`array_key_last` semantics —
+   just increment from the current max value in each table; the two tables number independently).
+4. Add a data-provider case to
+   `tests/Unit/App/Logic/CombatLog/SpecialEvents/CombatLogVersion/CombatLogVersionTest.php`.
+5. **Before considering it done**, re-parse real failing logs from that build end-to-end (not just the
+   `COMBAT_LOG_VERSION` line in isolation) — see `combatlog-parse-failure-triage` for the exact
+   reproduction recipe. Zero new exceptions across a couple of real runs is the bar; if anything new
+   surfaces, that's a genuine new-build field-shape difference and needs its own fix in the relevant
+   builder/handler, not a version-registry tweak.
+
+## `CombatLogService` parsing entry points
+
+`app/Service/CombatLog/CombatLogService.php` — the streaming reader that drives `CombatLogEntry` over
+a whole file:
+
+| Method | Use for |
+|---|---|
+| `parseCombatLog(string $filePath, callable $callback)` | Low-level: streams `fgets()` line by line, tracks the active `combatLogVersion`/advanced-logging flag across `COMBAT_LOG_VERSION` lines, transparently unzips `.zip` input first. Wraps any exception from `$callback` in `CombatLogParseException` (captures line number + raw line). |
+| `parseCombatLogToEvents(string $filePath): Collection<BaseEvent>` | Convenience wrapper: parses the whole file into an in-memory `Collection` of events. **Read-only, no DB writes** — this is the right tool to reproduce/verify a parse failure locally. |
+| `parseCombatLogStreaming(string $filePath, callable $callable)` | Like `parseCombatLogToEvents` but calls `$callable($event, $lineNr)` per line instead of collecting — used when the caller needs to react per-event without holding the whole file in memory. |
+| `extractCombatLog(string $filePath): ?string` | Unzips a `.zip` to `/tmp` if the path ends in `.zip`; returns `null` (no-op) for anything else, including plain `.txt`. |
+
+For the full production ingestion path (extractors, NPC/spell mapping writes, `ParsedCombatLog`
+idempotency, staleness sweep) see the `combatlog-data-pipeline` skill instead —
+`CombatLogDataExtractionService::extractData()` is built on top of `parseCombatLog()` but has real DB
+side effects, so don't reach for it just to reproduce a parse failure.
+
+## How parse failures get recorded
+
+`App\Jobs\CombatLog\ProcessCombatLogSegments::handle()` (the Raider.IO M+ run ingestion path) catches
+any `Throwable` from `extractData()` and calls
+`CombatLogParseFailureRepositoryInterface::recordFailure()`, which `updateOrCreate`s a
+`CombatLogParseFailure` row (connection `combatlog`) deduplicated on `(run_id, line_number)`. Key
+fields: `raw_line`, `message`, `exception_class`, `combat_log_version`, `resolved_at` (null = still
+unresolved). `CombatLogParseException::getOriginalExceptionClass()` unwraps to the *real* underlying
+exception class (`InvalidArgumentException`, etc.) rather than always recording the wrapper.
+
+## Key files
+
+| Area | Path |
+|---|---|
+| Line entry point | `app/Logic/CombatLog/CombatLogEntry.php` |
+| Base class | `app/Logic/CombatLog/BaseEvent.php` |
+| Version registry | `app/Logic/CombatLog/CombatLogVersion.php` |
+| Version-carrying special events | `app/Logic/CombatLog/SpecialEvents/CombatLogVersion.php`, `.../RioLogVersion.php`, trait `.../Traits/ComputesVersionLong.php` |
+| Special event dispatch | `app/Logic/CombatLog/SpecialEvents/SpecialEvent.php` (`SPECIAL_EVENT_ALL`, `*_CLASS_MAPPING`, `*_BUILDER_CLASS_MAPPING`) |
+| Generic combat event | `app/Logic/CombatLog/CombatEvents/CombatLogEvent.php`, `.../AdvancedCombatLogEvent.php` |
+| Prefix/Suffix dispatch | `app/Logic/CombatLog/CombatEvents/Prefixes/Prefix.php`, `.../Suffixes/Suffix.php` |
+| Param count validation | `app/Logic/CombatLog/CombatEvents/Traits/ValidatesParameterCount.php` |
+| Streaming reader | `app/Service/CombatLog/CombatLogService.php` (+ `CombatLogServiceInterface`) |
+| Parse exception | `app/Service/CombatLog/Exceptions/CombatLogParseException.php` |
+| Failure record model/repo | `app/Models/CombatLog/CombatLogParseFailure.php`, `app/Repositories/{Interfaces,Database}/CombatLog/CombatLogParseFailureRepository*.php` |
+| Failure-recording call site | `app/Jobs/CombatLog/ProcessCombatLogSegments.php` |
+| Version unit test | `tests/Unit/App/Logic/CombatLog/SpecialEvents/CombatLogVersion/CombatLogVersionTest.php` |
+| Other parser unit tests | `tests/Unit/App/Logic/CombatLog/**` |
+| Legacy fixture logs (full route-creation tests, not M+ segments) | `tests/CombatLogs/*.zip` |
+
+## Caveats
+
+- `CombatLogEntry::$previousDateFormat` is a **static** — persists for the process lifetime, shared
+  across every `CombatLogEntry` instance. Harmless for one-shot CLI/tinker reproduction but be aware
+  of it if writing anything that parses multiple unrelated logs in the same PHP-FPM/Octane worker.
+- `CombatLogEntry::parseEvent()` has a leftover `echo` debug statement in its catch block (prints the
+  exception message + raw line to stdout) — expect that noise when reproducing failures via `artisan
+  tinker`; it's not an error signal by itself, just log clutter.
+- `RAW_EVENT_IGNORE` is a hardcoded allowlist of a few known-garbage lines (including one specific
+  stray `COMBAT_LOG_VERSION,20,...,BUILD_VERSION,11.0.0,...` line) that are silently dropped instead
+  of throwing — a precedent for "sometimes a single malformed line needs an explicit ignore-list entry
+  rather than a structural fix", if a future failure turns out to be one truly one-off garbled line
+  from the WoW client itself.
+- The `combat_log_version` int threaded everywhere is **not** the same number as the small "revision"
+  stored in `ALL`/`RETAIL_ALL` — don't mix them up when reading builder `match` arms.

--- a/app/Logic/CombatLog/CombatLogVersion.php
+++ b/app/Logic/CombatLog/CombatLogVersion.php
@@ -18,6 +18,7 @@ class CombatLogVersion
     public const int RETAIL_11_2_0      = 22_011_002_000;
     public const int RETAIL_12_0_1      = 22_012_000_001;
     public const int RETAIL_12_0_5      = 22_012_000_005;
+    public const int RETAIL_12_0_7      = 22_012_000_007;
 
     public const array RETAIL_ALL = [
         self::RETAIL_10_1_0 => 2,
@@ -29,6 +30,7 @@ class CombatLogVersion
         self::RETAIL_11_2_0 => 11,
         self::RETAIL_12_0_1 => 12,
         self::RETAIL_12_0_5 => 14,
+        self::RETAIL_12_0_7 => 15,
     ];
 
     public const array ALL = [
@@ -46,5 +48,6 @@ class CombatLogVersion
         self::RETAIL_12_0_1      => 12,
         self::CLASSIC_TBC_2_5_5  => 13,
         self::RETAIL_12_0_5      => 14,
+        self::RETAIL_12_0_7      => 15,
     ];
 }

--- a/tests/Unit/App/Logic/CombatLog/SpecialEvents/CombatLogVersion/CombatLogVersionTest.php
+++ b/tests/Unit/App/Logic/CombatLog/SpecialEvents/CombatLogVersion/CombatLogVersionTest.php
@@ -48,6 +48,10 @@ final class CombatLogVersionTest extends PublicTestCase
                 '5/31/2026 22:00:00.0000  COMBAT_LOG_VERSION,22,ADVANCED_LOG_ENABLED,1,BUILD_VERSION,12.0.5,PROJECT_ID,1',
                 CombatLogVersion::RETAIL_12_0_5,
             ],
+            'retail-12-0-7' => [
+                '7/19/2026 19:31:59.774-6  COMBAT_LOG_VERSION,22,ADVANCED_LOG_ENABLED,1,BUILD_VERSION,12.0.7,PROJECT_ID,1',
+                CombatLogVersion::RETAIL_12_0_7,
+            ],
         ];
     }
 }


### PR DESCRIPTION
:robot: Closes #3632

## Summary
- Registers WoW client build `12.0.7` (`22_012_000_007`, revision `15`) in `App\Logic\CombatLog\CombatLogVersion::ALL`/`RETAIL_ALL`.
- This was the root cause of 493/500 (98.6%) of the currently-unresolved `CombatLogParseFailure` rows on Staging: `Exception: Unable to find combat log version 22012000007!`, thrown on the very first line of every affected log.
- Verified this is safe to register: every version-gated builder (`DamageBuilder`, `AuraAppliedBuilder`, `CombatantInfoBuilder`, `AdvancedDataBuilder`, etc.) already has a `default =>` arm that falls through to its newest handler for any unlisted version — the `ALL`/`RETAIL_ALL` table is purely a "known version" allowlist, not a schema-revision switch. Confirmed by re-parsing two full real Staging runs (16 segments, ~330K events total) end-to-end through `CombatLogServiceInterface::parseCombatLogToEvents()` with this change applied: zero exceptions, no new downstream failures.

## Test plan
- [x] Added `retail-12-0-7` case to `CombatLogVersionTest`'s data provider — green.
- [x] Full `CombatLog` test group (207 tests) green.
- [x] `composer run fix` / `composer run analyse` clean.
- [x] Manually re-parsed two real failing Staging runs (run 40653052, 9 segments; run 40712395, 7 segments) end-to-end with the fix applied — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)