### PR TITLE
#3637 Add /poll skill for on-demand combat log parse-failure sweeps

### DIFF
--- a/.claude/skills/combatlog-parse-failure-poll/SKILL.md
+++ b/.claude/skills/combatlog-parse-failure-poll/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: poll
-description: On-demand combat log parse-failure sweep — run manually via /poll whenever you're at your machine. Checks Staging (and, once configured, Production) for new or worsening CombatLogParseFailure clusters and files/updates GitHub issues describing them. Read-only against the app: never writes code, never opens MRs, never marks failures resolved. Mirrors the update-mdt-package skill's "human-run check" pattern rather than being a scheduled/autonomous job. Use when the user runs /poll, or asks to "check for new combat log failures" / "sweep Staging for parse failures".
+name: combatlog-parse-failure-poll
+description: On-demand combat log parse-failure sweep — run manually via /combatlog-parse-failure-poll whenever you're at your machine. Checks Staging (and, once configured, Production) for new or worsening CombatLogParseFailure clusters and files/updates GitHub issues describing them. Read-only against the app: never writes code, never opens MRs, never marks failures resolved. Mirrors the update-mdt-package skill's "human-run check" pattern rather than being a scheduled/autonomous job. Use when the user runs /combatlog-parse-failure-poll, or asks to "check for new combat log failures" / "sweep Staging for parse failures".
 ---
 
-# /poll — Combat Log Parse-Failure Sweep
+# /combatlog-parse-failure-poll — Combat Log Parse-Failure Sweep
 
-A lightweight, **human-initiated** check — you run it (`/poll`) when you're around, the same way
+A lightweight, **human-initiated** check — you run it (`/combatlog-parse-failure-poll`) when you're around, the same way
 someone would manually re-run `update-mdt-package`'s Step 1 to see if a new MDT release exists.
 There is no cron job, no cloud routine, no unattended execution. Its only output is GitHub issues
 (new ones, or a comment bumping an existing tracked one) — it never touches application code and
@@ -110,5 +110,5 @@ count), or unchanged. If nothing changed at all, say so briefly — don't pad th
 When the user wants an issue this skill filed actually fixed, that's ordinary work: open a worktree
 (`sh/worktree.sh create <issue>-<slug>`), follow `combatlog-parse-failure-triage` for the
 download/reproduce loop and `combatlog-parsing-internals` for the parser architecture, and open an
-MR the normal way — the same process used for #3632/#3633 this session. `/poll` only ever gets you
-to "here's a diagnosed issue," never further.
+MR the normal way — the same process used for #3632/#3633 this session. `/combatlog-parse-failure-poll`
+only ever gets you to "here's a diagnosed issue," never further.

--- a/.claude/skills/combatlog-parse-failure-triage/SKILL.md
+++ b/.claude/skills/combatlog-parse-failure-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: combatlog-parse-failure-triage
-description: Operational runbook to find, download, and reproduce real Staging/Production combat log parse failures before fixing them — the internal-team API endpoints, how to pull a failure's real Raider.IO log segments, the gzip/docker-cp reproduction recipe, and the safety checklist for shipping a fix. Use when triaging CombatLogParseFailure rows, chasing a "combat log parses are failing" report, or verifying a combatlog-parsing-internals fix against real production data. Pairs with combatlog-parsing-internals (how the parser itself works) and create-github-issue / worktree-docker (how to turn a diagnosis into a shipped MR).
+description: Operational runbook to find, download, and reproduce real Staging/Production combat log parse failures before fixing them — the internal-team API endpoints, how to pull a failure's real Raider.IO log segments, the gzip/docker-cp reproduction recipe, and the safety checklist for shipping a fix. Use when triaging CombatLogParseFailure rows, chasing a "combat log parses are failing" report, or verifying a combatlog-parsing-internals fix against real production data. Pairs with combatlog-parsing-internals (how the parser itself works), create-github-issue / worktree-docker (how to turn a diagnosis into a shipped MR), and poll (the lighter on-demand sweep that just files/updates issues without fixing anything).
 ---
 
 # Combat Log Parse-Failure Triage
