### PR TITLE
#3651 EnsureHeroThumbnails never re-queues a fully-missing floor's hero thumbnail

### DIFF
--- a/app/Repositories/Database/DungeonRoute/DungeonRouteThumbnailRepository.php
+++ b/app/Repositories/Database/DungeonRoute/DungeonRouteThumbnailRepository.php
@@ -18,11 +18,30 @@ class DungeonRouteThumbnailRepository extends DatabaseRepository implements Dung
 
     public function hasFreshThumbnailForVariant(DungeonRoute $dungeonRoute, DungeonRouteThumbnailVariant $variant): bool
     {
+        $mappingVersion = $dungeonRoute->mappingVersion;
+        if ($mappingVersion === null) { // @phpstan-ignore identical.alwaysFalse
+            return false;
+        }
+
+        $expectedFloorCount = $dungeonRoute->dungeon
+            ->floorsForMapFacade($mappingVersion, true)
+            ->active()
+            ->count();
+
+        $existingThumbnailCount = $dungeonRoute->dungeonRouteThumbnails()
+            ->where('variant', $variant)
+            ->count();
+
+        // A floor with zero thumbnail rows for the variant (a render that never ran or never succeeded)
+        // has no updated_at to compare, so it must be caught here before the min() staleness check below -
+        // otherwise it stays invisible to the freshness check until the route is edited again.
+        if ($existingThumbnailCount < $expectedFloorCount) {
+            return false;
+        }
+
         // Gate on the OLDEST render among this route's thumbnails for the variant, not the newest: for a
         // multi-floor route, one freshly-rendered floor must not mask another floor whose thumbnail row
-        // still exists but is stale (e.g. a failed re-render left the old row in place). Note this still
-        // can't detect a floor whose thumbnail row doesn't exist at all (a wholly failed render) - that
-        // requires knowing the expected floor count, which is a larger follow-up.
+        // still exists but is stale (e.g. a failed re-render left the old row in place).
         $oldestRenderedAt = $dungeonRoute->dungeonRouteThumbnails()
             ->where('variant', $variant)
             ->min('updated_at');

--- a/tests/Feature/App/Repository/DungeonRoute/DungeonRouteThumbnailRepositoryTest.php
+++ b/tests/Feature/App/Repository/DungeonRoute/DungeonRouteThumbnailRepositoryTest.php
@@ -44,12 +44,35 @@ final class DungeonRouteThumbnailRepositoryTest extends PublicTestCase
     }
 
     #[Test]
