### PR TITLE
#3645 Restore missing dungeon-start map icons on 3 more bare mapping versions

### DIFF
--- a/database/seeders/dungeondata/classic/the_temple_of_atal_hakkar/4/map_icons.json
+++ b/database/seeders/dungeondata/classic/the_temple_of_atal_hakkar/4/map_icons.json
@@ -76,5 +76,18 @@
         "permanent_tooltip": 0,
         "seasonal_index": null,
         "is_admin": true
+    },
+    {
+        "mapping_version_id": 223,
+        "floor_id": 237,
+        "dungeon_route_id": null,
+        "team_id": null,
+        "map_icon_type_id": 10,
+        "lat": -28,
+        "lng": 191.25,
+        "comment": null,
+        "permanent_tooltip": 0,
+        "seasonal_index": null,
+        "is_admin": true
     }
 ]

--- a/database/seeders/dungeondata/legion/cathedralofeternalnight/1/map_icons.json
+++ b/database/seeders/dungeondata/legion/cathedralofeternalnight/1/map_icons.json
@@ -24,5 +24,18 @@
         "permanent_tooltip": 0,
         "seasonal_index": null,
         "is_admin": true
+    },
+    {
+        "mapping_version_id": 3,
+        "floor_id": 8,
+        "dungeon_route_id": null,
+        "team_id": null,
+        "map_icon_type_id": 10,
+        "lat": -204.326,
+        "lng": 179.6193,
+        "comment": null,
+        "permanent_tooltip": 0,
+        "seasonal_index": null,
+        "is_admin": true
     }
 ]

--- a/database/seeders/dungeondata/legion/courtofstars/1/map_icons.json
+++ b/database/seeders/dungeondata/legion/courtofstars/1/map_icons.json
@@ -531,5 +531,18 @@
         "permanent_tooltip": 0,
         "seasonal_index": null,
         "is_admin": true
+    },
+    {
+        "mapping_version_id": 614,
+        "floor_id": 13,
+        "dungeon_route_id": null,
+        "team_id": null,
+        "map_icon_type_id": 10,
+        "lat": -189.9994,
+        "lng": 171.3249,
+        "comment": null,
+        "permanent_tooltip": 0,
+        "seasonal_index": null,
+        "is_admin": true
     }
 ]


### PR DESCRIPTION
:robot: Closes #3645

## Summary
#3643 fixed the 5 dungeons Wotuu identified by hand for the #3639 CI failure
(`DungeonRouteControllerSaveNewTemporaryTest::saveNewTemporary_givenValidStartMapIcon_setsStartMapIconId`).
After merging it, several unrelated PRs kept failing the same test with the same signature
(`642 identical to 806`) — a full scan of every active dungeon's current mapping version for a
dungeon-start `MapIcon` turned up 3 more dungeons hit by the same #3629 backfill-script gap (a
"bare" mapping version cloned without its dungeon-start icon):

- `cathedralofeternalnight`: current mv 3 (v1) had none — copied floor/coordinates from mv 611 (v2).
- `courtofstars`: current mv 614 (v6) had none — copied from mv 631 (v8).
- `the_temple_of_atal_hakkar`: current mv 223 (v2) had none — copied from mv 178 (v1).

Floors are dungeon-scoped, not mapping-version-scoped, so each source icon's floor/lat/lng is
valid on the bare current version too — verified each source floor is non-facade and the
dungeon's `default` floor before copying.

`voidscar_arena`, `magtheridons_lair`, `altar_of_fangs` have zero dungeon-start icons on any
mapping version, ever — left untouched (no safe source to copy from); flagged in #3645 for Wotuu
to confirm whether that's intentional.

## Verification
- `mapping:save` export touched exactly the 3 targeted seeder JSON files, no drift elsewhere.
- Full round-trip: re-seeded via `db:seedone DungeonDataSeeder`, then re-scanned all active
  dungeons — only the 3 known "never had one" dungeons remain without a start icon on their
  current version.

## Test plan
- [ ] CI green (this is what should finally unblock #3644/#3447/#3285/#3638/#3630's shared red CI)