### PR TITLE
#3704 Add the Blizzard/MDT floor-style toggle to the route edit page

### DIFF
--- a/resources/views/common/maps/controls/draw.blade.php
+++ b/resources/views/common/maps/controls/draw.blade.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 /**
  * @var boolean                $isAdmin
  * @var Collection<int, Floor> $floors
- * @var DungeonRoute           $dungeonroute
+ * @var DungeonRoute|null      $dungeonroute
  * @var bool                   $facadeEnabled
  */
 ?>

--- a/resources/views/common/maps/controls/draw.blade.php
+++ b/resources/views/common/maps/controls/draw.blade.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
  * @var boolean                $isAdmin
  * @var Collection<int, Floor> $floors
  * @var DungeonRoute           $dungeonroute
+ * @var bool                   $facadeEnabled
  */
 ?>
 <nav
@@ -64,6 +65,10 @@ use Illuminate\Support\Collection;
         @endif
 
         <div id="edit_route_misc_actions_container">
+            @if($facadeEnabled && isset($dungeonroute))
+                @include('common.maps.controls.elements.facadetoggle')
+            @endif
+
             @include('common.maps.controls.elements.labeltoggle')
         </div>
     </div>

--- a/resources/views/common/maps/map.blade.php
+++ b/resources/views/common/maps/map.blade.php
@@ -315,6 +315,7 @@ if ($isAdmin) {
             'floors' => ($isAdmin ? $dungeon->floors() : $dungeon->floorsForMapFacade($mappingVersion, $useFacade)->active())->get(),
             'selectedFloorId' => $floor->id,
             'isMobile' => $isMobile,
+            'facadeEnabled' => $mappingVersion->facade_enabled,
         ])
     @elseif(isset($show['controls']['liveSession']) && $show['controls']['liveSession'])
         @include('common.maps.controls.livesession', [

--- a/tests/Feature/Controller/DungeonRoute/DungeonRouteEditSidebarTest.php
+++ b/tests/Feature/Controller/DungeonRoute/DungeonRouteEditSidebarTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature\Controller\DungeonRoute;
+
+use App\Models\Dungeon;
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\Laratrust\Role;
+use App\Models\PublishedState;
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Covers issue #3704 - the route edit page must show the Blizzard/MDT floor-style (facade) toggle
+ * whenever the route's mapping version supports it, mirroring the route view page's sidebar. The
+ * admin mapping-version editor renders through the same `common.maps.controls.draw` partial but
+ * must never show the toggle (per the issue's explicit scope), so that page is covered too.
+ */
+#[Group('Controller')]
+#[Group('DungeonRoute')]
+final class DungeonRouteEditSidebarTest extends PublicTestCase
+{
+    #[Test]
+    public function editFloor_givenMappingVersionWithFacadeEnabled_rendersTheFacadeToggle(): void
+    {
+        // Arrange
+        $owner   = User::factory()->create();
+        $dungeon = $this->dungeonWithFacadeEnabled(true);
+        $route   = $this->createRoute($owner, $dungeon);
+
+        try {
+            $this->be($owner);
+
+            // Act
+            $response = $this->followingRedirects()->get($this->editUrl($route));
+
+            // Assert
+            $response->assertOk();
+            $response->assertSee('map_controls_element_facade_toggle_btn', false);
+        } finally {
+            $route->delete();
+            $owner->delete();
+        }
+    }
+
+    #[Test]
+    public function editFloor_givenMappingVersionWithFacadeDisabled_hidesTheFacadeToggle(): void
+    {
+        // Arrange
+        $owner   = User::factory()->create();
+        $dungeon = $this->dungeonWithFacadeEnabled(false);
+        $route   = $this->createRoute($owner, $dungeon);
+
+        try {
+            $this->be($owner);
+
+            // Act
+            $response = $this->followingRedirects()->get($this->editUrl($route));
+
+            // Assert
+            $response->assertOk();
+            $response->assertDontSee('map_controls_element_facade_toggle_btn', false);
+        } finally {
+            $route->delete();
+            $owner->delete();
+        }
+    }
+
+    #[Test]
+    public function mapping_givenMappingVersionWithFacadeEnabled_hidesTheFacadeToggle(): void
+    {
+        // Arrange
+        $admin   = User::findOrFail(1);
+        $dungeon = $this->dungeonWithFacadeEnabled(true);
+        $floor   = $dungeon->floors()->first();
+
+        $this->assertTrue($admin->hasRole(Role::ROLE_ADMIN), 'User id=1 must be admin (seed the DB).');
+        $this->assertNotNull($floor, 'Dungeon used for this test must have at least one floor.');
+
+        $this->be($admin);
+
+        // Act
+        $response = $this->get(route('admin.floor.edit.mapping', [
+            'dungeon'         => $dungeon,
+            'floor'           => $floor,
+            'mapping_version' => $dungeon->getCurrentMappingVersion()->id,
+        ]));
+
+        // Assert
+        $response->assertOk();
+        $response->assertDontSee('map_controls_element_facade_toggle_btn', false);
+    }
+
+    /**
+     * Finds a seeded dungeon whose current mapping version matches the requested facade_enabled
+     * state, so the test exercises real data instead of hand-crafting a MappingVersion row.
+     */
+    private function dungeonWithFacadeEnabled(bool $facadeEnabled): Dungeon
+    {
+        /** @var Dungeon|null $dungeon */
+        $dungeon = Dungeon::whereNotNull('challenge_mode_id')
+            ->get()
+            ->first(static function (Dungeon $dungeon) use ($facadeEnabled): bool {
+                $mappingVersion = $dungeon->getCurrentMappingVersion();
+
+                return $mappingVersion !== null && (bool)$mappingVersion->facade_enabled === $facadeEnabled;
+            });
+
+        if ($dungeon === null) {
+            self::fail(sprintf(
+                'No seeded dungeon with facade_enabled=%s found to test the edit sidebar.',
+                $facadeEnabled ? 'true' : 'false',
+            ));
+        }
+
+        return $dungeon;
+    }
+
+    /**
+     * A published, non-sandbox route owned by $owner, pinned to $dungeon's current mapping
+     * version. Sandbox routes (which the factory creates by default) are editable by anyone, so
+     * expires_at must be null here.
+     */
+    private function createRoute(User $owner, Dungeon $dungeon): DungeonRoute
+    {
+        return DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $dungeon->getCurrentMappingVersion()->id,
+            'author_id'          => $owner->id,
+            'expires_at'         => null,
+            'published_state_id' => PublishedState::ALL[PublishedState::WORLD],
+        ]);
+    }
+
+    private function editUrl(DungeonRoute $route): string
+    {
+        return route('dungeonroute.edit', [
+            'dungeon'      => $route->dungeon,
+            'dungeonroute' => $route,
+            'title'        => $route->getTitleSlug(),
+        ]);
+    }
+}

--- a/tests/Feature/Controller/DungeonRoute/DungeonRouteEditSidebarTest.php
+++ b/tests/Feature/Controller/DungeonRoute/DungeonRouteEditSidebarTest.php
@@ -5,10 +5,13 @@ namespace Tests\Feature\Controller\DungeonRoute;
 use App\Models\Dungeon;
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Laratrust\Role;
+use App\Models\Mapping\MappingVersion;
 use App\Models\PublishedState;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Traits\ProvidesDungeon;
 use Tests\TestCases\PublicTestCase;
 
 /**
@@ -21,17 +24,19 @@ use Tests\TestCases\PublicTestCase;
 #[Group('DungeonRoute')]
 final class DungeonRouteEditSidebarTest extends PublicTestCase
 {
+    use ProvidesDungeon;
+
     #[Test]
     public function editFloor_givenMappingVersionWithFacadeEnabled_rendersTheFacadeToggle(): void
     {
         // Arrange
-        $owner   = User::factory()->create();
-        $dungeon = $this->dungeonWithFacadeEnabled(true);
-        $route   = $this->createRoute($owner, $dungeon);
+        $owner = User::factory()->create();
+        $this->be($owner);
+
+        [$dungeon, $mappingVersion] = $this->dungeonWithFacadeEnabled(true);
+        $route                      = $this->createRoute($owner, $dungeon, $mappingVersion);
 
         try {
-            $this->be($owner);
-
             // Act
             $response = $this->followingRedirects()->get($this->editUrl($route));
 
@@ -48,13 +53,13 @@ final class DungeonRouteEditSidebarTest extends PublicTestCase
     public function editFloor_givenMappingVersionWithFacadeDisabled_hidesTheFacadeToggle(): void
     {
         // Arrange
-        $owner   = User::factory()->create();
-        $dungeon = $this->dungeonWithFacadeEnabled(false);
-        $route   = $this->createRoute($owner, $dungeon);
+        $owner = User::factory()->create();
+        $this->be($owner);
+
+        [$dungeon, $mappingVersion] = $this->dungeonWithFacadeEnabled(false);
+        $route                      = $this->createRoute($owner, $dungeon, $mappingVersion);
 
         try {
-            $this->be($owner);
-
             // Act
             $response = $this->followingRedirects()->get($this->editUrl($route));
 
@@ -71,20 +76,29 @@ final class DungeonRouteEditSidebarTest extends PublicTestCase
     public function mapping_givenMappingVersionWithFacadeEnabled_hidesTheFacadeToggle(): void
     {
         // Arrange
-        $admin   = User::findOrFail(1);
-        $dungeon = $this->dungeonWithFacadeEnabled(true);
-        $floor   = $dungeon->floors()->first();
-
+        $admin = User::findOrFail(1);
         $this->assertTrue($admin->hasRole(Role::ROLE_ADMIN), 'User id=1 must be admin (seed the DB).');
-        $this->assertNotNull($floor, 'Dungeon used for this test must have at least one floor.');
 
+        // Switch to the admin user *before* resolving the dungeon's mapping version: it is cached
+        // per acting-user game version (see Dungeon::$currentMappingVersionCache), so resolving it
+        // beforehand (as an unauthenticated visitor) could hand the request below a different,
+        // possibly facade-disabled mapping version than the one just verified here.
         $this->be($admin);
+
+        [$dungeon, $mappingVersion] = $this->dungeonWithFacadeEnabled(true);
+        $floor                      = $dungeon->floors()->first();
+
+        $this->assertTrue(
+            (bool)$mappingVersion->facade_enabled,
+            'Mapping version under test must be facade-enabled, otherwise this test proves nothing.',
+        );
+        $this->assertNotNull($floor, 'Dungeon used for this test must have at least one floor.');
 
         // Act
         $response = $this->get(route('admin.floor.edit.mapping', [
             'dungeon'         => $dungeon,
             'floor'           => $floor,
-            'mapping_version' => $dungeon->getCurrentMappingVersion()->id,
+            'mapping_version' => $mappingVersion->id,
         ]));
 
         // Assert
@@ -93,40 +107,55 @@ final class DungeonRouteEditSidebarTest extends PublicTestCase
     }
 
     /**
-     * Finds a seeded dungeon whose current mapping version matches the requested facade_enabled
-     * state, so the test exercises real data instead of hand-crafting a MappingVersion row.
+     * Finds a seeded dungeon whose *current* mapping version matches the requested facade_enabled
+     * state, reusing `ProvidesDungeon`'s `inRandomOrder()`-based helpers instead of an ad-hoc
+     * query. Those helpers only guarantee the presence/absence of facade floors, which - as real
+     * seeded data shows - does not always agree with the current mapping version's
+     * `facade_enabled` flag (older facade floors can outlive the mapping version that enabled
+     * them), so this still verifies `facade_enabled` explicitly and retries otherwise.
+     *
+     * Must be called after switching to the acting user (`$this->be(...)`), since the resolved
+     * mapping version is cached per acting-user game version and is returned here for the caller
+     * to reuse verbatim, so the exact row just verified is the one the request under test uses.
+     *
+     * Restricted to Mythic+ dungeons (`challenge_mode_id` not null): non-Mythic+ dungeons (e.g.
+     * Horrific Visions) aren't valid `DungeonRoute` targets and some don't even have a default
+     * floor, which `dungeonroute.edit`'s redirect chain requires.
+     *
+     * @return array{0: Dungeon, 1: MappingVersion}
      */
-    private function dungeonWithFacadeEnabled(bool $facadeEnabled): Dungeon
+    private function dungeonWithFacadeEnabled(bool $facadeEnabled): array
     {
-        /** @var Dungeon|null $dungeon */
-        $dungeon = Dungeon::whereNotNull('challenge_mode_id')
-            ->get()
-            ->first(static function (Dungeon $dungeon) use ($facadeEnabled): bool {
-                $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $constraint = static fn(Builder $query): Builder => $query->whereNotNull('challenge_mode_id');
 
-                return $mappingVersion !== null && (bool)$mappingVersion->facade_enabled === $facadeEnabled;
-            });
+        $count = 0;
+        do {
+            if (++$count > 20) {
+                self::fail(sprintf(
+                    'No seeded dungeon with a facade_enabled=%s mapping version found to test the edit sidebar.',
+                    $facadeEnabled ? 'true' : 'false',
+                ));
+            }
 
-        if ($dungeon === null) {
-            self::fail(sprintf(
-                'No seeded dungeon with facade_enabled=%s found to test the edit sidebar.',
-                $facadeEnabled ? 'true' : 'false',
-            ));
-        }
+            $dungeon = $facadeEnabled
+                ? $this->getDungeonWithFacadeFloor($constraint)
+                : $this->getDungeonWithNonFacadeFloor($constraint);
+            $mappingVersion = $dungeon->getCurrentMappingVersion();
+        } while ($mappingVersion === null || (bool)$mappingVersion->facade_enabled !== $facadeEnabled);
 
-        return $dungeon;
+        return [$dungeon, $mappingVersion];
     }
 
     /**
-     * A published, non-sandbox route owned by $owner, pinned to $dungeon's current mapping
-     * version. Sandbox routes (which the factory creates by default) are editable by anyone, so
-     * expires_at must be null here.
+     * A published, non-sandbox route owned by $owner, pinned to $mappingVersion. Sandbox routes
+     * (which the factory creates by default) are editable by anyone, so expires_at must be null
+     * here.
      */
-    private function createRoute(User $owner, Dungeon $dungeon): DungeonRoute
+    private function createRoute(User $owner, Dungeon $dungeon, MappingVersion $mappingVersion): DungeonRoute
     {
         return DungeonRoute::factory()->create([
             'dungeon_id'         => $dungeon->id,
-            'mapping_version_id' => $dungeon->getCurrentMappingVersion()->id,
+            'mapping_version_id' => $mappingVersion->id,
             'author_id'          => $owner->id,
             'expires_at'         => null,
             'published_state_id' => PublishedState::ALL[PublishedState::WORLD],


### PR DESCRIPTION
:robot: Closes #3704

## Summary
- The route view and explore pages let users toggle floor rendering between Blizzard-style and MDT-style (the "facade" toggle); the route edit page's sidebar was missing this control entirely.
- Adds the same toggle to `common.maps.controls.draw` (the edit-page sidebar), mirroring `common.maps.controls.view`'s placement in the misc-actions container.
- Gated on `isset($dungeonroute)` so it does **not** leak onto the admin mapping-version editor (`admin/floor/mapping.blade.php`), which renders through this same `draw` partial but is explicitly out of scope per the issue ("Map-version editing pages do not need this toggle").
- No JS changes needed — `_setupFacadeToggle()` in `map.js` already binds unconditionally and is a no-op when the button isn't present.

## Test plan
- [x] New feature test `DungeonRouteEditSidebarTest`: toggle renders on the route edit page when the mapping version has `facade_enabled`, is hidden when it doesn't, and is hidden on the admin mapping-version editor page.
- [x] `composer run fix` / `composer run analyse` clean.
- [x] Verified in a real headless-Chrome session: toggle renders correctly on the route edit page (screenshot below); confirmed absent on the admin mapping editor via the feature test.
- [x] Manual self-review of the diff — `code-review` skill could not be invoked directly (`disable-model-invocation`); a human run is still recommended.

![verification](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3704-edit-facade-toggle.png)