### PR TITLE
#3669 Fix Pickr.create being undefined, which aborted map editor initialisation

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -29,6 +29,12 @@ import Echo from 'laravel-echo'
 
 import Pusher from 'pusher-js';
 
+// Imported as ESM rather than require()d (#3669): since 1.10.0 the package declares
+// "type": "module", so its `require` export condition (dist/pickr.min.js) is parsed as ESM even
+// though it contains UMD code - the resulting module has no exports at all and Pickr.create is
+// undefined. Only the `import` condition (dist/pickr.min.mjs) exports the class.
+import Pickr from '@simonwep/pickr';
+
 window.Pusher = Pusher;
 
 function startLaravelEcho() {
@@ -108,7 +114,7 @@ window.d3 = require('d3'); // v3.5.14 since Pather uses an out-of-date version
 window.Pather = require('leaflet-pather');
 window.circleMenu = require('zikes-circlemenu');
 window.Noty = require('noty');
-window.Pickr = require('@simonwep/pickr');
+window.Pickr = Pickr; // See the ESM import above (#3669)
 window.AntPath = require('leaflet-ant-path');
 window.Grapick = require('grapick');
 window.simplebar = require('simplebar');

--- a/resources/assets/js/pickr-export.test.js
+++ b/resources/assets/js/pickr-export.test.js
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------
+// Regression coverage for #3669, in the spirit of the jquery4-plugin-audit
+// (#3590): guard a bundled dependency's export shape against a version bump
+// that silently breaks it.
+//
+// @simonwep/pickr 1.10.0 (bumped from 1.9.1 in #3618) declares "type": "module"
+// while its `require` export condition still points at dist/pickr.min.js, which
+// contains UMD code. Because of the package type that file is parsed as ESM, so
+// it exports nothing at all: `require('@simonwep/pickr')` yields an empty module
+// and `Pickr.create` is undefined. That threw
+// `TypeError: Pickr.create is not a function` inside SettingsTabMap#activate(),
+// which aborted the rest of Map#activate() and the InlineManager dependency
+// cascade behind it - i.e. most of the map editor sidebar never initialised.
+//
+// bootstrap.js therefore imports Pickr as ESM. This test bundles that exact
+// usage with the esbuild settings that drive module resolution in
+// scripts/build/app.mjs (bundle + format + platform) and evaluates the result,
+// so a future bump that breaks the export shape fails here rather than in
+// production.
+// ---------------------------------------------------------------------------
+
+const fs = require('node:fs');
+const path = require('node:path');
+const util = require('node:util');
+
+// esbuild asserts `new TextEncoder().encode('') instanceof Uint8Array` on load, which fails under
+// jsdom: its TextEncoder and its Uint8Array come from different realms. Line up all three on Node's
+// implementations before requiring esbuild. Pickr itself still needs the jsdom DOM, so switching
+// the whole file to the node environment isn't an option.
+global.TextEncoder = util.TextEncoder;
+global.TextDecoder = util.TextDecoder;
+global.Uint8Array = new util.TextEncoder().encode('').constructor;
+
+const {buildSync} = require('esbuild');
+
+const rootDir = path.resolve(__dirname, '..', '..', '..');
+
+/**
+ * Bundles a snippet with the resolution-relevant settings scripts/build/app.mjs uses for app.js,
+ * and returns the generated code.
+ */
+function bundle(contents) {
+    const result = buildSync({
+        absWorkingDir: rootDir,
+        stdin: {contents, resolveDir: path.join(rootDir, 'resources', 'assets', 'js'), loader: 'js'},
+        bundle: true,
+        write: false,
+        format: 'iife',
+        platform: 'browser',
+        logLevel: 'silent',
+    });
+
+    return result.outputFiles[0].text;
+}
+
+describe('@simonwep/pickr export shape (#3669)', () => {
+    test('pickr_givenTheAppBundleEsmImport_exposesACreateFactory', () => {
+        // Arrange
+        const code = bundle(`import Pickr from '@simonwep/pickr'; window.Pickr = Pickr;`);
+
+        // Act
+        new Function(code)();
+
+        // Assert
+        expect(typeof window.Pickr).toBe('function');
+        expect(typeof window.Pickr.create).toBe('function');
+    });
+
+    test('bootstrapJs_givenPickrIsBundled_doesNotRequireIt', () => {
+        // Arrange
+        const bootstrapJs = fs.readFileSync(path.join(rootDir, 'resources', 'assets', 'js', 'bootstrap.js'), 'utf8');
+
+        // Act
+        const requiresPickr = /require\(\s*['"]@simonwep\/pickr['"]\s*\)/.test(bootstrapJs);
+
+        // Assert: require() resolves the broken CJS condition - see the file header
+        expect(requiresPickr).toBe(false);
+        expect(bootstrapJs).toMatch(/import\s+Pickr\s+from\s+['"]@simonwep\/pickr['"]/);
+    });
+});


### PR DESCRIPTION
:robot: Closes #3669

## Problem

`@simonwep/pickr` 1.10.0 (bumped from 1.9.1 in #3618) declares `"type": "module"` while its
`require` export condition still points at `dist/pickr.min.js`, a file containing UMD code. Because
of the package type that file is parsed as ESM, so it exports nothing at all -
`require('@simonwep/pickr')` yields an empty module and `Pickr.create` is `undefined`. Only
`dist/pickr.min.mjs` (the `import` condition) exports the class.

The resulting `TypeError: Pickr.create is not a function` is thrown inside
`SettingsTabMap#activate()`, so everything after that call in `Map#activate()` never runs -
`settingsTabPull.activate()`, the `floorid:changed` registration and the whole `_setup*()` sidebar
wiring - and `InlineManager#activate()` never reaches `this._activatedInlineCode[code.id] = code`,
so every inline code depending on `common/maps/map` is skipped too.

This is in v15.7.0, so staging is affected.

## Fix

Import Pickr as ESM. `bootstrap.js` already mixes hoisted ESM imports (`laravel-echo`, `pusher-js`)
with in-place `require()` calls; the `window.Pickr` assignment stays exactly where it was, and Pickr
has no load-order dependency on jQuery.

## Verification

Headless Chrome, same editor page, master baseline (`:8008`) vs this branch (`:8106`):

| | master | this branch |
|---|---|---|
| page errors | `Pickr.create is not a function` | none |
| `typeof window.Pickr` | `object` | `function` |
| `typeof window.Pickr.create` | `undefined` | `function` |
| rendered `.pickr` widgets | 0 | 4 |

The visible symptom is the pull list, which sits on "Loading..." forever on master - the same class
of breakage as #3588.

**Before (master)**

![before](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3669-editor-before.png)

**After (this branch)**

![after](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3669-editor-after.png)

## Test

`resources/assets/js/pickr-export.test.js` bundles the exact usage from `bootstrap.js` with the
resolution-relevant esbuild settings from `scripts/build/app.mjs` and evaluates the output, plus a
static check that `bootstrap.js` doesn't reintroduce the `require()` form. Follows the
`jquery4-plugin-audit.test.js` precedent for bundled-dependency contract tests.

Confirmed the test actually catches the bug: switching the bundled snippet back to `require()` fails
with `expected 'object' to be 'function'`.

`npx vitest run`: 24 files, 248 tests, all green. No PHP touched.

## Note on the jsdom/esbuild shim

The test overrides `TextEncoder`/`TextDecoder`/`Uint8Array` with Node's implementations before
requiring esbuild - esbuild asserts `new TextEncoder().encode('') instanceof Uint8Array` on load,
which fails under jsdom because those come from different realms. Pickr itself needs the jsdom DOM,
so moving the file to the `node` environment isn't an option. Vitest isolates per test file, so the
override doesn't leak (full suite verified green).
