### PR TITLE
#3670 Rebind the enemy tooltip when nothing is bound, not only when the text changed

### DIFF
--- a/resources/assets/js/custom/models/enemy.js
+++ b/resources/assets/js/custom/models/enemy.js
@@ -809,8 +809,13 @@ class Enemy extends VersionableMapObject {
                 text = lang.get('js.no_npc_found_label');
             }
 
-            // Only rebind if the text has changed
-            if (this.tooltipText !== text) {
+            // Only rebind if the text has changed - or if nothing is bound right now (#3670).
+            // Anything that unbinds the tooltip without also resetting tooltipText (the circle menu
+            // in EnemyVisual, a layer swap in MapObjectGroup#setLayerToMapObject) would otherwise
+            // leave this enemy without a tooltip permanently: the recomputed text is identical, so
+            // the guard short-circuits and the rebind never happens.
+            // Leaflet's getTooltip() is undefined before the first bind and null after unbindTooltip().
+            if (this.tooltipText !== text || !this.layer.getTooltip()) {
                 this.tooltipText = text;
 
                 // Remove any previous tooltip
@@ -1355,4 +1360,12 @@ class Enemy extends VersionableMapObject {
             this.visual = null;
         }
     }
+}
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        Enemy,
+    };
 }

--- a/resources/assets/js/custom/models/enemy.test.js
+++ b/resources/assets/js/custom/models/enemy.test.js
@@ -1,0 +1,173 @@
+// ---------------------------------------------------------------------------
+// Regression coverage for #3670, following the global-script model recipe
+// documented at the top of killzone.test.js: define the globals enemy.js touches
+// at LOAD time before require()-ing it, then hand the class fake collaborators
+// instead of building a real DungeonMap.
+//
+// Enemy#bindTooltip() only rebinds when the rendered text changed. That guard
+// checked the text but not whether a tooltip was actually bound, so any code
+// path that unbinds without also resetting `tooltipText` (the raid marker circle
+// menu in EnemyVisual, a layer swap in MapObjectGroup#setLayerToMapObject) left
+// the enemy without a tooltip permanently - the recomputed text is identical, so
+// the guard short-circuited and nothing was ever rebound.
+// ---------------------------------------------------------------------------
+
+// 1a. Leaflet: enemy.js builds div icons and draw handlers at load time.
+global.L = {
+    divIcon: function () {
+    },
+    Marker: {extend: () => function () {}},
+    Draw: {
+        Marker: {extend: () => function () {}},
+        Feature: {prototype: {initialize() {}}},
+    },
+};
+
+// 1b. Map states referenced by the constructor and by bindTooltip(). The fake map below never
+// returns an instance of either, so the tooltip is always considered enabled.
+global.MapState = class MapState {};
+global.EditMapState = class EditMapState extends global.MapState {};
+
+// 1c. Lightweight base class standing in for VersionableMapObject -> MapObject, providing only
+// what Enemy calls on `super` / `this`. unbindTooltip() mirrors the real MapObject implementation,
+// which forwards to the layer without touching tooltipText - that asymmetry is the bug under test.
+global.VersionableMapObject = class VersionableMapObject {
+    constructor(map, layer = null, options = {}) {
+        this.map = map;
+        this.layer = layer;
+        this.options = options;
+        this.id = 0;
+        this._cachedAttributes = null;
+    }
+
+    register() {
+    }
+
+    unregister() {
+    }
+
+    signal() {
+    }
+
+    unbindTooltip() {
+        this.layer.unbindTooltip();
+    }
+};
+
+// 1d. Handlebars template + default variables used to render the tooltip body. The template simply
+// echoes the name so a test can change the rendered text by changing the npc.
+global.Handlebars = {
+    templates: {
+        enemy_tooltip_template: (data) => `<div>${data.name}</div>`,
+    },
+};
+global.getHandlebarsDefaultVariables = () => ({});
+
+// 1e. The shared setup's `$` stub has no extend().
+global.$.extend = Object.assign;
+
+global.getState = () => ({
+    getMapContext: () => ({register: () => {}}),
+});
+
+const {Enemy} = require('./enemy');
+
+/**
+ * A fake Leaflet layer mirroring Leaflet's own tooltip semantics: getTooltip() is undefined before
+ * the first bind and null after unbindTooltip(). Records how often bindTooltip() was called so a
+ * test can assert that redundant rebinds are still avoided.
+ */
+function makeFakeLayer() {
+    return {
+        _tooltip: undefined,
+        bindCount: 0,
+        getTooltip() {
+            return this._tooltip;
+        },
+        bindTooltip(text) {
+            this._tooltip = {text};
+            this.bindCount++;
+        },
+        unbindTooltip() {
+            this._tooltip = null;
+        },
+    };
+}
+
+/**
+ * A fake DungeonMap exposing only what Enemy touches: an event bus, edit/state accessors.
+ */
+function makeFakeMap() {
+    return {
+        options: {edit: false},
+        register: () => {},
+        unregister: () => {},
+        getMapState: () => null,
+    };
+}
+
+/**
+ * Builds an Enemy with a fake map/layer and an npc, with its tooltip already bound once.
+ */
+function makeBoundEnemy(npcName = 'Murkbrine Shorerunner') {
+    const layer = makeFakeLayer();
+    const enemy = new Enemy(makeFakeMap(), layer);
+    enemy.npc = {id: 1, name: npcName};
+    enemy.getVisualData = () => ({info: [], custom: []});
+    enemy.bindTooltip();
+
+    return {enemy, layer};
+}
+
+describe('Enemy#bindTooltip (#3670)', () => {
+    test('bindTooltip_givenTooltipWasUnboundAndTextUnchanged_rebindsTheTooltip', () => {
+        // Arrange: the circle menu / a layer swap unbinds without resetting tooltipText
+        const {enemy, layer} = makeBoundEnemy();
+        const textBefore = enemy.tooltipText;
+        enemy.unbindTooltip();
+        expect(layer.getTooltip()).toBeNull();
+
+        // Act
+        enemy.bindTooltip();
+
+        // Assert
+        expect(layer.getTooltip()).not.toBeNull();
+        expect(layer.getTooltip().text).toBe(textBefore);
+    });
+
+    test('bindTooltip_givenTooltipStillBoundAndTextUnchanged_doesNotRebind', () => {
+        // Arrange
+        const {enemy, layer} = makeBoundEnemy();
+        expect(layer.bindCount).toBe(1);
+
+        // Act
+        enemy.bindTooltip();
+
+        // Assert: the guard still short-circuits redundant work
+        expect(layer.bindCount).toBe(1);
+    });
+
+    test('bindTooltip_givenTheTextChanged_rebindsWithTheNewText', () => {
+        // Arrange
+        const {enemy, layer} = makeBoundEnemy();
+        enemy.npc = {id: 2, name: 'Deathwhisper Necrolyte'};
+
+        // Act
+        enemy.bindTooltip();
+
+        // Assert
+        expect(layer.bindCount).toBe(2);
+        expect(layer.getTooltip().text).toContain('Deathwhisper Necrolyte');
+    });
+
+    test('bindTooltip_givenNoLayer_doesNothing', () => {
+        // Arrange
+        const enemy = new Enemy(makeFakeMap(), null);
+        enemy.npc = {id: 1, name: 'Murkbrine Shorerunner'};
+        enemy.getVisualData = () => ({info: [], custom: []});
+
+        // Act + Assert: no layer to bind to, so this must not throw
+        expect(() => enemy.bindTooltip()).not.toThrow();
+        expect(enemy.tooltipText).toBe('');
+    });
+});


