### PR TITLE
#128 Document the facade floor_id conversion trap

### DIFF
--- a/.claude/skills/mapping-versioned-models/SKILL.md
+++ b/.claude/skills/mapping-versioned-models/SKILL.md
@@ -146,10 +146,12 @@ one. Repositories that query mapping tables scope manually (e.g.
 - Caching: `Dungeon::$currentMappingVersionCache` and `MappingVersion`'s internal caches are
   per-request; the models extend `CacheModel` (query cache), and `mapping:save` runs
   `modelCache:clear` first because stale model caches corrupt exports.
-- The `mapContext*()` methods on `MappingVersion` **overwrite `floor_id` with the facade floor**
-  when serializing for a facade map, so the front-end can never group by the real floor. See
-  "Gotcha: facade conversion rewrites `floor_id`" in the **new-map-view** skill before writing
-  anything that groups map objects per floor.
+- Serializing for a facade map **overwrites `floor_id` with the facade floor**, so the front-end
+  can never group by the real floor. Most models go through a `MappingVersion::mapContext*()`
+  method (`mapContextMapIcons`, `mapContextEnemyPacks`, …) — but enemies don't; they're converted
+  inline in `MapContextMappingVersionData::toArray()` via `$enemy->setLatLng(...)`. See "Gotcha:
+  facade conversion rewrites `floor_id`" in the **new-map-view** skill before writing anything that
+  groups map objects per floor.
 
 ## Related skills
 

--- a/.claude/skills/mapping-versioned-models/SKILL.md
+++ b/.claude/skills/mapping-versioned-models/SKILL.md
@@ -146,6 +146,10 @@ one. Repositories that query mapping tables scope manually (e.g.
 - Caching: `Dungeon::$currentMappingVersionCache` and `MappingVersion`'s internal caches are
   per-request; the models extend `CacheModel` (query cache), and `mapping:save` runs
   `modelCache:clear` first because stale model caches corrupt exports.
+- The `mapContext*()` methods on `MappingVersion` **overwrite `floor_id` with the facade floor**
+  when serializing for a facade map, so the front-end can never group by the real floor. See
+  "Gotcha: facade conversion rewrites `floor_id`" in the **new-map-view** skill before writing
+  anything that groups map objects per floor.
 
 ## Related skills
 

--- a/.claude/skills/new-map-view/SKILL.md
+++ b/.claude/skills/new-map-view/SKILL.md
@@ -214,3 +214,81 @@ each path segment:
 | `admin/tools/mypage` | `AdminToolsMypage` |
 
 All file names under `resources/assets/js/custom/inline/` must be **lowercase**.
+
+## Gotcha: facade conversion rewrites `floor_id`
+
+**In facade mode, `enemy.floor_id` on the wire is the *facade* floor, not the floor the enemy
+actually lives on.** Client-side code therefore *cannot* group map objects by their real floor.
+This is invisible from the JS and has silently broken a feature before (#3660): a per-floor total
+computed in the browser collapsed every enemy into one group on every union-based facade, while
+appearing to work on facades that define no floor unions at all.
+
+### The chain
+
+**1. `FloorUnion`'s two floor columns read backwards from their names.**
+`MappingVersion::getFloorUnionsForFloor()` filters on `target_floor_id`:
+
+```php
+$floorUnions = $this->floorUnions()
+    ->where('target_floor_id', $floor->id)   // $floor = the enemy's REAL floor
+```
+
+So `target_floor_id` is the **real/source** floor the union pulls *from*, and `floor_id` /
+`$floorUnion->floor` is the **facade** floor it draws *onto*. Exactly the opposite of what the
+names suggest.
+
+**2. The conversion reassigns the floor.** `CoordinatesService::convertMapLocationToFacadeMapLocation()`:
+
+```php
+// Ok this lat lng is inside a floor union area - this means we must use it's attached floor union's target floor
+$result->setFloor($floorUnion->floor);   // <-- the FACADE floor. The comment is wrong.
+```
+
+Note the early return above it — when no union matches the point, the LatLng is returned
+**unchanged**, which is why a facade with zero floor unions (Lower Karazhan) keeps real floor ids
+and makes buggy code look correct.
+
+**3. `setLatLng()` writes it through to the model.** `app/Models/Traits/HasLatLng.php`:
+
+```php
+$this->floor_id = $latLng->getFloor()?->id;
+```
+
+**4. Call site:** `MapContextMappingVersionData::toArray()`, and every
+`MappingVersion::mapContext*()` method (`mapContextMapIcons`, `mapContextEnemyPacks`, …) does the
+same for its own model type.
+
+### Three secondary traps
+
+- **`floor_id` and the loaded `floor` relation desync.** `setLatLng()` writes only `floor_id` and
+  never resets the eager-loaded relation, so after conversion `$enemy->floor->id` (real floor)
+  ≠ `$enemy->floor_id` (facade floor) *in the same PHP process*.
+- **…but the relation is not a client-side substitute.** `Enemy::$hidden` contains `'floor'`, so it
+  is stripped from the JSON. Conversely `Enemy` defines no `$visible`, which is *why* an ad-hoc
+  `setAttribute('source_floor_id', …)` on a non-column survives serialization — adding a `$visible`
+  to `Enemy` would silently break anything relying on that.
+- **The payload is cached.** It lives under `dungeon_{dungeonId}_{mappingVersionId}_{facadeStyle}`
+  via `rememberLocal(…, 86400, …)` wrapping `cacheService->remember(…)` — *two* layers. A newly
+  added attribute only appears once that entry regenerates, so client-side
+  `?? enemy.floor_id` fallbacks are load-bearing, not defensive noise.
+
+### The fix
+
+Carry the real floor alongside as `source_floor_id`, captured **before** the conversion, mirroring
+what `MappingVersion::mapContextDungeonFloorSwitchMarkers()` already does:
+
+```php
+$enemy->setAttribute('source_floor_id', $enemy->floor_id);
+
+$enemy->setLatLng($this->coordinatesService->convertMapLocationToFacadeMapLocation(
+    $this->mappingVersion,
+    $enemy->getLatLng(),
+));
+```
+
+Client-side, read `enemy.source_floor_id ?? enemy.floor_id`.
+
+**Related:** computing a per-floor *centroid* server-side has its own trap — a single floor can be
+carved into several floor unions that land in completely different places on the combined image
+(The Nokhud Offensive splits one floor into four), so you must average in the floor's own
+coordinate space and convert afterwards, never average already-converted points.

--- a/.claude/skills/new-map-view/SKILL.md
+++ b/.claude/skills/new-map-view/SKILL.md
@@ -254,15 +254,22 @@ and makes buggy code look correct.
 $this->floor_id = $latLng->getFloor()?->id;
 ```
 
-**4. Call site:** `MapContextMappingVersionData::toArray()`, and every
-`MappingVersion::mapContext*()` method (`mapContextMapIcons`, `mapContextEnemyPacks`, …) does the
-same for its own model type.
+**4. Call site — but not every model goes through `setLatLng()`.** Enemies convert inline in
+`MapContextMappingVersionData::toArray()` via `$enemy->setLatLng(...)`, and
+`MappingVersion::mapContextMapIcons()` / `mapContextDungeonFloorSwitchMarkers()` do the same for
+`MapIcon` / `DungeonFloorSwitchMarker`. But `mapContextEnemyPacks()`, `mapContextEnemyPatrols()`,
+and `mapContextMountableAreas()` instead call `setRelation('floor', $newFloor)` *and* assign
+`floor_id` directly — both stay in sync, so those three don't hit the desync trap below.
+`mapContextFloorUnions()` / `mapContextFloorUnionAreas()` return their collections untouched and
+don't convert anything at all.
 
 ### Three secondary traps
 
-- **`floor_id` and the loaded `floor` relation desync.** `setLatLng()` writes only `floor_id` and
+- **`floor_id` and the loaded `floor` relation desync — for the `setLatLng()` models only**
+  (`Enemy`, `MapIcon`, `DungeonFloorSwitchMarker`). `setLatLng()` writes only `floor_id` and
   never resets the eager-loaded relation, so after conversion `$enemy->floor->id` (real floor)
-  ≠ `$enemy->floor_id` (facade floor) *in the same PHP process*.
+  ≠ `$enemy->floor_id` (facade floor) *in the same PHP process*. The `setRelation()` models
+  (`EnemyPack`, `EnemyPatrol`, `MountableArea`) are not affected — see point 4 above.
 - **…but the relation is not a client-side substitute.** `Enemy::$hidden` contains `'floor'`, so it
   is stripped from the JSON. Conversely `Enemy` defines no `$visible`, which is *why* an ad-hoc
   `setAttribute('source_floor_id', …)` on a non-column survives serialization — adding a `$visible`
@@ -274,8 +281,10 @@ same for its own model type.
 
 ### The fix
 
-Carry the real floor alongside as `source_floor_id`, captured **before** the conversion, mirroring
-what `MappingVersion::mapContextDungeonFloorSwitchMarkers()` already does:
+**Not implemented today** — this is the pattern to reach for if you need the real floor on the
+client, not existing behavior. Carry the real floor alongside as `source_floor_id`, captured
+**before** the conversion, mirroring what `MappingVersion::mapContextDungeonFloorSwitchMarkers()`
+already does server-side:
 
 ```php
 $enemy->setAttribute('source_floor_id', $enemy->floor_id);
@@ -286,7 +295,18 @@ $enemy->setLatLng($this->coordinatesService->convertMapLocationToFacadeMapLocati
 ));
 ```
 
-Client-side, read `enemy.source_floor_id ?? enemy.floor_id`.
+That server-side half is only half the fix. `MapObject.loadRemoteMapObject()`
+(`resources/assets/js/custom/models/mapobject.js`) copies only the properties each model declares
+in its own `_getAttributes()` — there's no catch-all `Object.assign` in the
+`loadMapObject → _createMapObject → loadRemoteMapObject` chain. `resources/assets/js/custom/models/enemy.js`
+does not declare `source_floor_id`, so on an `Enemy` instance a client-side
+`enemy.source_floor_id ?? enemy.floor_id` silently falls through to the facade floor every time —
+the `setAttribute()` above never reaches the browser. `DungeonFloorSwitchMarker` works today only
+because it *does* register `source_floor_id` as a real `Attribute` in its own `_getAttributes()`
+(`resources/assets/js/custom/models/dungeonfloorswitchmarker.js`) — that registration, not the `??`
+fallback, is the load-bearing half of the pattern. If you add the server-side `setAttribute()` call
+to `Enemy`, add the matching client-side attribute registration too, or the fallback will do
+nothing.
 
 **Related:** computing a per-floor *centroid* server-side has its own trap — a single floor can be
 carved into several floor unions that land in completely different places on the combined image


### PR DESCRIPTION
:robot: Documentation only — split out of #128 / #3660 so it lands independently of that feature.

## Why

While building the per-floor enemy forces pill (#3660) the single biggest time sink was a trap that
isn't documented anywhere and isn't guessable from the JS:

> **In facade mode, `enemy.floor_id` on the wire is the *facade* floor, not the floor the enemy
> actually lives on** — so client-side code can never group map objects by their real floor.

It fails silently and *selectively*: on every union-based facade (Nokhud, Skyreach, Dawnbreaker,
Algeth'ar, Halls of Infusion, Uldaman, Pit of Saron) every enemy collapses into one group, while on
a facade that defines no floor unions at all (Lower Karazhan) the conversion is a no-op and the
same buggy code looks correct.

## What

A **Gotcha: facade conversion rewrites `floor_id`** section in the `new-map-view` skill, walking
the whole chain with the code quoted:

1. **`FloorUnion`'s two floor columns read backwards from their names** — `target_floor_id` is the
   *real/source* floor the union pulls from; `floor_id` / `$floorUnion->floor` is the *facade*
   floor it draws onto.
2. `CoordinatesService::convertMapLocationToFacadeMapLocation()` does
   `$result->setFloor($floorUnion->floor)` — the facade floor, despite the inline comment above it
   saying "target floor". That comment actively misleads, so it's quoted verbatim with the
   correction.
3. `HasLatLng::setLatLng()` writes `floor_id` through to the model.

Plus the three secondary traps that each cost their own debugging session:

- `floor_id` and the eager-loaded `floor` relation **desync** after conversion — `$enemy->floor->id`
  ≠ `$enemy->floor_id` in the same process.
- …but that relation is no substitute client-side: `floor` is in `Enemy::$hidden`. Conversely
  `Enemy` defines no `$visible`, which is *why* an ad-hoc `setAttribute('source_floor_id', …)` on a
  non-column survives serialization — adding a `$visible` would silently break it.
- The payload is cached under `dungeon_{id}_{mvid}_{style}` through **two** layers
  (`rememberLocal` wrapping `cacheService->remember`), so a new attribute only appears once that
  entry regenerates — which is why the client-side `?? enemy.floor_id` fallbacks are load-bearing
  rather than defensive noise.

Then the fix (`source_floor_id`, captured before conversion, mirroring what
`mapContextDungeonFloorSwitchMarkers()` already does), and a closing note that server-side per-floor
*centroids* must be averaged in the floor's own coordinate space before converting — a floor can be
carved into several unions landing in different places on the combined image.

`mapping-versioned-models` gets a one-line pointer in its Gotchas list, since that's where someone
adding a `mapContext*()` method for a new model will be reading.

## Notes

- No code changes — two `.claude/skills/*/SKILL.md` files only. Nothing to test or verify in a
  browser.
- Deliberately **not** `Closes #128` — that issue is closed by the feature work, which is being
  revamped separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
