### PR TITLE
#3694 Fix /ajax/routes 500 when a table's tags select is absent

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
+++ b/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
@@ -134,7 +134,12 @@ class AjaxDungeonRouteController extends Controller
                                     dungeon_routes.enemy_forces >= mapping_versions.enemy_forces_required)');
         }
 
+        // A tags select that isn't rendered for the current view (e.g. the team edit page's Route
+        // Publishing tab) sends the literal string 'undefined' instead of omitting the param
         $tags = $request->get('tags', []);
+        if (!is_array($tags)) {
+            $tags = [];
+        }
 
         // Must have these tags
         if (!empty($tags)) {

--- a/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
+++ b/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
@@ -124,7 +124,12 @@ class AjaxDungeonRouteController extends Controller
         // If we're viewing a team's route this will be filled
         $team = null;
 
+        // A requirements select that isn't rendered for the current view sends the literal string
+        // 'undefined' instead of omitting the param, same as the tags select below
         $requirements = $request->get('requirements', []);
+        if (!is_array($requirements)) {
+            $requirements = [];
+        }
 
         // Enough enemy forces
         if (in_array('enough_enemy_forces', $requirements, true)) {

--- a/resources/assets/js/custom/inline/dungeonroute/table.js
+++ b/resources/assets/js/custom/inline/dungeonroute/table.js
@@ -160,7 +160,10 @@ class DungeonrouteTable extends InlineCode {
                 'url': '/ajax/routes',
                 'data': function (d) {
                     d.requirements = $(self.options.requirementsSelectId).val();
-                    d.tags = $(self.options.tagsSelectId).val();
+                    // .val() on a zero-element jQuery collection (e.g. the tags select doesn't
+                    // exist for this table's view) returns undefined, which would otherwise be
+                    // serialized as the literal query string 'tags=undefined'
+                    d.tags = $(self.options.tagsSelectId).val() || [];
                     d = $.extend(d, self._tableView.getAjaxParameters());
                 },
                 'cache': false

--- a/resources/assets/js/custom/inline/dungeonroute/table.js
+++ b/resources/assets/js/custom/inline/dungeonroute/table.js
@@ -159,10 +159,10 @@ class DungeonrouteTable extends InlineCode {
             'ajax': {
                 'url': '/ajax/routes',
                 'data': function (d) {
-                    d.requirements = $(self.options.requirementsSelectId).val();
-                    // .val() on a zero-element jQuery collection (e.g. the tags select doesn't
-                    // exist for this table's view) returns undefined, which would otherwise be
-                    // serialized as the literal query string 'tags=undefined'
+                    // .val() on a zero-element jQuery collection (e.g. a select that doesn't exist
+                    // for this table's view) returns undefined, which would otherwise be serialized
+                    // as the literal query string 'requirements=undefined' / 'tags=undefined'
+                    d.requirements = $(self.options.requirementsSelectId).val() || [];
                     d.tags = $(self.options.tagsSelectId).val() || [];
                     d = $.extend(d, self._tableView.getAjaxParameters());
                 },

--- a/resources/views/team/edittabs/routepublishing.blade.php
+++ b/resources/views/team/edittabs/routepublishing.blade.php
@@ -30,7 +30,6 @@ use App\Models\Team;
             'affixSelectId' => 'route_publishing_affixes',
             'attributesSelectId' => 'route_publishing_attributes',
             'requirementsSelectId' => 'route_publishing_requirements',
-            'tagsSelectId' => 'route_publishing_tags',
         ])
     </div>
 </div>

--- a/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
@@ -21,4 +21,34 @@ final class AjaxDungeonRouteControllerTest extends AjaxPublicTestCase
         // Assert
         $response->assertUnprocessable();
     }
+
+    #[Test]
+    public function get_givenTagsParameterIsTheStringUndefined_returnsOk(): void
+    {
+        // Arrange - this mirrors the request sent by a DungeonrouteTable instance whose tags
+        // select isn't rendered for its view (e.g. the team edit page's Route Publishing tab),
+        // where jQuery's `.val()` on the missing element resolves to `undefined`
+        $query = http_build_query([
+            'draw'    => 1,
+            'start'   => 0,
+            'length'  => 25,
+            'columns' => [
+                [
+                    'data'       => 0,
+                    'name'       => 'title',
+                    'searchable' => 'true',
+                    'orderable'  => 'true',
+                    'search'     => ['value' => '', 'regex' => 'false'],
+                ],
+            ],
+            'search' => ['value' => '', 'regex' => 'false'],
+            'tags'   => 'undefined',
+        ]);
+
+        // Act
+        $response = $this->get(sprintf('/ajax/routes?%s', $query));
+
+        // Assert
+        $response->assertOk();
+    }
 }

--- a/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
@@ -51,4 +51,33 @@ final class AjaxDungeonRouteControllerTest extends AjaxPublicTestCase
         // Assert
         $response->assertOk();
     }