@@ -18,6 +18,13 @@ else that gets checked in. Each session, ask Wotuu for a current Staging (or Pro
 what's being triaged) admin API service-account credential, use it only for that session, and remind
 him to rotate/delete it once you're done. Treat it like any other secret: environment/conversation
 only, never `.env`, never a file under version control (see `feedback_no_env_file` in memory).
+
+**Exception**: the `/poll` skill (a separate, lighter on-demand sweep — see below) uses a durable
+long-lived service account read from a local file outside the repo
+(`~/.config/keystone-guru/combatlog-staging-basic-auth`), since it's meant to be re-run casually
+without re-requesting a credential each time. That file is `/poll`'s concern, not this skill's —
+don't reuse it here or assume it exists; keep using fresh per-session credentials for the deeper
+reproduction work this skill covers.
 
 ## 1. List unresolved failures
 
@@ -169,22 +176,26 @@ run doesn't get automatically reprocessed) — **don't do this without being exp
 even then only after the fix has actually shipped, not just been merged. This mirrors the project's
 general "no unattended prod actions without a human saying so in the current conversation" norm.
 
-## Toward full autonomy — what's still a manual gate
+## The diagnosis/fix split — and why it's not a cloud/cron job
 
-The user's end goal is running this loop unattended as new failures show up. What's still manual
-today, and why it's not automated yet:
+The user's end goal is running this loop with minimal manual effort. After weighing it (2026-07-21):
+a true unattended cloud/cron job was ruled out, because the *fix* half of this loop needs real
+Docker access to the shared DB/Redis/seeded test DB (`worktree-docker`) that an isolated cloud
+sandbox doesn't have — running "verified" fixes against a different, unseeded DB would produce false
+confidence, not real verification. The resolved split:
 
-- **Credentials**: no durable secret storage in-repo (by design — public repo). A fully autonomous
-  loop needs its own credential-provisioning story (e.g. a scheduled agent with its own vaulted
-  secret) that doesn't yet exist here.
-- **Shipping**: MRs still go through normal review per this repo's `CLAUDE.md` — nothing here should
-  bypass that, even if the agent is confident in a fix.
-- **Resolving failure rows**: a production data mutation; keep requiring an explicit go-ahead per the
-  paragraph above until there's a clearer signal (e.g. automatic reprocessing) that a resolve is safe
-  to make unattended.
+- **Diagnosis** (find new/worsening failure clusters, file/update GitHub issues) is cheap, read-only,
+  and safe to run often — that's the `/poll` skill, invoked manually (`/poll`) whenever the user is
+  around. It uses its own durable local credential (see the exception above) precisely because it's
+  low-risk enough to not need a fresh credential every time.
+- **The fix** (this skill, steps 1-6) still needs a real worktree session with Docker access, and
+  still ends at an MR — never merges. Pick up a `/poll`-filed issue the same way you'd pick up any
+  other issue.
+- **Resolving failure rows**: still requires an explicit go-ahead each time, for the reasons above —
+  a production data mutation that doesn't by itself confirm anything was fixed.
 
-If/when the user wants to close these gaps (e.g. via `/schedule` or a cron-based agent), that's a
-separate, explicit setup step — don't wire it up implicitly while just doing triage.
+This split is deliberate, not a placeholder — don't try to collapse it back into one unattended job
+without a real answer to the Docker/DB-access problem.
 
 ## Gotchas
 

--- a/.claude/skills/combatlog-parse-failure-triage/SKILL.md
+++ b/.claude/skills/combatlog-parse-failure-triage/SKILL.md
@@ -19,12 +19,12 @@ what's being triaged) admin API service-account credential, use it only for that
 him to rotate/delete it once you're done. Treat it like any other secret: environment/conversation
 only, never `.env`, never a file under version control (see `feedback_no_env_file` in memory).
 
-**Exception**: the `/poll` skill (a separate, lighter on-demand sweep — see below) uses a durable
-long-lived service account read from a local file outside the repo
+**Exception**: the `/combatlog-parse-failure-poll` skill (a separate, lighter on-demand sweep — see
+below) uses a durable long-lived service account read from a local file outside the repo
 (`~/.config/keystone-guru/combatlog-staging-basic-auth`), since it's meant to be re-run casually
-without re-requesting a credential each time. That file is `/poll`'s concern, not this skill's —
-don't reuse it here or assume it exists; keep using fresh per-session credentials for the deeper
-reproduction work this skill covers.
+without re-requesting a credential each time. That file is `/combatlog-parse-failure-poll`'s
+concern, not this skill's — don't reuse it here or assume it exists; keep using fresh per-session
+credentials for the deeper reproduction work this skill covers.
 
 ## 1. List unresolved failures
 
@@ -185,12 +185,13 @@ sandbox doesn't have — running "verified" fixes against a different, unseeded 
 confidence, not real verification. The resolved split:
 
 - **Diagnosis** (find new/worsening failure clusters, file/update GitHub issues) is cheap, read-only,
-  and safe to run often — that's the `/poll` skill, invoked manually (`/poll`) whenever the user is
-  around. It uses its own durable local credential (see the exception above) precisely because it's
-  low-risk enough to not need a fresh credential every time.
+  and safe to run often — that's the `/combatlog-parse-failure-poll` skill, invoked manually
+  (`/combatlog-parse-failure-poll`) whenever the user is around. It uses its own durable local
+  credential (see the exception above) precisely because it's low-risk enough to not need a fresh
+  credential every time.
 - **The fix** (this skill, steps 1-6) still needs a real worktree session with Docker access, and
-  still ends at an MR — never merges. Pick up a `/poll`-filed issue the same way you'd pick up any
-  other issue.
+  still ends at an MR — never merges. Pick up a `/combatlog-parse-failure-poll`-filed issue the
+  same way you'd pick up any other issue.
 - **Resolving failure rows**: still requires an explicit go-ahead each time, for the reasons above —
   a production data mutation that doesn't by itself confirm anything was fixed.
 

--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: poll
+description: On-demand combat log parse-failure sweep — run manually via /poll whenever you're at your machine. Checks Staging (and, once configured, Production) for new or worsening CombatLogParseFailure clusters and files/updates GitHub issues describing them. Read-only against the app: never writes code, never opens MRs, never marks failures resolved. Mirrors the update-mdt-package skill's "human-run check" pattern rather than being a scheduled/autonomous job. Use when the user runs /poll, or asks to "check for new combat log failures" / "sweep Staging for parse failures".
+---
+
+# /poll — Combat Log Parse-Failure Sweep
+
+A lightweight, **human-initiated** check — you run it (`/poll`) when you're around, the same way
+someone would manually re-run `update-mdt-package`'s Step 1 to see if a new MDT release exists.
+There is no cron job, no cloud routine, no unattended execution. Its only output is GitHub issues
+(new ones, or a comment bumping an existing tracked one) — it never touches application code and
+never opens an MR. That's deliberate: diagnosis is safe to run casually and often; a fix needs a
+real worktree session using `combatlog-parse-failure-triage` + `combatlog-parsing-internals`,
+which you (or a follow-up Claude session) picks up from the filed issue when you're ready.
+
+## Credentials
+
+Reads Staging admin API Basic-auth credentials from a **local file outside the repo**, never from
+chat, never committed:
+
+```
+~/.config/keystone-guru/combatlog-staging-basic-auth
+```
+
+Format: a single line, `user@example.com:password` (exactly the value you'd pass to `curl -u`).
+`chmod 600` it.
+
+- If the file doesn't exist, **stop and tell the user** how to create it — don't ask them to paste
+  the secret into chat, and don't create the file yourself from a chat-provided value unless they
+  explicitly ask you to. Provisioning the actual admin service account (an app-level user with the
+  `admin` role) is a separate, deliberate step the user does — see
+  `combatlog-parse-failure-triage`'s credentials section for the general handling rules.
+- Only check for existence (`test -f ... && echo present`) — never `cat`/print the file's contents
+  back into the conversation.
+- Production isn't wired up yet. If/when it is, the convention will be a second file
+  (`~/.config/keystone-guru/combatlog-production-basic-auth`) against `https://keystone.guru`
+  instead of `https://staging.keystone.guru` — don't build that until asked.
+
+## Step 1 — Fetch unresolved failures
+
+```bash
+curl -s -u "$(cat ~/.config/keystone-guru/combatlog-staging-basic-auth)" \
+  'https://staging.keystone.guru/api/v1/combatlog/parse-failures' -o /tmp/poll_failures.json
+```
+
+Rows are under `.data` (Resource envelope) — see `combatlog-parse-failure-triage` for the full
+field shape and pagination caveat (caps at 500).
+
+## Step 2 — Cluster
+
+Group by `(exceptionClass, normalizedMessage)` where `normalizedMessage` replaces every digit run
+in `message` with `#` (e.g. `Unable to find combat log version #!`). This intentionally treats
+"same error shape, different specific number" as one cluster — good enough for a lightweight sweep.
+**Known limitation**: if two *different* root causes ever produce the same normalized shape at the
+same time (e.g. two distinct unregistered versions failing simultaneously), they'd merge into one
+tracked issue — acceptable for a periodic check, not for the actual fix (that still needs the real
+per-cluster diagnosis from `combatlog-parse-failure-triage`).
+
+## Step 3 — Match against already-tracked clusters
+
+```bash
+gh issue list --repo RaiderIO/keystone.guru --label combatlog --state open --json number,title,body
+```
+
+Every issue this skill files embeds a hidden marker in its body:
+
+```
+<!-- poll-signature: <sha1 of "exceptionClass|normalizedMessage"> count:<N> -->
+```
+
+For each cluster from Step 2, compute its signature and check whether any open `combatlog`-labeled
+issue already carries it.
+
+## Step 4 — New cluster → file an issue
+
+No matching open issue found. File one (label `combatlog`; add a second topic label only if
+obviously fitting, same rules as `create-github-issue`):
+
+- Title: short description of the error shape (e.g. `Combat log parse failures: unable to find
+  combat log version <example>`), **not** prefixed with an issue number (this skill files it, no
+  existing number to reference).
+- Body: failure count, 1-2 example rows verbatim (`run_id`, `season_id`, `raw_line`, `message`),
+  and — **only if directly inferable from the message/exceptionClass alone, not from a deep
+  dive** — a one-line hypothesis pointing at the likely area (e.g. "likely an unregistered
+  `CombatLogVersion` — see the `combatlog-parsing-internals` skill's registration procedure").
+  Do **not** attempt the full local reproduction here; that's what a follow-up worktree session is
+  for. End with the `<!-- poll-signature: ... -->` marker line.
+- Report the new issue URL to the user in your summary.
+
+## Step 5 — Existing cluster → bump only if it moved
+
+Compare the cluster's current count to the `count:<N>` in the matched issue's marker. If unchanged,
+say nothing (don't spam a comment every run). If it changed meaningfully, post a short comment
+(`gh issue comment <n> --body "..."`) noting the new count and update the marker via
+`gh issue edit <n> --body-file` (re-emit the full body with the `count:` value updated).
+
+## Step 6 — Summarize
+
+Tell the user, per cluster: new issue filed (with link), existing issue bumped (with link + old→new
+count), or unchanged. If nothing changed at all, say so briefly — don't pad the response.
+
+## Boundaries — what this skill never does
+
+- Never writes/edits application code.
+- Never opens or touches an MR.
+- Never calls the admin `resolve` action or otherwise mutates `CombatLogParseFailure` rows.
+- Never merges anything (not applicable here, but stating it for clarity — merging is always a
+  human decision per this repo's `CLAUDE.md`).
+
+When the user wants an issue this skill filed actually fixed, that's ordinary work: open a worktree
+(`sh/worktree.sh create <issue>-<slug>`), follow `combatlog-parse-failure-triage` for the
+download/reproduce loop and `combatlog-parsing-internals` for the parser architecture, and open an
+MR the normal way — the same process used for #3632/#3633 this session. `/poll` only ever gets you
+to "here's a diagnosed issue," never further.


### PR DESCRIPTION
:robot: Closes #3637

## Summary
- New `.claude/skills/poll/SKILL.md` — a human-run (`/poll`), read-only sweep of Staging's combat log parse failures. Fetches unresolved rows, clusters them, and files/updates GitHub issues via a hidden signature marker for dedup. Never writes application code, never opens an MR, never marks a `CombatLogParseFailure` resolved.
- Deliberately **not** a scheduled/cron/cloud job — the fix half of this workflow needs real Docker access to the shared DB/Redis/seeded test DB that an isolated cloud sandbox doesn't have, so an unattended "verified" fix from there would be false confidence. Diagnosis (cheap, safe, frequent) and the actual fix (worktree session ending at an MR, human-reviewed) stay split.
- Created the `combatlog` GitHub label for issues this skill files.
- Updated `combatlog-parse-failure-triage`'s credentials section and "toward full autonomy" section to describe the now-resolved split instead of leaving it open.

## Not done here (tracked in #3637)
- Provisioning the actual Staging admin service account and populating `~/.config/keystone-guru/combatlog-staging-basic-auth` — that's a local, non-repo file `/poll` reads credentials from; needs Wotuu's decision on how the account itself gets created.
- A live `/poll` dry run against real data (needs the credential above first).

## Test plan
This is a skill-only change (markdown + a GitHub label) — no application code touched, no tests applicable. Reviewed the skill body manually for consistency with `combatlog-parsing-internals`/`combatlog-parse-failure-triage` conventions and this repo's existing credential-handling rules (never commit secrets, repo is public).

🤖 Generated with [Claude Code](https://claude.com/claude-code)