### PR TITLE
#3679 Fix the flaky raid-marker mapping-version test

### DIFF
--- a/tests/Feature/App/Service/DungeonRoute/DungeonRouteEnemyRaidMarkerMappingVersionTest.php
+++ b/tests/Feature/App/Service/DungeonRoute/DungeonRouteEnemyRaidMarkerMappingVersionTest.php
@@ -27,25 +27,9 @@ final class DungeonRouteEnemyRaidMarkerMappingVersionTest extends DungeonRouteSa
     public function upgradeMappingVersion_givenNpcStillExistsInNewMappingVersion_preservesRaidMarker(): void
     {
         // Arrange
-        $dungeon    = $this->getRetailDungeon();
-        $existingMV = $dungeon->getCurrentMappingVersion();
+        [$dungeon, $existingMV, $enemy] = $this->getRetailDungeonWithUniquelyIdentifiedEnemy();
         // Cloning a new mapping version also clones every enemy (same npc_id/mdt_id, new ids)
         $newMV = $this->createNewerMappingVersion($dungeon, $existingMV);
-
-        // npc_id/mdt_id is not guaranteed unique within a mapping version - a handful of NPCs are
-        // placed twice under the same MDT clone index. Excluding those keeps this test aligned
-        // with what production actually resolves (see DungeonRouteEnemyRaidMarkerRepository),
-        // instead of occasionally comparing against an arbitrary sibling via firstOrFail() below.
-        /** @var Enemy $enemy */
-        $enemy = Enemy::where('mapping_version_id', $existingMV->id)
-            ->whereRaw('(
-                SELECT COUNT(*) FROM enemies e2
-                WHERE e2.mapping_version_id = enemies.mapping_version_id
-                  AND COALESCE(e2.mdt_npc_id, e2.npc_id) = COALESCE(enemies.mdt_npc_id, enemies.npc_id)
-                  AND e2.mdt_id <=> enemies.mdt_id
-            ) = 1')
-            ->inRandomOrder()
-            ->first();
 
         $route      = DungeonRoute::factory()->create(['dungeon_id' => $dungeon->id, 'mapping_version_id' => $existingMV->id]);
         $raidMarker = $this->createRaidMarker($route, $enemy);
@@ -151,6 +135,52 @@ final class DungeonRouteEnemyRaidMarkerMappingVersionTest extends DungeonRouteSa
     }
 
     /**
+     * A retail dungeon that actually has an enemy uniquely identified by its
+     * (mdt_npc_id/npc_id, mdt_id) pair on its current mapping version.
+     *
+     * npc_id/mdt_id is not guaranteed unique within a mapping version - a handful of NPCs are
+     * placed twice under the same MDT clone index. Excluding those keeps this test aligned with
+     * what production actually resolves (see DungeonRouteEnemyRaidMarkerRepository) instead of
+     * comparing against an arbitrary sibling.
+     *
+     * Picking a random dungeon and *then* filtering was flaky: 3 of the 70 retail dungeons (The
+     * Arcway, Cathedral of Eternal Night, Maw of Souls) have no uniquely-identified enemy at all,
+     * so roughly one run in twenty drew one of them, got a null enemy and died with a TypeError in
+     * createRaidMarker(). Search across dungeons instead, mirroring
+     * getRetailDungeonWithNullMdtIdEnemy() below.
+     *
+     * @return array{0: Dungeon, 1: MappingVersion, 2: Enemy}
+     */
+    private function getRetailDungeonWithUniquelyIdentifiedEnemy(): array
+    {
+        $dungeons = Dungeon::whereNotNull('challenge_mode_id')->get()->shuffle();
+
+        foreach ($dungeons as $dungeon) {
+            /** @var Dungeon $dungeon */
+            $mappingVersion = $dungeon->getCurrentMappingVersion();
+            if ($mappingVersion === null) {
+                continue;
+            }
+
+            $enemy = Enemy::where('mapping_version_id', $mappingVersion->id)
+                ->whereRaw('(
+                    SELECT COUNT(*) FROM enemies e2
+                    WHERE e2.mapping_version_id = enemies.mapping_version_id
+                      AND COALESCE(e2.mdt_npc_id, e2.npc_id) = COALESCE(enemies.mdt_npc_id, enemies.npc_id)
+                      AND e2.mdt_id <=> enemies.mdt_id
+                ) = 1')
+                ->inRandomOrder()
+                ->first();
+
+            if ($enemy !== null) {
+                return [$dungeon, $mappingVersion, $enemy];
+            }
+        }
+
+        self::markTestSkipped('Unable to find a retail dungeon with a uniquely identified enemy on its current mapping version');
+    }
+
+    /**
      * @return array{0: Dungeon, 1: MappingVersion, 2: Enemy}
      */
     private function getRetailDungeonWithNullMdtIdEnemy(): array