+
+    #[Test]
+    public function get_givenRequirementsParameterIsTheStringUndefined_returnsOk(): void
+    {
+        // Arrange - same failure mode as the tags parameter above: a requirements select that
+        // isn't rendered for the current view sends the literal string 'undefined'
+        $query = http_build_query([
+            'draw'    => 1,
+            'start'   => 0,
+            'length'  => 25,
+            'columns' => [
+                [
+                    'data'       => 0,
+                    'name'       => 'title',
+                    'searchable' => 'true',
+                    'orderable'  => 'true',
+                    'search'     => ['value' => '', 'regex' => 'false'],
+                ],
+            ],
+            'search'       => ['value' => '', 'regex' => 'false'],
+            'requirements' => 'undefined',
+        ]);
+
+        // Act
+        $response = $this->get(sprintf('/ajax/routes?%s', $query));
+
+        // Assert
+        $response->assertOk();
+    }
 }


### PR DESCRIPTION
:robot: Closes #3694

## Summary
The team edit page's Route Publishing tab (`resources/views/team/edittabs/routepublishing.blade.php`)
configures a `tagsSelectId` for a `DungeonrouteTable` instance whose view (`team_route_publishing`)
`table.blade.php` never renders a tags `<select>` for. jQuery's `.val()` on the resulting
zero-element selection resolves to `undefined`, which DataTables serializes into the literal query
string `tags=undefined`. Server-side, `AjaxDungeonRouteController::get()` then calls `count()` on
that string, throwing a `TypeError` and 500ing the tab's table on every load for every team
moderator/admin.

## Changes
- **Client-side** (`table.js`): default `d.tags` to `[]` when the tags select doesn't resolve,
  instead of forwarding `undefined`.
- **Server-side** (`AjaxDungeonRouteController::get()`, defense in depth): treat a non-array `tags`
  request value as `[]` rather than assuming the request always sends an array.
- Added a feature test reproducing the exact crash (`tags=undefined` on `/ajax/routes`) and
  asserting it now returns 200.

## Verification
- `php artisan test --compact tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php` — 2 passed.
- Confirmed the new test fails with the original `count(): Argument #1 ($value) must be of type
  Countable|array, string given` TypeError when the server-side fix is reverted.
- `composer run fix` / `composer run analyse` — clean.
- Verified end-to-end in headless Chrome as a team moderator: opened the Route Publishing tab and
  captured the real `GET /ajax/routes?...&tags=undefined&team_public_key=...` request — `200` with
  the fix in place, and reproduced the exact same `TypeError` server log entry when the fix was
  temporarily reverted.

## Test plan
- [x] `GET /ajax/routes` with `tags=undefined` no longer 500s (covered by new test).
- [x] The team edit page's Route Publishing tab loads its table successfully for moderators/admins
      (verified in headless Chrome).
- [x] Covered by a test.
