### PR TITLE
#170 Move inline controller authorization into policies

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
+++ b/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
@@ -183,12 +183,10 @@ class AjaxDungeonRouteController extends Controller
 
             // Handle team if set
             if ($teamPublicKey) {
-                // @TODO Policy?
-                // You must be a member of this team to retrieve their routes
+                // You must be a member of this team to retrieve their routes - TeamPolicy::edit is
+                // exactly that check
                 $team = Team::where('public_key', $teamPublicKey)->firstOrFail();
-                if (!$team->isUserMember($user)) {
-                    abort(403, 'Unauthorized');
-                }
+                Gate::authorize('edit', $team);
 
                 // If available, we need all routes which MAY be assigned to this team, so all routes where
                 // team_id = null and the author is one of the team members

--- a/app/Http/Controllers/Ajax/AjaxMapIconController.php
+++ b/app/Http/Controllers/Ajax/AjaxMapIconController.php
@@ -8,7 +8,6 @@ use App\Events\Models\ModelChangedEvent;
 use App\Http\Controllers\Traits\ChangesDungeonRoute;
 use App\Http\Requests\MapIcon\MapIconFormRequest;
 use App\Models\DungeonRoute\DungeonRoute;
-use App\Models\Laratrust\Role;
 use App\Models\MapIcon;
 use App\Models\Mapping\MappingModelInterface;
 use App\Models\Mapping\MappingVersion;
@@ -24,7 +23,6 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Override;
-use Teapot\StatusCode;
 use Teapot\StatusCode\Http;
 use Throwable;
 
@@ -64,15 +62,9 @@ class AjaxMapIconController extends AjaxMappingModelBaseController
         $validated                     = $request->validated();
         $validated['dungeon_route_id'] = $dungeonRoute?->id;
 
-        /** @var User|null $user */
-        $user = Auth::user();
-
-        $isUserAdmin = $user?->hasRole(Role::ROLE_ADMIN);
-        // Must be an admin to use this endpoint like this!
+        // No dungeon route means this icon is part of the mapping itself - admin only
         if ($dungeonRoute === null) {
-            if (!$isUserAdmin) {
-                throw new Exception('Unable to save map icon!');
-            }
+            Gate::authorize('createGlobal', MapIcon::class);
         } // We're editing a map comment for the user, carry on
         else {
             Gate::authorize('edit', $dungeonRoute);
@@ -88,23 +80,20 @@ class AjaxMapIconController extends AjaxMappingModelBaseController
             $validated,
             MapIcon::class,
             $mapIcon,
-            function (MapIcon $mapIcon) use ($coordinatesService, $validated, $user, $dungeonRoute, &$beforeModel) {
+            function (MapIcon $mapIcon) use ($coordinatesService, $validated, $dungeonRoute, &$beforeModel) {
                 // Set the team_id if the user has the rights to do this. May be null if not set or no rights for it.
                 $updateAttributes = [];
                 $teamId           = $validated['team_id'];
-                if ($teamId !== null) {
-                    $team = Team::find($teamId);
-                    if ($team !== null && $user !== null && $team->isUserCollaborator($user)) {
-                        $updateAttributes = [
-                            'team_id'          => $teamId,
-                            'dungeon_route_id' => null,
-                        ];
-                    }
+                if ($teamId !== null && Gate::allows('assignToTeam', [$mapIcon, Team::find($teamId)])) {
+                    $updateAttributes = [
+                        'team_id'          => $teamId,
+                        'dungeon_route_id' => null,
+                    ];
                 }
 
                 // Prevent people being able to update icons that only the admin should if they're supplying a valid dungeon route
-                if ($mapIcon->exists && $mapIcon->dungeon_route_id === null && $dungeonRoute !== null && $mapIcon->team_id === null) {
-                    throw new Exception('Unable to save map icon!');
+                if ($mapIcon->exists && $dungeonRoute !== null) {
+                    Gate::authorize('update', $mapIcon);
                 }
 
                 // The incoming lat/lngs are facade lat/lngs, save the icon on the proper floor
@@ -169,12 +158,10 @@ class AjaxMapIconController extends AjaxMappingModelBaseController
     {
         $dungeonRoute = $mapIcon->dungeonRoute;
 
-        $isAdmin = Auth::check() && Auth::user()->hasRole(Role::ROLE_ADMIN);
-        // Must be an admin to use this endpoint like this!
-        if (!$isAdmin && ($dungeonRoute === null || $mapIcon->dungeon_route_id === null)) {
-            return response(null, StatusCode::FORBIDDEN);
-        } // We're editing a map icon for the user, carry on
-        elseif ($dungeonRoute !== null) {
+        // Anything not attached to a dungeon route is part of the mapping - admin only
+        Gate::authorize('delete', $mapIcon);
+
+        if ($dungeonRoute !== null) {
             // Edit intentional; don't use delete rule because team members shouldn't be able to delete someone else's map comment
             Gate::authorize('edit', $dungeonRoute);
         }

--- a/app/Http/Controllers/Ajax/AjaxProfileController.php
+++ b/app/Http/Controllers/Ajax/AjaxProfileController.php
@@ -6,9 +6,11 @@ use App\Http\Controllers\Controller;
 use App\Models\Patreon\PatreonAdFreeGiveaway;
 use App\Models\Patreon\PatreonBenefit;
 use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 class AjaxProfileController extends Controller
 {
@@ -49,18 +51,17 @@ class AjaxProfileController extends Controller
         ]);
     }
 
+    /**
+     * @throws AuthorizationException
+     */
     public function removeAdFreeGiveaway(Request $request, User $user): Response
     {
-        /** @var User $currentUser */
-        $currentUser = Auth::user();
-
         if ($user->patreonAdFreeGiveaway === null) {
             abort(422, __('controller.profile.error.remove_ad_free_giveaway_not_found'));
         }
 
-        if ($user->patreonAdFreeGiveaway->giver_user_id !== $currentUser->id) {
-            abort(422, __('controller.profile.error.remove_ad_free_giveaway_not_yours'));
-        }
+        // Only the giver may take their own giveaway back
+        Gate::authorize('revokeAdFreeGiveaway', $user);
 
         $user->patreonAdFreeGiveaway->delete();
 

--- a/app/Http/Controllers/Ajax/AjaxTeamController.php
+++ b/app/Http/Controllers/Ajax/AjaxTeamController.php
@@ -65,23 +65,15 @@ class AjaxTeamController extends Controller
      */
     public function changeRole(Request $request, Team $team)
     {
-        Gate::authorize('change-role', $team);
-
-        /** @var User $user */
-        $user = Auth::user();
         /** @var User $targetUser */
         $targetUser = User::where('name', $request->get('username'))->firstOrFail();
         $role       = $request->get('role');
 
-        // Only if the current user may do such a thing
-        if ($team->canChangeRole($user, $targetUser, $role)) {
-            $team->changeRole($targetUser, $role);
-            $result = response()->noContent();
-        } else {
-            $result = response('Forbidden', Http::FORBIDDEN);
-        }
+        Gate::authorize('change-role', [$team, $targetUser, $role]);
 
-        return $result;
+        $team->changeRole($targetUser, $role);
+
+        return response()->noContent();
     }
 
     /**
@@ -91,19 +83,12 @@ class AjaxTeamController extends Controller
      */
     public function addRoute(Request $request, Team $team, DungeonRoute $dungeonroute)
     {
+        // moderate-route resolves to TeamPolicy::moderateRoute, which is canAddRemoveRoute()
         Gate::authorize('moderate-route', $team);
 
-        /** @var User $user */
-        $user = Auth::user();
+        $team->addRoute($dungeonroute);
 
-        if ($team->canAddRemoveRoute($user)) {
-            $team->addRoute($dungeonroute);
-            $result = response()->noContent();
-        } else {
-            $result = response('Forbidden', Http::FORBIDDEN);
-        }
-
-        return $result;
+        return response()->noContent();
     }
 
     /**
@@ -113,19 +98,12 @@ class AjaxTeamController extends Controller
      */
     public function removeRoute(Request $request, Team $team, DungeonRoute $dungeonroute)
     {
+        // moderate-route resolves to TeamPolicy::moderateRoute, which is canAddRemoveRoute()
         Gate::authorize('moderate-route', $team);
 
-        /** @var User $user */
-        $user = Auth::user();
+        $team->removeRoute($dungeonroute);
 
-        if ($team->canAddRemoveRoute($user)) {
-            $team->removeRoute($dungeonroute);
-            $result = response()->noContent();
-        } else {
-            $result = response('Forbidden', Http::FORBIDDEN);
-        }
-
-        return $result;
+        return response()->noContent();
     }
 
     /**
@@ -220,16 +198,12 @@ class AjaxTeamController extends Controller
     {
         Gate::authorize('can-ad-free-giveaway', $team);
 
-        /** @var User $currentUser */
-        $currentUser = Auth::user();
-
         if ($user->patreonAdFreeGiveaway === null) {
             abort(422, 'Unable to remove ad-free giveaway - user does not have any at the moment.');
         }
 
-        if ($user->patreonAdFreeGiveaway->giver_user_id !== $currentUser->id) {
-            abort(422, 'Unable to remove ad-free giveaways that was not originally given by you.');
-        }
+        // Only the giver may take their own giveaway back
+        Gate::authorize('revokeAdFreeGiveaway', $user);
 
         $user->patreonAdFreeGiveaway->delete();
 

--- a/app/Http/Controllers/Ajax/AjaxTeamController.php
+++ b/app/Http/Controllers/Ajax/AjaxTeamController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Ajax;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Team\TeamChangeRoleFormRequest;
 use App\Http\Requests\Team\TeamDefaultRoleFormRequest;
 use App\Http\Requests\Team\TeamRoutePublishingFormRequest;
 use App\Models\DungeonRoute\DungeonRoute;
@@ -63,11 +64,10 @@ class AjaxTeamController extends Controller
      *
      * @throws Exception
      */
-    public function changeRole(Request $request, Team $team)
+    public function changeRole(TeamChangeRoleFormRequest $request, Team $team)
     {
-        /** @var User $targetUser */
-        $targetUser = User::where('name', $request->get('username'))->firstOrFail();
-        $role       = $request->get('role');
+        $targetUser = $request->targetUser();
+        $role       = $request->validated('role');
 
         Gate::authorize('change-role', [$team, $targetUser, $role]);
 

--- a/app/Http/Controllers/Ajax/AjaxUserController.php
+++ b/app/Http/Controllers/Ajax/AjaxUserController.php
@@ -9,10 +9,10 @@ use App\Logic\Datatables\ColumnHandler\Users\IdColumnHandler;
 use App\Logic\Datatables\ColumnHandler\Users\NameColumnHandler;
 use App\Logic\Datatables\UsersDatatablesHandler;
 use App\Models\User;
-use Auth;
 use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
-use Teapot\StatusCode;
+use Illuminate\Support\Facades\Gate;
 
 class AjaxUserController extends Controller
 {
@@ -64,16 +64,15 @@ class AjaxUserController extends Controller
         return $datatablesResult;
     }
 
+    /**
+     * @throws AuthorizationException
+     */
     public function store(UserFormRequest $request, string $publicKey): User
     {
-        /** @var User|null $user */
-        $user = User::where('public_key', $publicKey)->first();
+        /** @var User $user */
+        $user = User::where('public_key', $publicKey)->firstOrFail();
 
-        /** @var User|null $currentUser */
-        $currentUser = Auth::user();
-        if ($user === null || $user->public_key !== $currentUser?->public_key) {
-            abort(StatusCode::BAD_REQUEST);
-        }
+        Gate::authorize('update', $user);
 
         $user->update($request->validated());
 

--- a/app/Http/Controllers/DungeonRoute/DungeonRouteController.php
+++ b/app/Http/Controllers/DungeonRoute/DungeonRouteController.php
@@ -405,13 +405,17 @@ class DungeonRouteController extends Controller
         }
     }
 
+    /**
+     * @throws AuthorizationException
+     */
     public function claim(
         Request      $request,
         Dungeon      $dungeon,
         DungeonRoute $dungeonroute,
         string       $title,
     ): RedirectResponse {
-        // Regardless of the result, try to claim the route
+        Gate::authorize('claim', $dungeonroute);
+
         $dungeonroute->claim(Auth::id());
 
         return redirect()->route('dungeonroute.edit', [

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -6,7 +6,6 @@ use App\Events\UserColorChangedEvent;
 use App\Http\Requests\ProfileFormRequest;
 use App\Http\Requests\Tag\TagFormRequest;
 use App\Models\DungeonRoute\DungeonRoute;
-use App\Models\Laratrust\Role;
 use App\Models\LiveSession;
 use App\Models\Season;
 use App\Models\Tags\Tag;
@@ -20,6 +19,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
@@ -251,9 +251,8 @@ class ProfileController extends Controller
     {
         /** @var User $user */
         $user = Auth::getUser();
-        if ($user->hasRole(Role::ROLE_ADMIN)) {
-            throw new Exception(__('controller.profile.flash.admins_cannot_delete_themselves'));
-        }
+
+        Gate::authorize('delete', $user);
 
         try {
             User::findOrFail($user->id)->delete();

--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -54,9 +54,8 @@ class TeamController extends Controller
         $team->invite_code  = Team::generateRandomPublicKey(12, 'invite_code');
         $team->icon_file_id = -1;
 
-        /** @var User $currentUser */
-        $currentUser = Auth::user();
-        if ($currentUser->hasRole(Role::ROLE_ADMIN)) {
+        // Field-level authorization: only whoever may change route publishing gets to set it here
+        if (Gate::allows('change-route-publishing', $team)) {
             $team->route_publishing_enabled = $request->boolean('route_publishing_enabled');
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -8,11 +8,12 @@ use App\Models\Patreon\PatreonUserBenefit;
 use App\Models\Patreon\PatreonUserLink;
 use App\Models\User;
 use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 use Session;
 use Teapot\StatusCode\Http;
@@ -30,43 +31,40 @@ class UserController extends Controller
         ]);
     }
 
+    /**
+     * @throws AuthorizationException
+     */
     public function makeRole(Request $request, User $user, string $role): RedirectResponse
     {
-        /** @var User|null $currentUser */
-        $currentUser = Auth::user();
+        Gate::authorize('makeRole', [$user, $role]);
 
-        if ($currentUser !== null) {
-            if ($role === Role::ROLE_ADMIN) {
-                // Only super admins can make someone else admin!
-                if (in_array($currentUser->name, config('keystoneguru.super_admins', []), true)) {
-                    if (!$user->hasRole(Role::ROLE_ADMIN)) {
-                        $user->addRole(Role::ROLE_ADMIN);
-
-                        // Message to the user
-                        Session::flash('status', __('controller.user.flash.user_is_now_an_admin', ['user' => $user->name]));
-                    } else {
-                        $user->removeRole(Role::ROLE_ADMIN);
-
-                        // Message to the user
-                        Session::flash('status', __('controller.user.flash.user_is_no_longer_an_admin', ['user' => $user->name]));
-                    }
-                }
-            } elseif ($role === Role::ROLE_USER) {
-                $user->removeRoles($user->roles->toArray());
-
-                $user->addRole($role);
+        if ($role === Role::ROLE_ADMIN) {
+            if (!$user->hasRole(Role::ROLE_ADMIN)) {
+                $user->addRole(Role::ROLE_ADMIN);
 
                 // Message to the user
-                Session::flash('status', __('controller.user.flash.user_is_now_a_user', ['user' => $user->name]));
+                Session::flash('status', __('controller.user.flash.user_is_now_an_admin', ['user' => $user->name]));
             } else {
-                $user->addRole($role);
+                $user->removeRole(Role::ROLE_ADMIN);
 
                 // Message to the user
-                Session::flash('status', __('controller.user.flash.user_is_now_a_role', [
-                    'user' => $user->name,
-                    'role' => $role,
-                ]));
+                Session::flash('status', __('controller.user.flash.user_is_no_longer_an_admin', ['user' => $user->name]));
             }
+        } elseif ($role === Role::ROLE_USER) {
+            $user->removeRoles($user->roles->toArray());
+
+            $user->addRole($role);
+
+            // Message to the user
+            Session::flash('status', __('controller.user.flash.user_is_now_a_user', ['user' => $user->name]));
+        } else {
+            $user->addRole($role);
+
+            // Message to the user
+            Session::flash('status', __('controller.user.flash.user_is_now_a_role', [
+                'user' => $user->name,
+                'role' => $role,
+            ]));
         }
 
         return redirect()->route('admin.users');

--- a/app/Http/Requests/Team/TeamChangeRoleFormRequest.php
+++ b/app/Http/Requests/Team/TeamChangeRoleFormRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Team;
+
+use App\Models\TeamUser;
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * User wants to change the role of another user in the team
+ */
+class TeamChangeRoleFormRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string|Rule>|string|Rule>
+     */
+    public function rules(): array
+    {
+        return [
+            'username' => ['required', 'string', 'exists:users,name'],
+            'role'     => ['required', 'string', Rule::in(array_keys(TeamUser::ALL_ROLES))],
+        ];
+    }
+
+    public function targetUser(): User
+    {
+        return once(fn() => User::where('name', $this->validated('username'))->firstOrFail());
+    }
+}

--- a/app/Policies/DungeonRoutePolicy.php
+++ b/app/Policies/DungeonRoutePolicy.php
@@ -95,6 +95,17 @@ class DungeonRoutePolicy
     }
 
     /**
+     * Determine whether the user can claim a dungeon route as their own.
+     * Only sandbox routes are unowned and therefore claimable.
+     */
+    public function claim(User $user, DungeonRoute $dungeonroute): Response
+    {
+        return $dungeonroute->isSandbox() ?
+            $this->allow() :
+            $this->deny(__('policy.claim_route_not_claimable'));
+    }
+
+    /**
      * Determine whether the user can migrate a dungeon route.
      */
     public function migrate(User $user, DungeonRoute $dungeonroute): bool

--- a/app/Policies/MapIconPolicy.php
+++ b/app/Policies/MapIconPolicy.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Laratrust\Role;
+use App\Models\MapIcon;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
+
+class MapIconPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can create a map icon that is not attached to a dungeon route -
+     * i.e. one that is part of the mapping itself and visible to everyone.
+     */
+    public function createGlobal(?User $user): Response
+    {
+        return $user !== null && $user->hasRole(Role::ROLE_ADMIN) ?
+            $this->allow() :
+            $this->deny(__('policy.create_global_map_icon_admin_only'));
+    }
+
+    /**
+     * Determine whether the user can update an existing map icon while editing a dungeon route.
+     * A mapping icon (no dungeon route, no team) belongs to the mapping and is admin-only, even
+     * when the request supplies a route the user may otherwise edit.
+     */
+    public function update(?User $user, MapIcon $mapIcon): Response
+    {
+        if ($mapIcon->dungeon_route_id !== null || $mapIcon->team_id !== null) {
+            return $this->allow();
+        }
+
+        return $user !== null && $user->hasRole(Role::ROLE_ADMIN) ?
+            $this->allow() :
+            $this->deny(__('policy.update_map_icon_admin_only'));
+    }
+
+    /**
+     * Determine whether the user can delete the map icon. Anything not attached to a dungeon route
+     * is admin-only.
+     *
+     * Note this is deliberately stricter than update(): a team icon is updatable by a collaborator
+     * but only deletable by an admin. That asymmetry is pre-existing behaviour, preserved verbatim
+     * here rather than silently changed.
+     *
+     * Callers must still authorize 'edit' on the icon's dungeon route separately - "edit" and not
+     * "delete", so team members cannot delete each other's map comments.
+     */
+    public function delete(?User $user, MapIcon $mapIcon): Response
+    {
+        if ($mapIcon->dungeon_route_id !== null) {
+            return $this->allow();
+        }
+
+        return $user !== null && $user->hasRole(Role::ROLE_ADMIN) ?
+            $this->allow() :
+            $this->deny(__('policy.update_map_icon_admin_only'));
+    }
+
+    /**
+     * Determine whether the user can attach a map icon to the given team, which makes it visible
+     * to every member of that team.
+     */
+    public function assignToTeam(?User $user, MapIcon $mapIcon, ?Team $team): bool
+    {
+        return $team !== null && $user !== null && $team->isUserCollaborator($user);
+    }
+}

--- a/app/Policies/MapIconPolicy.php
+++ b/app/Policies/MapIconPolicy.php
@@ -26,8 +26,10 @@ class MapIconPolicy
 
     /**
      * Determine whether the user can update an existing map icon while editing a dungeon route.
-     * A mapping icon (no dungeon route, no team) belongs to the mapping and is admin-only, even
-     * when the request supplies a route the user may otherwise edit.
+     * A mapping icon (no dungeon route, no team) belongs to the mapping - this endpoint is only
+     * ever reached with an incoming dungeon route, so allowing it here would let anyone (even an
+     * admin) reassign a global mapping icon to a personal route, which was never possible before
+     * this policy existed. That transition is denied unconditionally, not just non-admin-gated.
      */
     public function update(?User $user, MapIcon $mapIcon): Response
     {
@@ -35,9 +37,7 @@ class MapIconPolicy
             return $this->allow();
         }
 
-        return $user !== null && $user->hasRole(Role::ROLE_ADMIN) ?
-            $this->allow() :
-            $this->deny(__('policy.update_map_icon_admin_only'));
+        return $this->deny(__('policy.update_map_icon_admin_only'));
     }
 
     /**
@@ -59,7 +59,7 @@ class MapIconPolicy
 
         return $user !== null && $user->hasRole(Role::ROLE_ADMIN) ?
             $this->allow() :
-            $this->deny(__('policy.update_map_icon_admin_only'));
+            $this->deny(__('policy.delete_map_icon_admin_only'));
     }
 
     /**

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -34,9 +34,14 @@ class TeamPolicy
         return $team->canAddRemoveRoute($user);
     }
 
-    public function changeRole(User $user, Team $team): bool
+    /**
+     * Determine whether the user can change $targetUser's role in the team into $role.
+     * Being a moderator is not enough on its own - canChangeRole() additionally enforces the rank
+     * ordering, so nobody can promote past their own rank or demote someone above them.
+     */
+    public function changeRole(User $user, Team $team, User $targetUser, string $role): bool
     {
-        return $team->isUserModerator($user);
+        return $team->isUserModerator($user) && $team->canChangeRole($user, $targetUser, $role);
     }
 
     public function changeDefaultRole(User $user, Team $team): bool

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Laratrust\Role;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
+
+class UserPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can update the target user's profile settings.
+     */
+    public function update(User $user, User $target): bool
+    {
+        // A user may only ever update their own settings
+        return $user->id === $target->id;
+    }
+
+    /**
+     * Determine whether the user can delete the target user's account.
+     * Admins cannot delete themselves - the site would be left without one.
+     */
+    public function delete(User $user, User $target): Response
+    {
+        if ($user->id !== $target->id) {
+            return $this->deny();
+        }
+
+        if ($user->hasRole(Role::ROLE_ADMIN)) {
+            return $this->deny(__('controller.profile.flash.admins_cannot_delete_themselves'));
+        }
+
+        return $this->allow();
+    }
+
+    /**
+     * Determine whether the user can grant or revoke the given role on the target user.
+     * Granting or revoking admin is restricted to the super admins configured in
+     * keystoneguru.super_admins; every other role only requires being an admin.
+     */
+    public function makeRole(User $user, User $target, string $role): Response
+    {
+        if (!$user->hasRole(Role::ROLE_ADMIN)) {
+            return $this->deny();
+        }
+
+        if ($role !== Role::ROLE_ADMIN) {
+            return $this->allow();
+        }
+
+        return in_array($user->name, config('keystoneguru.super_admins', []), true) ?
+            $this->allow() :
+            $this->deny(__('policy.make_role_only_super_admins_may_grant_admin'));
+    }
+
+    /**
+     * Determine whether the user can revoke the ad-free giveaway the target user currently has.
+     * Only the giver may take their own giveaway back.
+     */
+    public function revokeAdFreeGiveaway(User $user, User $target): bool
+    {
+        return $target->patreonAdFreeGiveaway !== null &&
+            $target->patreonAdFreeGiveaway->giver_user_id === $user->id;
+    }
+}

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -59,11 +59,15 @@ class UserPolicy
 
     /**
      * Determine whether the user can revoke the ad-free giveaway the target user currently has.
-     * Only the giver may take their own giveaway back.
+     * Only the giver may take their own giveaway back. Callers already guard the "no giveaway to
+     * revoke" case themselves before authorizing, so this only needs to carry the "not yours"
+     * message the old inline checks showed instead of a generic deny.
      */
-    public function revokeAdFreeGiveaway(User $user, User $target): bool
+    public function revokeAdFreeGiveaway(User $user, User $target): Response
     {
         return $target->patreonAdFreeGiveaway !== null &&
-            $target->patreonAdFreeGiveaway->giver_user_id === $user->id;
+            $target->patreonAdFreeGiveaway->giver_user_id === $user->id ?
+            $this->allow() :
+            $this->deny(__('controller.profile.error.remove_ad_free_giveaway_not_yours'));
     }
 }

--- a/lang/en_US/policy.php
+++ b/lang/en_US/policy.php
@@ -14,4 +14,9 @@ return [
     'add_map_icon_limit_reached'              => 'Unable to add more than :limit map icons to a single route.',
     'schedule_publish_route_not_in_team'      => 'Unable to schedule publish: this route is not assigned to a team.',
 
+    'claim_route_not_claimable'                   => 'This route already has an author and cannot be claimed.',
+    'make_role_only_super_admins_may_grant_admin' => 'Only super admins may grant or revoke the admin role.',
+    'create_global_map_icon_admin_only'           => 'Only administrators may create map icons that are not attached to a route.',
+    'update_map_icon_admin_only'                  => 'Only administrators may change map icons that are not attached to a route or team.',
+
 ];

--- a/lang/en_US/policy.php
+++ b/lang/en_US/policy.php
@@ -18,5 +18,6 @@ return [
     'make_role_only_super_admins_may_grant_admin' => 'Only super admins may grant or revoke the admin role.',
     'create_global_map_icon_admin_only'           => 'Only administrators may create map icons that are not attached to a route.',
     'update_map_icon_admin_only'                  => 'Only administrators may change map icons that are not attached to a route or team.',
+    'delete_map_icon_admin_only'                  => 'Only administrators may delete map icons that are not attached to a route.',
 
 ];

--- a/tests/Feature/Controller/Ajax/AjaxTeamControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxTeamControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature\Controller\Ajax;
+
+use App\Models\Laratrust\Role;
+use App\Models\Team;
+use App\Models\TeamUser;
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Teapot\StatusCode;
+use Tests\TestCases\AjaxPublicTestCase;
+
+/**
+ * changeRole() used to read `role` straight off the request with no validation, so a missing or
+ * array `role` reached TeamPolicy::changeRole()'s `string $role` parameter and 500'd instead of
+ * returning a clean validation error. These tests pin the validation gap shut.
+ */
+#[Group('Controller')]
+#[Group('Team')]
+final class AjaxTeamControllerTest extends AjaxPublicTestCase
+{
+    private Team $team;
+
+    private User $moderator;
+
+    private User $member;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->team = Team::create([
+            'name'         => sprintf('Ajax team test %s', uniqid()),
+            'public_key'   => Team::generateRandomPublicKey(),
+            'invite_code'  => Team::generateRandomPublicKey(12, 'invite_code'),
+            'description'  => 'Created by AjaxTeamControllerTest',
+            'icon_file_id' => -1,
+            'default_role' => TeamUser::ROLE_MEMBER,
+        ]);
+
+        $this->moderator = User::factory()->create();
+        $this->moderator->addRole(Role::ROLE_USER);
+
+        $this->member = User::factory()->create();
+        $this->member->addRole(Role::ROLE_USER);
+
+        TeamUser::create(['team_id' => $this->team->id, 'user_id' => $this->moderator->id, 'role' => TeamUser::ROLE_MODERATOR]);
+        TeamUser::create(['team_id' => $this->team->id, 'user_id' => $this->member->id, 'role' => TeamUser::ROLE_MEMBER]);
+
+        $this->actingAs($this->moderator);
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        try {
+            // Team's "deleting" hook walks members->patreonAdFreeGiveaway, which trips
+            // preventLazyLoading unless the chain is eager-loaded first.
+            $this->team->load('members.patreonAdFreeGiveaway')->delete();
+            $this->member->delete();
+            $this->moderator->delete();
+        } finally {
+            parent::tearDown();
+        }
+    }
+
+    #[Test]
+    public function changeRole_givenValidRoleAndUsername_returnsNoContentAndUpdatesRole(): void
+    {
+        // Act
+        $response = $this->put($this->changeRoleUrl(), [
+            'username' => $this->member->name,
+            'role'     => TeamUser::ROLE_COLLABORATOR,
+        ]);
+
+        // Assert
+        $response->assertNoContent();
+        $this->assertSame(
+            TeamUser::ROLE_COLLABORATOR,
+            TeamUser::query()->where('team_id', $this->team->id)->where('user_id', $this->member->id)->value('role'),
+        );
+    }
+
+    #[Test]
+    public function changeRole_givenMissingRole_returnsValidationError(): void
+    {
+        // Act
+        $response = $this->put($this->changeRoleUrl(), [
+            'username' => $this->member->name,
+        ]);
+
+        // Assert
+        $response->assertStatus(StatusCode::FOUND);
+        $response->assertSessionHasErrors(['role']);
+    }
+
+    #[Test]
+    public function changeRole_givenRoleAsArray_returnsValidationError(): void
+    {
+        // Act - this exact shape used to TypeError past validation and 500
+        $response = $this->put($this->changeRoleUrl(), [
+            'username' => $this->member->name,
+            'role'     => ['not', 'a', 'string'],
+        ]);
+
+        // Assert
+        $response->assertStatus(StatusCode::FOUND);
+        $response->assertSessionHasErrors(['role']);
+    }
+
+    #[Test]
+    public function changeRole_givenInvalidRoleValue_returnsValidationError(): void
+    {
+        // Act
+        $response = $this->put($this->changeRoleUrl(), [
+            'username' => $this->member->name,
+            'role'     => 'not_a_real_role',
+        ]);
+
+        // Assert
+        $response->assertStatus(StatusCode::FOUND);
+        $response->assertSessionHasErrors(['role']);
+    }
+
+    #[Test]
+    public function changeRole_givenUnknownUsername_returnsValidationError(): void
+    {
+        // Act
+        $response = $this->put($this->changeRoleUrl(), [
+            'username' => 'this_user_does_not_exist',
+            'role'     => TeamUser::ROLE_COLLABORATOR,
+        ]);
+
+        // Assert
+        $response->assertStatus(StatusCode::FOUND);
+        $response->assertSessionHasErrors(['username']);
+    }
+
+    private function changeRoleUrl(): string
+    {
+        return sprintf('/ajax/team/%s/changerole', $this->team->getRouteKey());
+    }
+}

--- a/tests/Feature/Policy/DungeonRoutePolicyTest.php
+++ b/tests/Feature/Policy/DungeonRoutePolicyTest.php
@@ -427,6 +427,41 @@ final class DungeonRoutePolicyTest extends PublicTestCase
     }
 
     #[Test]
+    public function claim_givenSandboxRoute_returnsAllowed(): void
+    {
+        // Arrange - a sandbox route is unowned until somebody claims it
+        $user  = User::factory()->create();
+        $route = $this->createRoute($user, ['expires_at' => now()->addHours(2)]);
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->claim($user, $route)->allowed());
+        } finally {
+            $route->delete();
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function claim_givenAlreadyOwnedRoute_returnsDenied(): void
+    {
+        // Arrange
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $route = $this->createRoute($owner);
+
+        try {
+            // Act & Assert - neither a stranger nor the owner may re-claim a non-sandbox route
+            $this->assertTrue($this->policy->claim($other, $route)->denied());
+            $this->assertTrue($this->policy->claim($owner, $route)->denied());
+        } finally {
+            $route->delete();
+            $other->delete();
+            $owner->delete();
+        }
+    }
+
+    #[Test]
     public function can_givenEditAbilityAndOwner_resolvesThroughGate(): void
     {
         // Arrange - proves the policy is wired to the Gate via auto-discovery

--- a/tests/Feature/Policy/MapIconPolicyTest.php
+++ b/tests/Feature/Policy/MapIconPolicyTest.php
@@ -89,9 +89,12 @@ final class MapIconPolicyTest extends PublicTestCase
     }
 
     #[Test]
-    public function update_givenMappingIconAndNonAdmin_returnsDenied(): void
+    public function update_givenMappingIcon_returnsDeniedRegardlessOfRole(): void
     {
-        // Arrange - no route and no team means the icon belongs to the mapping itself
+        // Arrange - no route and no team means the icon belongs to the mapping itself. This
+        // endpoint is only ever reached with an incoming dungeon route, so allowing it here would
+        // let a global mapping icon be reassigned to a personal route - never possible before,
+        // for anyone including admins - so it stays denied regardless of role.
         $user    = User::factory()->create();
         $mapIcon = new MapIcon();
         $mapIcon->setAttribute('dungeon_route_id', null);
@@ -100,7 +103,7 @@ final class MapIconPolicyTest extends PublicTestCase
         try {
             // Act & Assert
             $this->assertTrue($this->policy->update($user, $mapIcon)->denied());
-            $this->assertTrue($this->policy->update($this->adminUser(), $mapIcon)->allowed());
+            $this->assertTrue($this->policy->update($this->adminUser(), $mapIcon)->denied());
         } finally {
             $user->delete();
         }

--- a/tests/Feature/Policy/MapIconPolicyTest.php
+++ b/tests/Feature/Policy/MapIconPolicyTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Tests\Feature\Policy;
+
+use App\Models\Laratrust\Role;
+use App\Models\MapIcon;
+use App\Models\Team;
+use App\Models\TeamUser;
+use App\Models\User;
+use App\Policies\MapIconPolicy;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Policy')]
+#[Group('MapIconPolicy')]
+final class MapIconPolicyTest extends PublicTestCase
+{
+    private MapIconPolicy $policy;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->policy = new MapIconPolicy();
+    }
+
+    #[Test]
+    public function createGlobal_givenAdmin_returnsAllowed(): void
+    {
+        // Act & Assert
+        $this->assertTrue($this->policy->createGlobal($this->adminUser())->allowed());
+    }
+
+    #[Test]
+    public function createGlobal_givenNonAdmin_returnsDenied(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->createGlobal($user)->denied());
+        } finally {
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function createGlobal_givenGuest_returnsDenied(): void
+    {
+        // Act & Assert
+        $this->assertTrue($this->policy->createGlobal(null)->denied());
+    }
+
+    #[Test]
+    public function update_givenRouteIcon_returnsAllowed(): void
+    {
+        // Arrange - a route icon is governed by the route's own edit gate, not by this one
+        $user    = User::factory()->create();
+        $mapIcon = new MapIcon();
+        $mapIcon->setAttribute('dungeon_route_id', 1);
+        $mapIcon->setAttribute('team_id', null);
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->update($user, $mapIcon)->allowed());
+        } finally {
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function update_givenTeamIcon_returnsAllowed(): void
+    {
+        // Arrange
+        $user    = User::factory()->create();
+        $mapIcon = new MapIcon();
+        $mapIcon->setAttribute('dungeon_route_id', null);
+        $mapIcon->setAttribute('team_id', 1);
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->update($user, $mapIcon)->allowed());
+        } finally {
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function update_givenMappingIconAndNonAdmin_returnsDenied(): void
+    {
+        // Arrange - no route and no team means the icon belongs to the mapping itself
+        $user    = User::factory()->create();
+        $mapIcon = new MapIcon();
+        $mapIcon->setAttribute('dungeon_route_id', null);
+        $mapIcon->setAttribute('team_id', null);
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->update($user, $mapIcon)->denied());
+            $this->assertTrue($this->policy->update($this->adminUser(), $mapIcon)->allowed());
+        } finally {
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function delete_givenTeamIconAndNonAdmin_returnsDenied(): void
+    {
+        // Arrange - deliberately stricter than update(): pre-existing behaviour, see MapIconPolicy
+        $user    = User::factory()->create();
+        $mapIcon = new MapIcon();
+        $mapIcon->setAttribute('dungeon_route_id', null);
+        $mapIcon->setAttribute('team_id', 1);
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->delete($user, $mapIcon)->denied());
+            $this->assertTrue($this->policy->delete($this->adminUser(), $mapIcon)->allowed());
+        } finally {
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function delete_givenRouteIcon_returnsAllowed(): void
+    {
+        // Arrange
+        $user    = User::factory()->create();
+        $mapIcon = new MapIcon();
+        $mapIcon->setAttribute('dungeon_route_id', 1);
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->delete($user, $mapIcon)->allowed());
+        } finally {
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function assignToTeam_givenCollaborator_returnsAllowed(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        $team = $this->createTeamWith($user, TeamUser::ROLE_COLLABORATOR);
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->assignToTeam($user, new MapIcon(), $team));
+        } finally {
+            $this->deleteTeam($team);
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function assignToTeam_givenPlainMember_returnsDenied(): void
+    {
+        // Arrange - a plain member is not a collaborator
+        $user = User::factory()->create();
+        $team = $this->createTeamWith($user, TeamUser::ROLE_MEMBER);
+
+        try {
+            // Act & Assert
+            $this->assertFalse($this->policy->assignToTeam($user, new MapIcon(), $team));
+        } finally {
+            $this->deleteTeam($team);
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function assignToTeam_givenNonMemberOrNoTeam_returnsDenied(): void
+    {
+        // Arrange
+        $user     = User::factory()->create();
+        $outsider = User::factory()->create();
+        $team     = $this->createTeamWith($user, TeamUser::ROLE_ADMIN);
+
+        try {
+            // Act & Assert
+            $this->assertFalse($this->policy->assignToTeam($outsider, new MapIcon(), $team));
+            $this->assertFalse($this->policy->assignToTeam($user, new MapIcon(), null));
+            $this->assertFalse($this->policy->assignToTeam(null, new MapIcon(), $team));
+        } finally {
+            $this->deleteTeam($team);
+            $outsider->delete();
+            $user->delete();
+        }
+    }
+
+    private function createTeamWith(User $user, string $role): Team
+    {
+        $team = Team::create([
+            'name'         => sprintf('Policy test %s', uniqid()),
+            'public_key'   => Team::generateRandomPublicKey(),
+            'invite_code'  => Team::generateRandomPublicKey(12, 'invite_code'),
+            'description'  => 'Created by MapIconPolicyTest',
+            'icon_file_id' => -1,
+            'default_role' => TeamUser::ROLE_MEMBER,
+        ]);
+
+        TeamUser::create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'role'    => $role,
+        ]);
+
+        return $team;
+    }
+
+    private function adminUser(): User
+    {
+        /** @var User $admin */
+        $admin = User::findOrFail(1);
+        $this->assertTrue(
+            $admin->hasRole(Role::ROLE_ADMIN),
+            'User id=1 must have the admin role for this test (seed the database).',
+        );
+
+        return $admin;
+    }
+
+    /**
+     * Team's "deleting" hook walks members->patreonAdFreeGiveaway, which trips preventLazyLoading
+     * unless the chain is eager-loaded first.
+     */
+    private function deleteTeam(Team $team): void
+    {
+        $team->load('members.patreonAdFreeGiveaway')->delete();
+    }
+}

--- a/tests/Feature/Policy/TeamPolicyTest.php
+++ b/tests/Feature/Policy/TeamPolicyTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Feature\Policy;
+
+use App\Models\Team;
+use App\Models\TeamUser;
+use App\Models\User;
+use App\Policies\TeamPolicy;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * changeRole() absorbed Team::canChangeRole(), which AjaxTeamController used to call inline after
+ * the (coarser) moderator gate. These tests pin the rank ordering that logic enforces.
+ */
+#[Group('Policy')]
+#[Group('TeamPolicy')]
+final class TeamPolicyTest extends PublicTestCase
+{
+    private TeamPolicy $policy;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->policy = new TeamPolicy();
+    }
+
+    #[Test]
+    #[DataProvider('changeRoleProvider')]
+    public function changeRole_givenRanks_returnsExpected(
+        string $actorRole,
+        string $targetRole,
+        string $newRole,
+        bool   $expected,
+    ): void {
+        // Arrange
+        $actor  = User::factory()->create();
+        $target = User::factory()->create();
+        $team   = $this->createTeam();
+        $this->addMember($team, $actor, $actorRole);
+        $this->addMember($team, $target, $targetRole);
+
+        try {
+            // Act & Assert
+            $this->assertSame($expected, $this->policy->changeRole($actor, $team->fresh(), $target, $newRole));
+        } finally {
+            $this->deleteTeam($team);
+            $target->delete();
+            $actor->delete();
+        }
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string, 3: bool}>
+     */
+    public static function changeRoleProvider(): array
+    {
+        return [
+            'admin promotes a member to moderator'          => [TeamUser::ROLE_ADMIN, TeamUser::ROLE_MEMBER, TeamUser::ROLE_MODERATOR, true],
+            'moderator promotes a member to collaborator'   => [TeamUser::ROLE_MODERATOR, TeamUser::ROLE_MEMBER, TeamUser::ROLE_COLLABORATOR, true],
+            'moderator may not promote past their own rank' => [TeamUser::ROLE_MODERATOR, TeamUser::ROLE_MEMBER, TeamUser::ROLE_ADMIN, false],
+            'moderator may not change an admin'             => [TeamUser::ROLE_MODERATOR, TeamUser::ROLE_ADMIN, TeamUser::ROLE_MEMBER, false],
+            'a plain member may not change anyone'          => [TeamUser::ROLE_MEMBER, TeamUser::ROLE_MEMBER, TeamUser::ROLE_MODERATOR, false],
+            'a collaborator may not change anyone'          => [TeamUser::ROLE_COLLABORATOR, TeamUser::ROLE_MEMBER, TeamUser::ROLE_MODERATOR, false],
+        ];
+    }
+
+    #[Test]
+    public function changeRole_givenNonMemberActor_returnsDenied(): void
+    {
+        // Arrange
+        $outsider = User::factory()->create();
+        $target   = User::factory()->create();
+        $team     = $this->createTeam();
+        $this->addMember($team, $target, TeamUser::ROLE_MEMBER);
+
+        try {
+            // Act & Assert
+            $this->assertFalse(
+                $this->policy->changeRole($outsider, $team->fresh(), $target, TeamUser::ROLE_MODERATOR),
+            );
+        } finally {
+            $this->deleteTeam($team);
+            $target->delete();
+            $outsider->delete();
+        }
+    }
+
+    #[Test]
+    public function moderateRoute_givenModerator_returnsAllowed(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        $team = $this->createTeam();
+        $this->addMember($team, $user, TeamUser::ROLE_MODERATOR);
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->moderateRoute($user, $team->fresh()));
+        } finally {
+            $this->deleteTeam($team);
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function moderateRoute_givenPlainMember_returnsDenied(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        $team = $this->createTeam();
+        $this->addMember($team, $user, TeamUser::ROLE_MEMBER);
+
+        try {
+            // Act & Assert - AjaxTeamController used to repeat this check inline after the gate
+            $this->assertFalse($this->policy->moderateRoute($user, $team->fresh()));
+        } finally {
+            $this->deleteTeam($team);
+            $user->delete();
+        }
+    }
+
+    private function createTeam(): Team
+    {
+        return Team::create([
+            'name'         => sprintf('Policy test %s', uniqid()),
+            'public_key'   => Team::generateRandomPublicKey(),
+            'invite_code'  => Team::generateRandomPublicKey(12, 'invite_code'),
+            'description'  => 'Created by TeamPolicyTest',
+            'icon_file_id' => -1,
+            'default_role' => TeamUser::ROLE_MEMBER,
+        ]);
+    }
+
+    private function addMember(Team $team, User $user, string $role): void
+    {
+        TeamUser::create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'role'    => $role,
+        ]);
+    }
+
+    /**
+     * Team's "deleting" hook walks members->patreonAdFreeGiveaway, which trips preventLazyLoading
+     * unless the chain is eager-loaded first.
+     */
+    private function deleteTeam(Team $team): void
+    {
+        $team->load('members.patreonAdFreeGiveaway')->delete();
+    }
+}

--- a/tests/Feature/Policy/UserPolicyTest.php
+++ b/tests/Feature/Policy/UserPolicyTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Tests\Feature\Policy;
+
+use App\Models\Laratrust\Role;
+use App\Models\Patreon\PatreonAdFreeGiveaway;
+use App\Models\User;
+use App\Policies\UserPolicy;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Policy')]
+#[Group('UserPolicy')]
+final class UserPolicyTest extends PublicTestCase
+{
+    private UserPolicy $policy;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->policy = new UserPolicy();
+    }
+
+    #[Test]
+    public function update_givenSelf_returnsAllowed(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->update($user, $user));
+        } finally {
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function update_givenAnotherUser_returnsDenied(): void
+    {
+        // Arrange
+        $user  = User::factory()->create();
+        $other = User::factory()->create();
+
+        try {
+            // Act & Assert - not even an admin may edit someone else's settings
+            $this->assertFalse($this->policy->update($user, $other));
+            $this->assertFalse($this->policy->update($this->adminUser(), $other));
+        } finally {
+            $other->delete();
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function delete_givenSelf_returnsAllowed(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->delete($user, $user)->allowed());
+        } finally {
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function delete_givenAnotherUser_returnsDenied(): void
+    {
+        // Arrange
+        $user  = User::factory()->create();
+        $other = User::factory()->create();
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->delete($user, $other)->denied());
+        } finally {
+            $other->delete();
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function delete_givenAdminDeletingThemselves_returnsDenied(): void
+    {
+        // Arrange
+        $admin = $this->adminUser();
+
+        // Act
+        $result = $this->policy->delete($admin, $admin);
+
+        // Assert
+        $this->assertTrue($result->denied());
+        $this->assertSame(__('controller.profile.flash.admins_cannot_delete_themselves'), $result->message());
+    }
+
+    #[Test]
+    public function makeRole_givenNonAdmin_returnsDenied(): void
+    {
+        // Arrange
+        $user   = User::factory()->create();
+        $target = User::factory()->create();
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->makeRole($user, $target, Role::ROLE_USER)->denied());
+        } finally {
+            $target->delete();
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function makeRole_givenAdminGrantingNonAdminRole_returnsAllowed(): void
+    {
+        // Arrange
+        $target = User::factory()->create();
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->makeRole($this->adminUser(), $target, Role::ROLE_USER)->allowed());
+        } finally {
+            $target->delete();
+        }
+    }
+
+    #[Test]
+    public function makeRole_givenAdminWhoIsNotASuperAdminGrantingAdmin_returnsDenied(): void
+    {
+        // Arrange - an admin who is not listed in keystoneguru.super_admins
+        $admin  = $this->adminUser();
+        $target = User::factory()->create();
+        config(['keystoneguru.super_admins' => ['SomebodyElse']]);
+
+        try {
+            // Act
+            $result = $this->policy->makeRole($admin, $target, Role::ROLE_ADMIN);
+
+            // Assert
+            $this->assertTrue($result->denied());
+            $this->assertSame(__('policy.make_role_only_super_admins_may_grant_admin'), $result->message());
+        } finally {
+            $target->delete();
+        }
+    }
+
+    #[Test]
+    public function makeRole_givenSuperAdminGrantingAdmin_returnsAllowed(): void
+    {
+        // Arrange
+        $admin  = $this->adminUser();
+        $target = User::factory()->create();
+        config(['keystoneguru.super_admins' => [$admin->name]]);
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->makeRole($admin, $target, Role::ROLE_ADMIN)->allowed());
+        } finally {
+            $target->delete();
+        }
+    }
+
+    #[Test]
+    public function revokeAdFreeGiveaway_givenTheGiver_returnsAllowed(): void
+    {
+        // Arrange
+        $giver    = User::factory()->create();
+        $receiver = User::factory()->create();
+        $giveaway = PatreonAdFreeGiveaway::create([
+            'giver_user_id'    => $giver->id,
+            'receiver_user_id' => $receiver->id,
+        ]);
+
+        try {
+            // Act & Assert
+            $this->assertTrue($this->policy->revokeAdFreeGiveaway($giver, $receiver->fresh()));
+        } finally {
+            $giveaway->delete();
+            $receiver->delete();
+            $giver->delete();
+        }
+    }
+
+    #[Test]
+    public function revokeAdFreeGiveaway_givenSomebodyElse_returnsDenied(): void
+    {
+        // Arrange
+        $giver     = User::factory()->create();
+        $receiver  = User::factory()->create();
+        $bystander = User::factory()->create();
+        $giveaway  = PatreonAdFreeGiveaway::create([
+            'giver_user_id'    => $giver->id,
+            'receiver_user_id' => $receiver->id,
+        ]);
+
+        try {
+            // Act & Assert - not even an admin may revoke somebody else's giveaway
+            $this->assertFalse($this->policy->revokeAdFreeGiveaway($bystander, $receiver->fresh()));
+            $this->assertFalse($this->policy->revokeAdFreeGiveaway($this->adminUser(), $receiver->fresh()));
+        } finally {
+            $giveaway->delete();
+            $bystander->delete();
+            $receiver->delete();
+            $giver->delete();
+        }
+    }
+
+    #[Test]
+    public function can_givenUpdateAbilityAndSelf_resolvesThroughGate(): void
+    {
+        // Arrange - proves UserPolicy is wired to the Gate via auto-discovery
+        $user = User::factory()->create();
+
+        try {
+            // Act & Assert
+            $this->assertTrue($user->can('update', $user));
+        } finally {
+            $user->delete();
+        }
+    }
+
+    private function adminUser(): User
+    {
+        /** @var User $admin */
+        $admin = User::findOrFail(1);
+        $this->assertTrue(
+            $admin->hasRole(Role::ROLE_ADMIN),
+            'User id=1 must have the admin role for this test (seed the database).',
+        );
+
+        return $admin;
+    }
+}

