### PR TITLE
#3640 Rename discover new() to newest() to avoid route-cache ParseError

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -133,6 +133,9 @@ review must start from a pre-reviewed, verified MR:
     }
 ```
 
+### Routes & controller method naming
+- Routes are registered with first-class callable syntax, e.g. `Route::get('new', new FooController()->new(...))`. Never name a controller method that's registered this way after a PHP reserved word (`new`, `list`, `print`, `echo`, `class`, `function`, ...). It parses and passes tests fine, but `php artisan route:cache` serializes the closure via laravel-serializable-closure, and reconstituting it later `eval`s code like `function new(...)` — invalid syntax, since a function can't be named after a reserved word outside class context. The crash only appears in production, per-request, once the route cache is warm and that request hits the route (`ParseError: syntax error, unexpected token "new"`), not at cache-build time or in tests (routes aren't cached under `runningUnitTests()`). Fix: rename the controller method (e.g. `new` → `newest`); the route path/name (`'new'`, `api.v1.discover.new`) can stay unchanged since that's just a string, not a callable identifier. This has bitten `new` (APIDungeonRouteDiscoverController) and `list` before.
+
 ### Queues
 - Use queued jobs for time-consuming operations with the `ShouldQueue` interface.
 

--- a/app/Http/Controllers/Api/V1/Public/Route/APIDungeonRouteDiscoverController.php
+++ b/app/Http/Controllers/Api/V1/Public/Route/APIDungeonRouteDiscoverController.php
@@ -59,7 +59,7 @@ class APIDungeonRouteDiscoverController extends Controller
      *     )
      * )
      */
-    public function new(
+    public function newest(
         APIOffsetPaginatedRequest $request,
         GameVersion               $gameVersion,
         DiscoverServiceInterface  $discoverService,

--- a/routes/api.php
+++ b/routes/api.php
@@ -52,7 +52,7 @@ Route::prefix('v1')->group(static function () {
 
     Route::prefix('routes/{gameVersion}')->group(static function () {
         Route::get('popular', new APIDungeonRouteDiscoverController()->popular(...))->name('api.v1.discover.popular');
-        Route::get('new', new APIDungeonRouteDiscoverController()->new(...))->name('api.v1.discover.new');
+        Route::get('new', new APIDungeonRouteDiscoverController()->newest(...))->name('api.v1.discover.new');
         Route::prefix('{dungeon}')->group(static function () {
             Route::get('popular', new APIDungeonRouteDiscoverController()->dungeonPopular(...))->name('api.v1.discover.dungeon.popular');
             Route::get('new', new APIDungeonRouteDiscoverController()->dungeonNew(...))->name('api.v1.discover.dungeon.new');

--- a/tests/Feature/Controller/Api/V1/APIDungeonRouteDiscoverController/APIDungeonRouteDiscoverControllerTest.php
+++ b/tests/Feature/Controller/Api/V1/APIDungeonRouteDiscoverController/APIDungeonRouteDiscoverControllerTest.php
@@ -142,7 +142,7 @@ final class APIDungeonRouteDiscoverControllerTest extends PublicTestCase
      * @throws Exception
      */
     #[Test]
-    public function new_givenValidGameVersion_shouldReturnOk(): void
+    public function newest_givenValidGameVersion_shouldReturnOk(): void
     {
         // Arrange
         $gameVersion = GameVersion::firstOrFail();
@@ -160,7 +160,7 @@ final class APIDungeonRouteDiscoverControllerTest extends PublicTestCase
      * @throws Exception
      */
     #[Test]
-    public function new_givenCountAboveMax_shouldReturn422(): void
+    public function newest_givenCountAboveMax_shouldReturn422(): void
     {
         // Arrange
         $gameVersion = GameVersion::firstOrFail();

--- a/tests/Feature/Controller/DungeonRouteController/DungeonRouteControllerCreateTestBase.php
+++ b/tests/Feature/Controller/DungeonRouteController/DungeonRouteControllerCreateTestBase.php
@@ -76,21 +76,27 @@ abstract class DungeonRouteControllerCreateTestBase extends PublicTestCase
      */
     protected function getDungeonWithStartIcon(): array
     {
-        $mapIcon = MapIcon::query()
+        // Some mapping versions are "bare" (e.g. created only to hold floor union data) and don't
+        // have a cloned dungeon start icon, so the newest icon overall isn't necessarily one that
+        // lives on its own dungeon's current mapping version - walk candidates until one does.
+        $mapIcons = MapIcon::query()
             ->where('map_icon_type_id', MapIconType::ALL[MapIconType::MAP_ICON_TYPE_DUNGEON_START])
             ->whereNotNull('mapping_version_id')
             ->whereHas('mappingVersion.dungeon', static function ($query): void {
                 $query->where('active', true);
             })
+            ->with('mappingVersion.dungeon')
             ->orderByDesc('id')
-            ->first();
+            ->get();
 
-        $this->assertNotNull($mapIcon, 'Expected a seeded dungeon start map icon.');
+        foreach ($mapIcons as $mapIcon) {
+            $dungeon = $mapIcon->mappingVersion->dungeon;
 
-        $dungeon = $mapIcon->mappingVersion->dungeon;
-        // Only usable when the icon lives on the dungeon's current mapping version
-        $this->assertSame($dungeon->getCurrentMappingVersion()->id, $mapIcon->mapping_version_id);
+            if ($dungeon->getCurrentMappingVersion()?->id === $mapIcon->mapping_version_id) {
+                return [$dungeon, $mapIcon];
+            }
+        }
 
-        return [$dungeon, $mapIcon];
+        $this->fail('Expected a seeded dungeon start map icon on its dungeon\'s current mapping version.');
     }
 }

--- a/tests/Feature/Routes/RouteActionSerializationTest.php
+++ b/tests/Feature/Routes/RouteActionSerializationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Routes;
+
+use Closure;
+use Illuminate\Support\Facades\Route;
+use Laravel\SerializableClosure\SerializableClosure;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use Throwable;
+
+#[Group('Routes')]
+final class RouteActionSerializationTest extends TestCase
+{
+    /**
+     * `php artisan route:cache` serializes every closure-based route action via
+     * laravel-serializable-closure, then reconstitutes it by `eval`-ing generated code on each
+     * request once the cache is warm. A controller method literally named after a PHP reserved
+     * word (`new`, `list`, ...) produces invalid generated code (`function new(...)`), which only
+     * throws a ParseError at unserialize/eval time - not at serialize time, and never under
+     * runningUnitTests() since routes aren't cached there. This has bitten `new`
+     * (APIDungeonRouteDiscoverController) and `list` before; see the CLAUDE.md note on route
+     * naming.
+     *
+     * This round-trips every registered closure route action through the exact same
+     * serialize/unserialize cycle route:cache performs, so a reintroduced reserved-word method
+     * name fails here deterministically instead of only surfacing per-request in production.
+     */
+    #[Test]
+    public function routes_givenFirstClassCallableActions_surviveSerializableClosureRoundTrip(): void
+    {
+        // Arrange/Act
+        $failures = [];
+
+        foreach (Route::getRoutes()->getRoutes() as $route) {
+            $uses = $route->getAction('uses');
+            if (!$uses instanceof Closure) {
+                continue;
+            }
+
+            try {
+                $serialized = serialize(new SerializableClosure($uses));
+                unserialize($serialized)->getClosure();
+            } catch (Throwable $e) {
+                $failures[] = sprintf('%s %s: %s', implode('|', $route->methods()), $route->uri(), $e->getMessage());
+            }
+        }
+
+        // Assert
+        $this->assertSame(
+            [],
+            $failures,
+            "The following routes failed the SerializableClosure round-trip route:cache performs in production:\n" . implode("\n", $failures),
+        );
+    }
+}


### PR DESCRIPTION
:robot: Closes #3640

## Summary
- `APIDungeonRouteDiscoverController::new()` → `newest()`. Routes registered with first-class
  callable syntax (`new FooController()->new(...)`) get serialized via
  `laravel-serializable-closure` when `route:cache` runs, and reconstituted by `eval`-ing
  generated code. A method literally named `new` produces invalid PHP
  (`function new(...)`), causing a per-request `ParseError` in production once the route cache
  is warm — this is exactly what production was hitting on `GET /api/v1/routes/{gameVersion}/new`.
- The route path (`new`) and route name (`api.v1.discover.new`) are unchanged — those are plain
  strings, not callable identifiers, so the public API URL is unaffected.
- Updated `routes/api.php` and the matching test method names.
- Documented the quirk in `.claude/CLAUDE.md` (this is the second time it's bitten a controller
  method — previously `list`) so it isn't reintroduced.
- Incidental fix: CI's `feature-controller` job was red on this branch from an unrelated flaky
  test, `DungeonRouteControllerSaveNewTemporaryTest::saveNewTemporary_givenValidStartMapIcon_setsStartMapIconId`.
  `DungeonRouteControllerCreateTestBase::getDungeonWithStartIcon()` assumed the newest
  (highest-id) dungeon-start `MapIcon` overall is on its own dungeon's current mapping version.
  That assumption broke once "bare" mapping versions (created only to hold floor union data,
  without a cloned map icon set) can become a dungeon's current version. Fixed the helper to walk
  candidates newest-first until one actually sits on its dungeon's current mapping version.

## Test plan
- [x] `php artisan test --compact tests/Feature/Controller/Api/V1/APIDungeonRouteDiscoverController/APIDungeonRouteDiscoverControllerTest.php` — 10 passed
- [x] Reproduced the actual failure mechanism via tinker: serializing/unserializing the route
      closure with `Laravel\SerializableClosure\SerializableClosure` fails with the old `new`
      method name and succeeds after the rename
- [x] `php artisan route:cache` succeeds; `route:list` shows `api/v1/routes/{gameVersion}/new`
      unchanged
- [x] `composer run fix` / `composer run analyse` clean on touched files
- [x] No UI change — no screenshots needed
- [ ] Watching CI to confirm `feature-controller` is green after the test-helper fix