+    public function hasFreshThumbnailForVariant_givenNullMappingVersion_returnsFalse(): void
+    {
+        // Arrange - mapping_version_id is nullable in the schema (legacy data), so the check must not
+        // blow up trying to compute an expected floor count from a null mapping version.
+        $dungeonRoute = DungeonRoute::factory()->create(['mapping_version_id' => null]);
+
+        try {
+            // Act
+            $result = $this->repository->hasFreshThumbnailForVariant($dungeonRoute, DungeonRouteThumbnailVariant::Hero);
+
+            // Assert
+            $this->assertFalse($result);
+        } finally {
+            $dungeonRoute->delete();
+        }
+    }
+
+    #[Test]
     public function hasFreshThumbnailForVariant_givenThumbnailRenderedAfterLastContentChange_returnsTrue(): void
     {
-        // Arrange
-        $dungeon      = $this->getDungeonWithNonFacadeFloor();
-        $floor        = $dungeon->floors()->where('facade', false)->first();
-        $dungeonRoute = DungeonRoute::factory()->create(['dungeon_id' => $dungeon->id]);
+        // Arrange - uses a dungeon with exactly one non-facade floor so the new expected-floor-count
+        // check (one thumbnail == one floor) doesn't flake on dungeons with several floors.
+        $dungeon        = $this->getDungeonWithExactlyOneNonFacadeFloor();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $floor          = $dungeon->floors()->where('facade', false)->first();
+        $dungeonRoute   = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
 
         $thumbnail = DungeonRouteThumbnail::create([
             'dungeon_route_id' => $dungeonRoute->id,
@@ -76,9 +99,13 @@ final class DungeonRouteThumbnailRepositoryTest extends PublicTestCase
     public function hasFreshThumbnailForVariant_givenThumbnailRenderedBeforeLastContentChange_returnsFalse(): void
     {
         // Arrange
-        $dungeon      = $this->getDungeonWithNonFacadeFloor();
-        $floor        = $dungeon->floors()->where('facade', false)->first();
-        $dungeonRoute = DungeonRoute::factory()->create(['dungeon_id' => $dungeon->id]);
+        $dungeon        = $this->getDungeonWithExactlyOneNonFacadeFloor();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $floor          = $dungeon->floors()->where('facade', false)->first();
+        $dungeonRoute   = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
 
         $thumbnail = DungeonRouteThumbnail::create([
             'dungeon_route_id' => $dungeonRoute->id,
@@ -106,9 +133,13 @@ final class DungeonRouteThumbnailRepositoryTest extends PublicTestCase
     {
         // Arrange - the legacy 'custom' boolean is intentionally left false here: 'variant' is the
         // single source of truth, and gating on both used to make the Custom variant unmatchable.
-        $dungeon      = $this->getDungeonWithNonFacadeFloor();
-        $floor        = $dungeon->floors()->where('facade', false)->first();
-        $dungeonRoute = DungeonRoute::factory()->create(['dungeon_id' => $dungeon->id]);
+        $dungeon        = $this->getDungeonWithExactlyOneNonFacadeFloor();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $floor          = $dungeon->floors()->where('facade', false)->first();
+        $dungeonRoute   = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
 
         $thumbnail = DungeonRouteThumbnail::create([
             'dungeon_route_id' => $dungeonRoute->id,
@@ -137,9 +168,13 @@ final class DungeonRouteThumbnailRepositoryTest extends PublicTestCase
         // Arrange - a partially-failed multi-floor render: one floor's thumbnail is fresh, but another
         // floor still carries a stale row from before the route's last content change. The stale floor
         // must not be masked by the fresh one.
-        $dungeon      = $this->getDungeonWithNonFacadeFloor();
-        $floor        = $dungeon->floors()->where('facade', false)->first();
-        $dungeonRoute = DungeonRoute::factory()->create(['dungeon_id' => $dungeon->id]);
+        $dungeon        = $this->getDungeonWithNonFacadeFloor();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $floor          = $dungeon->floors()->where('facade', false)->first();
+        $dungeonRoute   = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
 
         $freshThumbnail = DungeonRouteThumbnail::create([
             'dungeon_route_id' => $dungeonRoute->id,
@@ -171,6 +206,83 @@ final class DungeonRouteThumbnailRepositoryTest extends PublicTestCase
         } finally {
             $freshThumbnail->delete();
             $staleThumbnail->delete();
+            $dungeonRoute->delete();
+        }
+    }
+
+    #[Test]
+    public function hasFreshThumbnailForVariant_givenMissingThumbnailForOneOfMultipleFloors_returnsFalse(): void
+    {
+        // Arrange - a route whose dungeon has N non-facade floors, but hero thumbnails only exist (and
+        // are fresh) for N-1 of them. This is the fully-missing-floor case: a floor with zero rows has
+        // no updated_at to be caught as stale by the min() check, so it needs its own row-count check.
+        $dungeon        = $this->getDungeonWithMultipleNonFacadeFloors();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $floors         = $dungeon->floors()->where('facade', false)->where('active', true)->get();
+        $dungeonRoute   = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
+
+        $thumbnails = $floors->slice(0, -1)->map(function ($floor) use ($dungeonRoute) {
+            $thumbnail = DungeonRouteThumbnail::create([
+                'dungeon_route_id' => $dungeonRoute->id,
+                'floor_id'         => $floor->id,
+                'custom'           => false,
+                'variant'          => DungeonRouteThumbnailVariant::Hero,
+            ]);
+            DungeonRouteThumbnail::where('id', $thumbnail->id)
+                ->update(['updated_at' => $dungeonRoute->updated_at->copy()->addMinute()]);
+
+            return $thumbnail;
+        });
+
+        try {
+            // Act
+            $result = $this->repository->hasFreshThumbnailForVariant($dungeonRoute, DungeonRouteThumbnailVariant::Hero);
+
+            // Assert
+            $this->assertFalse($result);
+        } finally {
+            $thumbnails->each->delete();
+            $dungeonRoute->delete();
+        }
+    }
+
+    #[Test]
+    public function hasFreshThumbnailForVariant_givenFreshThumbnailsForAllFloors_returnsTrue(): void
+    {
+        // Arrange - the complete-set counterpart to the missing-floor test above: every floor has a
+        // fresh row, so the route must be reported as fresh.
+        $dungeon        = $this->getDungeonWithMultipleNonFacadeFloors();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $floors         = $dungeon->floors()->where('facade', false)->where('active', true)->get();
+        $dungeonRoute   = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
+
+        $thumbnails = $floors->map(function ($floor) use ($dungeonRoute) {
+            $thumbnail = DungeonRouteThumbnail::create([
+                'dungeon_route_id' => $dungeonRoute->id,
+                'floor_id'         => $floor->id,
+                'custom'           => false,
+                'variant'          => DungeonRouteThumbnailVariant::Hero,
+            ]);
+            DungeonRouteThumbnail::where('id', $thumbnail->id)
+                ->update(['updated_at' => $dungeonRoute->updated_at->copy()->addMinute()]);
+
+            return $thumbnail;
+        });
+
+        try {
+            // Act
+            $result = $this->repository->hasFreshThumbnailForVariant($dungeonRoute, DungeonRouteThumbnailVariant::Hero);
+
+            // Assert
+            $this->assertTrue($result);
+        } finally {
+            $thumbnails->each->delete();
             $dungeonRoute->delete();
         }
     }

--- a/tests/Feature/App/Service/DungeonRoute/ThumbnailServiceTest.php
+++ b/tests/Feature/App/Service/DungeonRoute/ThumbnailServiceTest.php
@@ -541,9 +541,10 @@ final class ThumbnailServiceTest extends PublicTestCase
     #[Test]
     public function queueThumbnailRefresh_givenHeroVariantAndFreshHeroThumbnail_doesNotQueue(): void
     {
-        // Arrange
+        // Arrange - a dungeon with exactly one non-facade floor, so the freshness check's expected-floor-
+        // count (one thumbnail == one floor) doesn't flake on dungeons with several floors.
         Queue::fake();
-        $dungeon        = $this->getDungeonWithNonFacadeFloor();
+        $dungeon        = $this->getDungeonWithExactlyOneNonFacadeFloor();
         $mappingVersion = $dungeon->getCurrentMappingVersion();
         $floor          = $dungeon->floors()->where('facade', false)->first();
         $dungeonRoute   = DungeonRoute::factory()->create([
@@ -582,7 +583,7 @@ final class ThumbnailServiceTest extends PublicTestCase
     {
         // Arrange
         Queue::fake();
-        $dungeon        = $this->getDungeonWithNonFacadeFloor();
+        $dungeon        = $this->getDungeonWithExactlyOneNonFacadeFloor();
         $mappingVersion = $dungeon->getCurrentMappingVersion();
         $floor          = $dungeon->floors()->where('facade', false)->first();
         $dungeonRoute   = DungeonRoute::factory()->create([
@@ -612,6 +613,49 @@ final class ThumbnailServiceTest extends PublicTestCase
             Queue::assertPushed(ProcessRouteFloorThumbnail::class);
         } finally {
             $heroThumbnail->delete();
+            $dungeonRoute->delete();
+        }
+    }
+
+    #[Test]
+    public function queueThumbnailRefresh_givenHeroVariantAndOneOfMultipleFloorsMissingThumbnail_queuesAHeroJob(): void
+    {
+        // Arrange - a multi-floor route where every floor except one already has a fresh hero thumbnail.
+        // The wholly-missing floor has no row at all (not just a stale one), so it must still trigger a
+        // requeue rather than being masked by the other fresh floors.
+        Queue::fake();
+        $dungeon        = $this->getDungeonWithMultipleNonFacadeFloors();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $floors         = $dungeon->floors()->where('facade', false)->where('active', true)->get();
+        $dungeonRoute   = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
+
+        $heroThumbnails = $floors->slice(0, -1)->map(function ($floor) use ($dungeonRoute) {
+            $thumbnail = DungeonRouteThumbnail::create([
+                'dungeon_route_id' => $dungeonRoute->id,
+                'floor_id'         => $floor->id,
+                'custom'           => false,
+                'variant'          => DungeonRouteThumbnailVariant::Hero,
+            ]);
+            DungeonRouteThumbnail::where('id', $thumbnail->id)
+                ->update(['updated_at' => $dungeonRoute->updated_at->copy()->addMinute()]);
+
+            return $thumbnail;
+        });
+
+        $service = $this->buildService($this->createMockPublic(ThumbnailServiceLoggingInterface::class));
+
+        try {
+            // Act
+            $result = $service->queueThumbnailRefresh($dungeonRoute, false, DungeonRouteThumbnailVariant::Hero);
+
+            // Assert
+            $this->assertTrue($result);
+            Queue::assertPushed(ProcessRouteFloorThumbnail::class, $floors->count());
+        } finally {
+            $heroThumbnails->each->delete();
             $dungeonRoute->delete();
         }
     }

--- a/tests/Feature/Traits/ProvidesDungeon.php
+++ b/tests/Feature/Traits/ProvidesDungeon.php
@@ -46,6 +46,75 @@ trait ProvidesDungeon
 
     /**
      * Returns a random dungeon guaranteed to have a current mapping version with facade rendering
+     * disabled and EXACTLY one non-facade floor. Use this instead of getDungeonWithNonFacadeFloor()
+     * when a test seeds a single thumbnail row and asserts on freshness/count, since several seeded
+     * dungeons (e.g. Karazhan) have many non-facade floors and would make such an assertion flaky.
+     *
+     * @param (Closure(Builder<Dungeon>): mixed)|null $constraint Optional extra constraint applied to the base query.
+     */
+    protected function getDungeonWithExactlyOneNonFacadeFloor(?Closure $constraint = null): Dungeon
+    {
+        $count = 0;
+        do {
+            if (++$count > 20) {
+                throw new \RuntimeException('Unable to find a dungeon with exactly one non-facade floor and a mapping version');
+            }
+
+            $query = Dungeon::query();
+            if ($constraint !== null) {
+                $constraint($query);
+            }
+
+            /** @var Dungeon $dungeon */
+            $dungeon = $query->inRandomOrder()->first();
+        } while (
+            ($mappingVersion = $dungeon->getCurrentMappingVersion()) === null ||
+            $mappingVersion->facade_enabled ||
+            // Mirrors floorsForMapFacade(...)->active(): an inactive floor row is never dispatched a job
+            // and must not be counted as "expected", or the freshness check's floor count would disagree
+            // with reality.
+            $dungeon->floors()->where('facade', 0)->where('active', 1)->count() !== 1 ||
+            $dungeon->floors()->where('facade', 1)->exists()
+        );
+
+        return $dungeon;
+    }
+
+    /**
+     * Returns a random dungeon guaranteed to have a current mapping version with facade rendering
+     * disabled and at least two active non-facade floors. Use this to exercise "missing thumbnail for
+     * one of several floors" scenarios.
+     *
+     * @param (Closure(Builder<Dungeon>): mixed)|null $constraint Optional extra constraint applied to the base query.
+     */
+    protected function getDungeonWithMultipleNonFacadeFloors(?Closure $constraint = null): Dungeon
+    {
+        $count = 0;
+        do {
+            if (++$count > 20) {
+                throw new \RuntimeException('Unable to find a dungeon with multiple non-facade floors and a mapping version');
+            }
+
+            $query = Dungeon::query();
+            if ($constraint !== null) {
+                $constraint($query);
+            }
+
+            /** @var Dungeon $dungeon */
+            $dungeon = $query->inRandomOrder()->first();
+        } while (
+            ($mappingVersion = $dungeon->getCurrentMappingVersion()) === null ||
+            $mappingVersion->facade_enabled ||
+            // Mirrors floorsForMapFacade(...)->active(): see getDungeonWithExactlyOneNonFacadeFloor().
+            $dungeon->floors()->where('facade', 0)->where('active', 1)->count() < 2 ||
+            $dungeon->floors()->where('facade', 1)->exists()
+        );
+
+        return $dungeon;
+    }
+
+    /**
+     * Returns a random dungeon guaranteed to have a current mapping version with facade rendering
      * enabled and at least one facade floor. Use this when a test needs to exercise the
      * facade-specific code paths.
      *


### PR DESCRIPTION
:robot: Closes #3651

## Summary

`DungeonRouteThumbnailRepository::hasFreshThumbnailForVariant()` previously
only compared the **oldest** existing thumbnail row's `updated_at` against
the route (fixed in #3447 to replace `max()` with `min()`). That caught a
stale-but-present row on one floor, but a floor with **zero** thumbnail rows
for the variant (a render that never ran or never succeeded) had no
`updated_at` to compare at all, so it stayed invisible to the freshness check
until the route was next edited — the hourly `EnsureHeroThumbnails` command
would never re-queue it.

This PR adds a row-count check: the existing thumbnail-row count for the
variant is compared against the expected floor count from
`Dungeon::floorsForMapFacade(...)->active()`, mirroring exactly what
`ThumbnailService::queueThumbnailRefresh()` dispatches jobs for. If a route
is missing rows for one or more floors, it's now reported as not fresh and
gets re-queued.

Also guards against a `null` `mappingVersion` (nullable in the schema/legacy
data), which the new floor-count lookup needs but the old code never touched.

## Test fixtures

The existing single-thumbnail tests used `getDungeonWithNonFacadeFloor()`,
and several seeded dungeons in that pool have multiple non-facade floors
(e.g. Karazhan: 17) — asserting "one thumbnail == fresh" against those would
now be flaky under the new row-count check. Added two new fixture helpers to
`ProvidesDungeon`:
- `getDungeonWithExactlyOneNonFacadeFloor()` — used by the existing
  single-thumbnail tests to keep them deterministic.
- `getDungeonWithMultipleNonFacadeFloors()` — used by the new
  missing-floor regression tests.

New tests:
- `DungeonRouteThumbnailRepositoryTest`: null-mapping-version guard,
  missing-one-of-several-floors → not fresh, all-floors-fresh → fresh.
- `ThumbnailServiceTest`: `queueThumbnailRefresh` queues a hero job when one
  of several floors is missing its thumbnail entirely.

## Base branch

This stacks on `3349-route-poster-card` (#3447, still open) since the
`hasFreshThumbnailForVariant()`/`EnsureHeroThumbnails` code this follow-up
touches only exists on that branch. Will need retargeting to `master` once
#3447 merges.

## Test plan
- [x] `DungeonRouteThumbnailRepositoryTest` green (reran 5x for fixture
      determinism)
- [x] `ThumbnailServiceTest` green (reran 3x)
- [x] `EnsureHeroThumbnailsTest` green
- [x] `composer run fix` clean
- [x] `composer run analyse` clean