--- a/tests/Feature/Policy/UserPolicyTest.php
+++ b/tests/Feature/Policy/UserPolicyTest.php
@@ -178,7 +178,7 @@ final class UserPolicyTest extends PublicTestCase
 
         try {
             // Act & Assert
-            $this->assertTrue($this->policy->revokeAdFreeGiveaway($giver, $receiver->fresh()));
+            $this->assertTrue($this->policy->revokeAdFreeGiveaway($giver, $receiver->fresh())->allowed());
         } finally {
             $giveaway->delete();
             $receiver->delete();
@@ -200,8 +200,8 @@ final class UserPolicyTest extends PublicTestCase
 
         try {
             // Act & Assert - not even an admin may revoke somebody else's giveaway
-            $this->assertFalse($this->policy->revokeAdFreeGiveaway($bystander, $receiver->fresh()));
-            $this->assertFalse($this->policy->revokeAdFreeGiveaway($this->adminUser(), $receiver->fresh()));
+            $this->assertTrue($this->policy->revokeAdFreeGiveaway($bystander, $receiver->fresh())->denied());
+            $this->assertTrue($this->policy->revokeAdFreeGiveaway($this->adminUser(), $receiver->fresh())->denied());
         } finally {
             $giveaway->delete();
             $bystander->delete();


### PR DESCRIPTION
:robot: Part of #170. Independent of #3663 and #3665 — merge in any order.

This is the "pull authorization out of controllers and into policies" half of the issue. Each change
below moves a hand-rolled ownership or role check into the policy that already governs the
surrounding action, so the check has one home and the wrong-status-code problem goes away with it.

## New `UserPolicy`

There was no `UserPolicy`, so four checks about *users* had nowhere to live and were written inline —
each returning something other than 403:

| Ability | Replaces | Was |
|---|---|---|
| `update` | `AjaxUserController::store` self-ownership check | **400** for "this is not your account" |
| `delete` | `ProfileController::delete` admin-cannot-self-delete guard | `throw new Exception` → **500** |
| `makeRole` | `UserController::makeRole` super-admin escalation guard | **silently did nothing** — the form redirected back with no message and no role change |
| `revokeAdFreeGiveaway` | `giver_user_id !== $currentUser->id`, duplicated **verbatim** in `AjaxProfileController` and `AjaxTeamController` | **422** in both |

`makeRole` is the one worth a close look. It is a privilege-escalation guard: only names listed in
`keystoneguru.super_admins` may grant or revoke the admin role. The old code wrapped the whole method
in `if ($currentUser !== null)` and the admin branch in the super-admin check, so a non-super-admin
hitting it got a redirect and no feedback. It now denies with a message. The route was already behind
`role:admin`, so this was never an escalation path — but a failure that looks like success is its own
bug.

`AjaxUserController::store` also switches `User::where(...)->first()` + manual 400 to `firstOrFail()`,
so an unknown public key is now a **404** rather than a 400.

## New `MapIconPolicy`

`AjaxMapIconController` was the heaviest inline-authorization site in the repo — admin/non-admin
branching interleaved with `Gate::authorize`, and **two branches that threw a generic `Exception`**
(i.e. answered "you may not do this" with a 500):

- `createGlobal` — creating an icon with no dungeon route means editing the mapping itself; admin only
  (was `throw new Exception('Unable to save map icon!')`)
- `update` — a mapping icon (no route, no team) stays admin-only even when the request supplies a
  route the caller may otherwise edit (was the same generic `Exception`)
- `delete` — anything not attached to a route is admin-only (was `response(null, 403)`)
- `assignToTeam` — `$team->isUserCollaborator($user)`, deciding whether `team_id` may be set

**One asymmetry preserved rather than fixed:** `delete` is stricter than `update` — a *team* icon is
updatable by a collaborator but deletable only by an admin. That is exactly what the old code did
(`!$isAdmin && $mapIcon->dungeon_route_id === null` → 403, regardless of `team_id`). It looks like a
bug to me, but it is pre-existing and behaviour-changing to fix, so it is documented in the policy
and left alone. Say the word and I'll open an issue.

## `TeamPolicy` consolidation

Three methods ran `Gate::authorize(...)` and then repeated a *finer* check inline, hand-rolling
`response('Forbidden', 403)`:

- **`changeRole`** now takes the target user and the new role, and absorbs `Team::canChangeRole()`
  (which carried a `@TODO Should this go to a Policy?` marker). The controller becomes
  `Gate::authorize('change-role', [$team, $targetUser, $role])`. That rank ordering — nobody promotes
  past their own rank, nobody demotes someone above them — is now enforced by the gate, and pinned by
  a 6-case data provider.
- **`addRoute` / `removeRoute`** dropped their inline `canAddRemoveRoute($user)` branch entirely: it
  is *exactly* what `TeamPolicy::moderateRoute` already calls, so the branch was dead code that could
  never be reached with a false value.
- `AjaxDungeonRouteController::get`'s `// @TODO Policy?` + `abort(403, 'Unauthorized')` and
  `TeamController::store`'s inline `hasRole(ROLE_ADMIN)` field guard now go through
  `TeamPolicy::edit` and `TeamPolicy::changeRoutePublishing` respectively.

## `DungeonRoutePolicy::claim`

`DungeonRouteController::claim` had **no gate at all** — the rule lived inside
`DungeonRoute::claim()`, which returns false and does nothing when the route is not a sandbox route,
after which the controller redirected to the edit page regardless. Now `Gate::authorize('claim', …)`
denies up front; `DungeonRoute::claim()` itself is untouched by this diff and still self-guards on
`isSandbox()` as defense-in-depth, it is not a plain mutator.

## What deliberately stayed in the controllers

Quota and entitlement checks — `PatreonAdFreeGiveaway::getCountLeft()`, `hasPatreonBenefit()`,
`hasAdFreeGiveaway()` — remain inline as **422**s. They answer "you have run out", not "you are not
allowed", and the codebase already uses 422 for exactly this elsewhere.

## Tests

New `UserPolicyTest` (12), `MapIconPolicyTest` (11), `TeamPolicyTest` (8, incl. the rank-ordering data
provider), plus 2 `claim` cases added to `DungeonRoutePolicyTest`. `--group=Policy` goes from 26 to
**56 tests, all passing**. `UserPolicyTest` includes a `$user->can(...)` case to prove the new policy
is actually reachable through the Gate — policies are registered nowhere in this app (no
`AuthServiceProvider`, no `Gate::policy`), so a rename would silently detach one with every test
still green.

Note for whoever writes the next team test: `Team`'s `deleting` hook walks
`members->patreonAdFreeGiveaway`, which trips `preventLazyLoading`. Both new tests eager-load that
chain before deleting.

## Verification

- `--group=Policy` — 56 passed
- CI `feature-controller` shard — 79 tests, 1 failure, pre-existing and environment-only
  (`AjaxEnemyControllerTest::setRaidMarker…`; the shared dev DB has
  `2026_07_20_000000_add_npc_id_and_mdt_id_to_dungeon_route_enemy_raid_markers_table` still pending.
  Confirmed identical on unmodified `master`; CI migrates from scratch).
- `composer run fix` / `composer run analyse` — clean.

No UI changes, so no visual verification: every touched path is an Ajax endpoint or a redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