### PR DESCRIPTION
:robot: Closes #3670

## Problem

`Enemy#bindTooltip()` short-circuited on `this.tooltipText !== text`, which checks the rendered text
but not whether a tooltip is actually bound to the layer. Any code path that unbinds without also
resetting `tooltipText` therefore left that enemy without a tooltip for the rest of the session: the
recomputed text is identical, so the guard skipped the rebind and nothing ever bound it again.

Two live call sites unbind that way:

- `EnemyVisual#_initCircleMenu()`'s `open:` handler (#1431). Not currently observable, but only by
  accident: the handler then sets a `RaidMarkerSelectMapState`, which flips
  `canOpenRaidMarkerMenu()` to false and so *changes* the rendered text
  (`show_raid_marker_shortcut`), letting the guard pass. Drop that hint from the tooltip and every
  shift+right-clicked enemy silently loses its tooltip.
- `MapObjectGroup#setLayerToMapObject()` unbinds the old layer's tooltip on a layer swap while
  `tooltipText` survives.

`Enemy#setTooltipEnabled(false)` already worked around this by explicitly resetting `tooltipText`,
which is a good sign the guard was the wrong place to stop.

## Fix

Also rebind when nothing is bound. Leaflet's `getTooltip()` is `undefined` before the first bind and
`null` after `unbindTooltip()`, so it's a reliable "is anything bound right now" check.

## Verification

Headless Chrome, `explore/retail/pit-of-saron`, master baseline (`:8008`) vs this branch (`:8107`).
Both bind tooltips to all 230 enemies on load; the difference is the unbind/rebind round trip the
circle menu performs, after which the affected enemy is hovered:

| | master | this branch |
|---|---|---|
| enemies with a tooltip on load | 230 / 230 | 230 / 230 |
| `getTooltip()` after unbind + rebind | `null` | bound |
| tooltip visible on hovering that enemy | no | yes |

**Before (master) - hovering the enemy after the round trip shows nothing**

![before](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3670-tooltip-before.png)

**After (this branch)**

![after](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3670-tooltip-after.png)

## Tests

New `resources/assets/js/custom/models/enemy.test.js`, following the global-script model recipe
documented at the top of `killzone.test.js`. It covers:

- the regression: rebinds after an `unbindTooltip()` when the text is unchanged;
- that redundant rebinds are still skipped when a tooltip is already bound (the guard's original
  purpose);
- that a changed text still rebinds;
- that a null layer is a no-op.

Confirmed the regression test fails on the old guard (`expected null not to be null`).

`npx vitest run`: 24 files, 250 tests, all green. No PHP touched.

## Note

`enemy.js` gained the same guarded `module.exports` block `util.js` and `killzone.js` already carry -
it's a no-op in the browser (`module` is undefined there) and doesn't affect the concatenated bundle.

## Not the explore-page tooltip report

This was found while investigating a report of enemy tooltips not appearing on explore pages. It is
**not** that bug - that one reproduces on page load with no interaction, and I could not reproduce it
on any explore page. Filed and fixed here on its own merits.