@@ -164,7 +194,23 @@ final class DungeonRouteEnemyRaidMarkerMappingVersionTest extends DungeonRouteSa
                 continue;
             }
 
-            $enemy = Enemy::where('mapping_version_id', $mappingVersion->id)->whereNull('mdt_id')->inRandomOrder()->first();
+            // Same uniqueness constraint as getRetailDungeonWithUniquelyIdentifiedEnemy(): only
+            // 152 of the 1549 null-mdt_id enemies are uniquely identified by their
+            // (mdt_npc_id/npc_id, mdt_id) pair, and an ambiguous one cannot be re-resolved after
+            // the upgrade, so the marker is dropped and the assertion below fails. The test is
+            // about null-safe matching (`<=>` rather than `=`), which an unambiguous enemy
+            // exercises just as well.
+            $enemy = Enemy::where('mapping_version_id', $mappingVersion->id)
+                ->whereNull('mdt_id')
+                ->whereRaw('(
+                    SELECT COUNT(*) FROM enemies e2
+                    WHERE e2.mapping_version_id = enemies.mapping_version_id
+                      AND COALESCE(e2.mdt_npc_id, e2.npc_id) = COALESCE(enemies.mdt_npc_id, enemies.npc_id)
+                      AND e2.mdt_id <=> enemies.mdt_id
+                ) = 1')
+                ->inRandomOrder()
+                ->first();
+
             if ($enemy !== null) {
                 return [$dungeon, $mappingVersion, $enemy];
             }


### PR DESCRIPTION
:robot: Closes #3679

Test-only, one file, branched straight off `master` so it can merge immediately and the three open creator MRs (#3675, #3676, #3677) pick it up from `master` rather than each carrying their own copy.

## Two failures, one root cause

`DungeonRouteEnemyRaidMarkerMappingVersionTest` resolves a raid marker across a mapping-version upgrade by matching on the `(mdt_npc_id/npc_id, mdt_id)` pair. That pair is **not unique** within a mapping version — some NPCs are placed twice under the same MDT clone index — so an ambiguous enemy cannot be re-resolved after the upgrade and its marker is dropped.

Both tests in the class picked an enemy without guaranteeing uniqueness, so both were data-dependent:

**1. `upgradeMappingVersion_givenNpcStillExistsInNewMappingVersion_preservesRaidMarker`** — picked a random retail dungeon *first*, then filtered for a uniquely-identified enemy. **3 of the 70** retail dungeons have none at all:

- The Arcway
- Cathedral of Eternal Night
- Maw of Souls

Drawing one of those returned `null` and the test died with `TypeError: createRaidMarker(): Argument #2 ($enemy) must be of type App\Models\Enemy, null given`. ~4% per run — this is what went red on #3675's `php-tests (feature-other)`.

**2. `upgradeMappingVersion_givenNpcWithNullMdtIdStillExistsInNewMappingVersion_preservesRaidMarker`** — applied no uniqueness filter at all. Only **152 of the 1549** null-`mdt_id` enemies in the seeded database are uniquely identified, so ~90% of draws picked an ambiguous one, the marker was dropped, and `assertNotNull($fresh)` failed.

The second one is worth flagging: **it fails 10 times out of 10 locally on plain `master`**, and has evidently only been passing in CI on friendlier seed data. It was going to start reddening MRs the moment that data shifted.

## Fix

Search shuffled dungeons for one that actually has a qualifying enemy, instead of sampling a dungeon and hoping — the shape the file already used for `getRetailDungeonWithNullMdtIdEnemy()`. Both helpers now only return once they hold a non-null enemy, so neither can hand back `null` by construction, and each skips if no dungeon qualifies.

The uniqueness filter itself is unchanged and deliberate: it keeps the tests aligned with what `DungeonRouteEnemyRaidMarkerRepository` actually resolves in production, rather than comparing against an arbitrary sibling. Constraining the null-`mdt_id` test the same way does not weaken it — that test is about the join being null-safe (`<=>` rather than `=`), which an unambiguous enemy exercises just as well.

## Verification

| | before | after |
|---|---|---|
| whole class, 15 consecutive local runs | ~9/15 failing | **0/15 failing** |
| null-mdt test alone on plain `master` | 10/10 failing | — |

PHPStan clean, php-cs-fixer clean. No production code touched.

## Note

I originally fixed only the first test, inside #3675. This MR hoists it out to `master` and adds the second fix, which only surfaced once the branch was rebuilt on current `master`. The copy in #3675 will be dropped so the fix lives in exactly one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
