### PR TITLE
#3702 Preserve enemy forces checkpoints across MDT mapping imports

### DIFF
--- a/.claude/skills/mapping-versioned-models/SKILL.md
+++ b/.claude/skills/mapping-versioned-models/SKILL.md
@@ -90,25 +90,25 @@ neither that method nor the MDT-copy path clones enemies (a checkpoint's members
 `copyMappingVersionContentsToDungeon()` would give it zero members with no way for the caller to
 fix that up later. `MappingService::copyEnemyForcesCheckpointsToMappingVersion(source, target):
 array<int, int>` returns **source checkpoint id => clone id**. That map has to cross the
-`MappingService` boundary back to the caller — `MappingVersionController::saveNew()`'s "Add bare
-mapping version" action, and `MDTMappingImportService::importMappingVersionFromMDT()` (which
-threads it into `importEnemies()`) — so the caller can translate each surviving enemy's
-`enemy_forces_checkpoint_id` through it; copying that field verbatim would attach the enemy to the
-*previous* mapping version's checkpoint. **Both existing callers of
-`copyMappingVersionContentsToDungeon()` also call `copyEnemyForcesCheckpointsToMappingVersion()`**
-— enforced only by the doc-block on `MappingServiceInterface::copyMappingVersionContentsToDungeon()`,
-not the type system, making this the fifth hardcoded-list-shaped trap in this file (see Gotchas). A
-by-reference out-param was tried and abandoned instead of a return value: the repo's
+`MappingService` boundary back to the caller — currently only
+`MDTMappingImportService::importMappingVersionFromMDT()` (which threads it into `importEnemies()`)
+— so the caller can translate each surviving enemy's `enemy_forces_checkpoint_id` through it;
+copying that field verbatim would attach the enemy to the *previous* mapping version's checkpoint.
+**Not every caller of `copyMappingVersionContentsToDungeon()` should pair it with this** —
+`MappingVersionController::saveNew()`'s "Add bare mapping version" action deliberately does *not*:
+a bare mapping version has no enemies at all, so a checkpoint cloned there would sit permanently
+empty with nothing to assign it to. Whether a given caller should pair the two is a judgment call
+documented on `MappingServiceInterface::copyMappingVersionContentsToDungeon()`'s doc-block, not
+enforced by the type system — read that doc-block before adding a new caller. A by-reference
+out-param was tried and abandoned instead of a return value: the repo's
 `ErickSkrauch/align_multiline_parameters` php-cs-fixer rule mangles `&$param` into
 `?array   &   $param`.
 
-A checkpoint cloned with zero members (e.g. every checkpoint "Add bare mapping version" clones,
-since that path never clones enemies at all) must not be treated as having *lost* its members on
-the next MDT import. `MDTMappingImportService::deleteEmptyEnemyForcesCheckpoints()` only prunes a
-still-empty clone whose **source** counterpart genuinely had members (checked against the same id
-map) — anything else, even if currently empty, survives untouched. Getting this wrong silently
-wipes every checkpoint of every dungeon on the very next real MDT change, since a bare mapping
-version's checkpoints have no members to match against by definition.
+A checkpoint cloned with zero members must not be treated as having *lost* its members on the next
+MDT import. `MDTMappingImportService::deleteEmptyEnemyForcesCheckpoints()` only prunes a
+still-empty clone whose **source** counterpart genuinely had members (checked against the id map
+above) — anything else, even if currently empty, survives untouched. Getting this wrong silently
+wipes every checkpoint of every dungeon on the very next real MDT change.
 
 ## Query scoping
 
@@ -177,8 +177,9 @@ example** — its diff contains exactly one of everything below; when in doubt, 
    model's children live in a table this method doesn't touch (the way `enemyForcesCheckpoints`'
    members live in `enemies`, which this method never copies), clone it via its own paired method
    instead — see `copyEnemyForcesCheckpointsToMappingVersion()` above — and return a
-   source id => clone id map so the caller can re-link children itself; every existing caller of
-   `copyMappingVersionContentsToDungeon()` must call the paired method too.
+   source id => clone id map so the caller can re-link children itself; only pair it from callers
+   that will actually populate those children afterwards (a caller with no children to assign,
+   like a bare mapping version, must not pair it or the clone sits permanently empty).
 6. `app/Console/Commands/Mapping/Copy.php` `$relations` array: any model carrying a `floor_id`
    must be listed or cross-dungeon copies strand it on the source dungeon's floors — see Gotchas.
 
@@ -264,13 +265,16 @@ example** — its diff contains exactly one of everything below; when in doubt, 
 - The hardcoded model lists (three in `MappingVersion::boot()`, the partial one in
   `MappingService::copyMappingVersionContentsToDungeon()`, the `$relations` array in
   `app/Console/Commands/Mapping/Copy.php`, the seeder's `$relationMapping` array) are the classic
-  "new model silently missing from new versions" bug source. A fifth spot of the same shape:
-  every caller of `copyMappingVersionContentsToDungeon()` must also call
-  `copyEnemyForcesCheckpointsToMappingVersion()` (#3702) — nothing enforces the pairing but a
-  doc-block comment, and forgetting it silently drops every checkpoint on that call path. Unlike
-  the other four, the fix also has to thread an id map (source checkpoint id => clone id) back
-  across the service boundary to the caller, because only the caller can re-link the children
-  (`enemies`) that method never copies.
+  "new model silently missing from new versions" bug source. A fifth spot of the same shape, but
+  inverted: a caller of `copyMappingVersionContentsToDungeon()` that *should* clone enemy forces
+  checkpoints (i.e. anything that will also re-create/re-link the enemies to assign to them, like
+  an MDT import) must remember to also call `copyEnemyForcesCheckpointsToMappingVersion()`
+  (#3702) — nothing enforces this but a doc-block comment on the interface, and forgetting it
+  silently drops every checkpoint on that call path. Not every caller should pair it though —
+  a caller with no enemies at all (bare mapping versions) must *not*, or the clone sits
+  permanently empty. When it does apply, the fix also has to thread an id map (source checkpoint
+  id => clone id) back across the service boundary to the caller, because only the caller can
+  re-link the children (`enemies`) that method never copies.
 - **Don't forget `Copy.php`.** `mapping:copy <gameVersion> <source> <target>` goes through
   `createNewMappingVersionFromPreviousMapping()`, so the boot clones everything correctly — but for a
   **cross-dungeon** copy `Copy.php` then re-points every cloned model's `floor_id` onto the target

--- a/.claude/skills/mapping-versioned-models/SKILL.md
+++ b/.claude/skills/mapping-versioned-models/SKILL.md
@@ -78,10 +78,37 @@ child clones.
    avoid double-cloning, then call `copyMappingVersionContentsToDungeon()` — which clones only a
    **subset**: floor switch markers (with `linked_dungeon_floor_switch_marker_id` re-linking),
    mapIcons, mountableAreas, floorUnions + floorUnionAreas. Enemies/packs/patrols/npcEnemyForces
-   are intentionally excluded (they come from the MDT import instead). `enemyForcesCheckpoints` are
-   excluded too, which is right for the bare-mapping-version caller but silently discards them on
-   every MDT bump — a known, tracked product decision (#3702), not an oversight; see the comment in
-   that method before "fixing" it.
+   are intentionally excluded (they come from the MDT import instead, or are re-linked by the
+   caller afterwards — see below). `enemyForcesCheckpoints` are cloned by a **separate paired
+   method** the caller must remember to invoke too — see the next subsection (#3702).
+
+### The `copyEnemyForcesCheckpointsToMappingVersion()` pairing (#3702)
+
+`EnemyForcesCheckpoint` clones **outside** `copyMappingVersionContentsToDungeon()` on purpose:
+neither that method nor the MDT-copy path clones enemies (a checkpoint's members live in
+`enemies`), so only the caller can re-link membership afterwards — cloning the checkpoint *inside*
+`copyMappingVersionContentsToDungeon()` would give it zero members with no way for the caller to
+fix that up later. `MappingService::copyEnemyForcesCheckpointsToMappingVersion(source, target):
+array<int, int>` returns **source checkpoint id => clone id**. That map has to cross the
+`MappingService` boundary back to the caller — `MappingVersionController::saveNew()`'s "Add bare
+mapping version" action, and `MDTMappingImportService::importMappingVersionFromMDT()` (which
+threads it into `importEnemies()`) — so the caller can translate each surviving enemy's
+`enemy_forces_checkpoint_id` through it; copying that field verbatim would attach the enemy to the
+*previous* mapping version's checkpoint. **Both existing callers of
+`copyMappingVersionContentsToDungeon()` also call `copyEnemyForcesCheckpointsToMappingVersion()`**
+— enforced only by the doc-block on `MappingServiceInterface::copyMappingVersionContentsToDungeon()`,
+not the type system, making this the fifth hardcoded-list-shaped trap in this file (see Gotchas). A
+by-reference out-param was tried and abandoned instead of a return value: the repo's
+`ErickSkrauch/align_multiline_parameters` php-cs-fixer rule mangles `&$param` into
+`?array   &   $param`.
+
+A checkpoint cloned with zero members (e.g. every checkpoint "Add bare mapping version" clones,
+since that path never clones enemies at all) must not be treated as having *lost* its members on
+the next MDT import. `MDTMappingImportService::deleteEmptyEnemyForcesCheckpoints()` only prunes a
+still-empty clone whose **source** counterpart genuinely had members (checked against the same id
+map) — anything else, even if currently empty, survives untouched. Getting this wrong silently
+wipes every checkpoint of every dungeon on the very next real MDT change, since a bare mapping
+version's checkpoints have no members to match against by definition.
 
 ## Query scoping
 
@@ -233,7 +260,13 @@ example** — its diff contains exactly one of everything below; when in doubt, 
 - The hardcoded model lists (three in `MappingVersion::boot()`, the partial one in
   `MappingService::copyMappingVersionContentsToDungeon()`, the `$relations` array in
   `app/Console/Commands/Mapping/Copy.php`, the seeder's `$relationMapping` array) are the classic
-  "new model silently missing from new versions" bug source.
+  "new model silently missing from new versions" bug source. A fifth spot of the same shape:
+  every caller of `copyMappingVersionContentsToDungeon()` must also call
+  `copyEnemyForcesCheckpointsToMappingVersion()` (#3702) — nothing enforces the pairing but a
+  doc-block comment, and forgetting it silently drops every checkpoint on that call path. Unlike
+  the other four, the fix also has to thread an id map (source checkpoint id => clone id) back
+  across the service boundary to the caller, because only the caller can re-link the children
+  (`enemies`) that method never copies.
 - **Don't forget `Copy.php`.** `mapping:copy <gameVersion> <source> <target>` goes through
   `createNewMappingVersionFromPreviousMapping()`, so the boot clones everything correctly — but for a
   **cross-dungeon** copy `Copy.php` then re-points every cloned model's `floor_id` onto the target

--- a/.claude/skills/mapping-versioned-models/SKILL.md
+++ b/.claude/skills/mapping-versioned-models/SKILL.md
@@ -173,8 +173,12 @@ example** — its diff contains exactly one of everything below; when in doubt, 
    clones of the referencing model keep pointing at the **old** version's row and the new
    version looks fine while being subtly wrong.
 5. `MappingService::copyMappingVersionContentsToDungeon()`: add a clone loop **if** the model
-   must survive the MDT-copy path — this is separate from the boot path and easy to forget. If
-   you deliberately skip it, say so in the comment there (checkpoints: tracked in #3702).
+   must survive the MDT-copy path — this is separate from the boot path and easy to forget. If the
+   model's children live in a table this method doesn't touch (the way `enemyForcesCheckpoints`'
+   members live in `enemies`, which this method never copies), clone it via its own paired method
+   instead — see `copyEnemyForcesCheckpointsToMappingVersion()` above — and return a
+   source id => clone id map so the caller can re-link children itself; every existing caller of
+   `copyMappingVersionContentsToDungeon()` must call the paired method too.
 6. `app/Console/Commands/Mapping/Copy.php` `$relations` array: any model carrying a `floor_id`
    must be listed or cross-dungeon copies strand it on the source dungeon's floors — see Gotchas.
 

--- a/app/Http/Controllers/Dungeon/MappingVersionController.php
+++ b/app/Http/Controllers/Dungeon/MappingVersionController.php
@@ -49,12 +49,8 @@ class MappingVersionController extends Controller
                     $newMappingVersion,
                 );
 
-                // A bare mapping version has no enemies, so its checkpoints arrive without members - but the
-                // mapper who added the checkpoints should not have to draw them again (#3702)
-                $mappingService->copyEnemyForcesCheckpointsToMappingVersion(
-                    $currentMappingVersion,
-                    $newMappingVersion,
-                );
+                // A bare mapping version has no enemies, so enemy forces checkpoints - which are only
+                // meaningful once enemies are assigned to them - deliberately don't come along either (#3702).
             }
 
             Session::flash('status', __('controller.mappingversion.created_bare_successfully'));

--- a/app/Http/Controllers/Dungeon/MappingVersionController.php
+++ b/app/Http/Controllers/Dungeon/MappingVersionController.php
@@ -48,6 +48,13 @@ class MappingVersionController extends Controller
                     $currentMappingVersion,
                     $newMappingVersion,
                 );
+
+                // A bare mapping version has no enemies, so its checkpoints arrive without members - but the
+                // mapper who added the checkpoints should not have to draw them again (#3702)
+                $mappingService->copyEnemyForcesCheckpointsToMappingVersion(
+                    $currentMappingVersion,
+                    $newMappingVersion,
+                );
             }
 
             Session::flash('status', __('controller.mappingversion.created_bare_successfully'));

--- a/app/Http/Controllers/Dungeon/MappingVersionController.php
+++ b/app/Http/Controllers/Dungeon/MappingVersionController.php
@@ -48,9 +48,6 @@ class MappingVersionController extends Controller
                     $currentMappingVersion,
                     $newMappingVersion,
                 );
-
-                // A bare mapping version has no enemies, so enemy forces checkpoints - which are only
-                // meaningful once enemies are assigned to them - deliberately don't come along either (#3702).
             }
 
             Session::flash('status', __('controller.mappingversion.created_bare_successfully'));

--- a/app/Service/MDT/Logging/MDTMappingImportServiceLogging.php
+++ b/app/Service/MDT/Logging/MDTMappingImportServiceLogging.php
@@ -198,6 +198,11 @@ class MDTMappingImportServiceLogging extends StructuredLogging implements MDTMap
         $this->warning(__METHOD__, get_defined_vars());
     }
 
+    public function importEnemiesPrunedEmptyEnemyForcesCheckpoints(int $dungeonId, int $count): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
+    }
+
     public function importEnemiesSaveNewEnemy(int $enemyId): void
     {
         $this->debug(__METHOD__, get_defined_vars());

--- a/app/Service/MDT/Logging/MDTMappingImportServiceLogging.php
+++ b/app/Service/MDT/Logging/MDTMappingImportServiceLogging.php
@@ -188,6 +188,16 @@ class MDTMappingImportServiceLogging extends StructuredLogging implements MDTMap
         $this->error(__METHOD__, get_defined_vars());
     }
 
+    public function importEnemiesCannotRecoverEnemyForcesCheckpoint(string $uniqueKey, int $enemyForcesCheckpointId): void
+    {
+        $this->warning(__METHOD__, get_defined_vars());
+    }
+
+    public function importEnemiesDeleteEmptyEnemyForcesCheckpoint(int $enemyForcesCheckpointId, ?string $name): void
+    {
+        $this->warning(__METHOD__, get_defined_vars());
+    }
+
     public function importEnemiesSaveNewEnemy(int $enemyId): void
     {
         $this->debug(__METHOD__, get_defined_vars());

--- a/app/Service/MDT/Logging/MDTMappingImportServiceLoggingInterface.php
+++ b/app/Service/MDT/Logging/MDTMappingImportServiceLoggingInterface.php
@@ -91,6 +91,10 @@ interface MDTMappingImportServiceLoggingInterface
 
     public function importEnemiesCannotRecoverPropertiesFromExistingEnemy(string $uniqueKey): void;
 
+    public function importEnemiesCannotRecoverEnemyForcesCheckpoint(string $uniqueKey, int $enemyForcesCheckpointId): void;
+
+    public function importEnemiesDeleteEmptyEnemyForcesCheckpoint(int $enemyForcesCheckpointId, ?string $name): void;
+
     public function importEnemiesSaveNewEnemy(int $enemyId): void;
 
     public function importEnemiesSaveNewEnemyException(Exception $exception): void;

--- a/app/Service/MDT/Logging/MDTMappingImportServiceLoggingInterface.php
+++ b/app/Service/MDT/Logging/MDTMappingImportServiceLoggingInterface.php
@@ -95,6 +95,13 @@ interface MDTMappingImportServiceLoggingInterface
 
     public function importEnemiesDeleteEmptyEnemyForcesCheckpoint(int $enemyForcesCheckpointId, ?string $name): void;
 
+    /**
+     * A dungeon-wide summary of the deletions above, logged at a level that reaches Discord: post-#3702 this
+     * only fires for checkpoints that genuinely had members in the source mapping version, so it is worth a
+     * human's attention.
+     */
+    public function importEnemiesPrunedEmptyEnemyForcesCheckpoints(int $dungeonId, int $count): void;
+
     public function importEnemiesSaveNewEnemy(int $enemyId): void;
 
     public function importEnemiesSaveNewEnemyException(Exception $exception): void;

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -89,17 +89,18 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
             $newMappingVersion = $mappingService->createNewMappingVersionFromMDTMapping($dungeon, $gameVersion, $this->getMDTMappingHash($dungeon));
             $this->log->importMappingVersionFromMDTCreateMappingVersion($newMappingVersion->version, $newMappingVersion->id);
 
-            // Enemies are re-created from MDT below, so their checkpoint membership has to be re-linked by hand -
-            // which is why the checkpoints are cloned here rather than as part of the mapping version's contents
-            $enemyForcesCheckpointIdMapping = $mappingService->copyEnemyForcesCheckpointsToMappingVersion(
-                $currentMappingVersion,
-                $newMappingVersion,
-            );
-
             $mdtDungeon = new MDTDungeon($this->cacheService, $this->coordinatesService, $dungeon);
 
             try {
                 $this->log->importMappingVersionFromMDTStart($dungeon->id);
+
+                // Enemies are re-created from MDT below, so their checkpoint membership has to be re-linked by
+                // hand - which is why the checkpoints are cloned here rather than as part of the mapping
+                // version's contents
+                $enemyForcesCheckpointIdMapping = $mappingService->copyEnemyForcesCheckpointsToMappingVersion(
+                    $currentMappingVersion,
+                    $newMappingVersion,
+                );
 
                 $this->importDungeon($mdtDungeon, $dungeon, $newMappingVersion);
                 $this->importNpcs($newMappingVersion, $mdtDungeon, $dungeon, $gameVersion);
@@ -601,6 +602,10 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
         EnemyForcesCheckpoint::query()
             ->whereIn('id', $emptyEnemyForcesCheckpoints->pluck('id'))
             ->delete();
+
+        // laravel-model-caching only flushes on model events and truncate(), never on a builder delete, so the
+        // reads above would otherwise keep serving the checkpoints this just removed
+        new EnemyForcesCheckpoint()->flushCache();
     }
 
     /**

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -9,6 +9,7 @@ use App\Logic\MDT\Entity\MDTPatrol;
 use App\Models\Dungeon;
 use App\Models\DungeonFloorSwitchMarker;
 use App\Models\Enemy;
+use App\Models\EnemyForcesCheckpoint;
 use App\Models\EnemyPack;
 use App\Models\EnemyPatrol;
 use App\Models\Faction;
@@ -88,6 +89,13 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
             $newMappingVersion = $mappingService->createNewMappingVersionFromMDTMapping($dungeon, $gameVersion, $this->getMDTMappingHash($dungeon));
             $this->log->importMappingVersionFromMDTCreateMappingVersion($newMappingVersion->version, $newMappingVersion->id);
 
+            // Enemies are re-created from MDT below, so their checkpoint membership has to be re-linked by hand -
+            // which is why the checkpoints are cloned here rather than as part of the mapping version's contents
+            $enemyForcesCheckpointIdMapping = $mappingService->copyEnemyForcesCheckpointsToMappingVersion(
+                $currentMappingVersion,
+                $newMappingVersion,
+            );
+
             $mdtDungeon = new MDTDungeon($this->cacheService, $this->coordinatesService, $dungeon);
 
             try {
@@ -95,7 +103,14 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
 
                 $this->importDungeon($mdtDungeon, $dungeon, $newMappingVersion);
                 $this->importNpcs($newMappingVersion, $mdtDungeon, $dungeon, $gameVersion);
-                $enemies = $this->importEnemies($currentMappingVersion, $newMappingVersion, $mdtDungeon, $dungeon, $forceImport);
+                $enemies = $this->importEnemies(
+                    $currentMappingVersion,
+                    $newMappingVersion,
+                    $mdtDungeon,
+                    $dungeon,
+                    $enemyForcesCheckpointIdMapping,
+                    $forceImport,
+                );
                 $this->importEnemyPacks($newMappingVersion, $mdtDungeon, $dungeon, $enemies);
                 $this->importEnemyPatrols($currentMappingVersion, $newMappingVersion, $mdtDungeon, $dungeon, $enemies);
                 $this->importMapPOIs($currentMappingVersion, $newMappingVersion, $mdtDungeon, $dungeon);
@@ -415,6 +430,9 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
     }
 
     /**
+     * @param  array<int, int>        $enemyForcesCheckpointIdMapping Source checkpoint id => cloned checkpoint id, as
+     *                                                                built by MappingService when it cloned the
+     *                                                                previous mapping version's checkpoints.
      * @return Collection<int, Enemy>
      */
     private function importEnemies(
@@ -422,6 +440,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
         MappingVersion $newMappingVersion,
         MDTDungeon     $mdtDungeon,
         Dungeon        $dungeon,
+        array          $enemyForcesCheckpointIdMapping,
         bool           $forceImport = false,
     ): Collection {
         // Get a list of new enemies and save them
@@ -461,8 +480,10 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                 unset($mdtEnemy->enemy_id);
 
                 // Is group ID - we handle this later on
-                $mdtEnemy->enemy_pack_id      = null;
-                $mdtEnemy->mapping_version_id = $newMappingVersion->id;
+                $mdtEnemy->enemy_pack_id = null;
+                // Membership is restored below, but only for enemies we can match to their predecessor
+                $mdtEnemy->enemy_forces_checkpoint_id = null;
+                $mdtEnemy->mapping_version_id         = $newMappingVersion->id;
 
                 $existingEnemy = $currentEnemies->get($mdtEnemy->getUniqueKey());
                 if ($existingEnemy instanceof Enemy) {
@@ -509,6 +530,23 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                         $updatedFields['seasonal_type'] = $existingEnemy->seasonal_type;
                     }
 
+                    // Enemy forces checkpoints were cloned into the new mapping version before we got here, so the
+                    // predecessor's checkpoint id must be translated - copying it verbatim would attach this enemy to
+                    // the previous mapping version's checkpoint (#3702).
+                    if ($existingEnemy->enemy_forces_checkpoint_id !== null) {
+                        $newEnemyForcesCheckpointId = $enemyForcesCheckpointIdMapping[$existingEnemy->enemy_forces_checkpoint_id] ?? null;
+
+                        if ($newEnemyForcesCheckpointId === null) {
+                            $this->log->importEnemiesCannotRecoverEnemyForcesCheckpoint(
+                                $mdtEnemy->getUniqueKey(),
+                                $existingEnemy->enemy_forces_checkpoint_id,
+                            );
+                        } else {
+                            $mdtEnemy->enemy_forces_checkpoint_id        = $newEnemyForcesCheckpointId;
+                            $updatedFields['enemy_forces_checkpoint_id'] = $newEnemyForcesCheckpointId;
+                        }
+                    }
+
                     $this->log->importEnemiesRecoverPropertiesFromExistingEnemy($mdtEnemy->getUniqueKey(), $updatedFields);
                 } else {
                     $this->log->importEnemiesCannotRecoverPropertiesFromExistingEnemy($mdtEnemy->getUniqueKey());
@@ -524,11 +562,45 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                     $this->log->importEnemiesSaveNewEnemyException($exception);
                 }
             }
+
+            $this->deleteEmptyEnemyForcesCheckpoints($newMappingVersion);
         } finally {
             $this->log->importEnemiesEnd();
         }
 
         return $enemies;
+    }
+
+    /**
+     * An MDT mapping bump is exactly when the enemy set changes. A checkpoint whose members were all removed
+     * upstream - or which lost them because we could not match them to their predecessor - would otherwise
+     * survive as an empty checkpoint reporting zero enemy forces, which is not what the mapper drew (#3702).
+     */
+    private function deleteEmptyEnemyForcesCheckpoints(MappingVersion $newMappingVersion): void
+    {
+        /** @var Collection<int, EnemyForcesCheckpoint> $emptyEnemyForcesCheckpoints */
+        $emptyEnemyForcesCheckpoints = $newMappingVersion->enemyForcesCheckpoints()
+            ->whereDoesntHave('enemies')
+            ->get();
+
+        if ($emptyEnemyForcesCheckpoints->isEmpty()) {
+            return;
+        }
+
+        foreach ($emptyEnemyForcesCheckpoints as $emptyEnemyForcesCheckpoint) {
+            $this->log->importEnemiesDeleteEmptyEnemyForcesCheckpoint(
+                $emptyEnemyForcesCheckpoint->id,
+                $emptyEnemyForcesCheckpoint->name,
+            );
+        }
+
+        // A query builder delete, not an Eloquent one: SeederModel's `deleting` listener refuses the delete
+        // unless an admin is authenticated, and this import runs from the scheduler with nobody logged in.
+        // The EnemyForcesCheckpoint `deleted` hook it also skips only releases member enemies - and these
+        // checkpoints have none by definition.
+        EnemyForcesCheckpoint::query()
+            ->whereIn('id', $emptyEnemyForcesCheckpoints->pluck('id'))
+            ->delete();
     }
 
     /**

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -564,7 +564,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                 }
             }
 
-            $this->deleteEmptyEnemyForcesCheckpoints($newMappingVersion);
+            $this->deleteEmptyEnemyForcesCheckpoints($currentMappingVersion, $newMappingVersion, $enemyForcesCheckpointIdMapping);
         } finally {
             $this->log->importEnemiesEnd();
         }
@@ -576,9 +576,24 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
      * An MDT mapping bump is exactly when the enemy set changes. A checkpoint whose members were all removed
      * upstream - or which lost them because we could not match them to their predecessor - would otherwise
      * survive as an empty checkpoint reporting zero enemy forces, which is not what the mapper drew (#3702).
+     *
+     * A checkpoint that never had any members in the SOURCE mapping version did not lose anything by staying
+     * empty here - most notably a "bare mapping version" checkpoint (MappingVersionController@saveNew's "Add
+     * bare mapping version" action clones checkpoints without cloning any enemies), which is memberless by
+     * construction until the mapper re-assigns enemies to it by hand. Only a clone whose source counterpart
+     * genuinely had members - and lost them, or could not be matched to them - is pruned. Anything in the new
+     * mapping version that is not in $enemyForcesCheckpointIdMapping's value set is therefore deliberately
+     * left alone, even if it is currently empty.
+     *
+     * @param array<int, int> $enemyForcesCheckpointIdMapping Source checkpoint id => cloned checkpoint id, as
+     *                                                        built by MappingService when it cloned the
+     *                                                        previous mapping version's checkpoints.
      */
-    private function deleteEmptyEnemyForcesCheckpoints(MappingVersion $newMappingVersion): void
-    {
+    private function deleteEmptyEnemyForcesCheckpoints(
+        MappingVersion $currentMappingVersion,
+        MappingVersion $newMappingVersion,
+        array          $enemyForcesCheckpointIdMapping,
+    ): void {
         /** @var Collection<int, EnemyForcesCheckpoint> $emptyEnemyForcesCheckpoints */
         $emptyEnemyForcesCheckpoints = $newMappingVersion->enemyForcesCheckpoints()
             ->whereDoesntHave('enemies')
@@ -588,19 +603,41 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
             return;
         }
 
-        foreach ($emptyEnemyForcesCheckpoints as $emptyEnemyForcesCheckpoint) {
+        /** @var array<int, int> $sourceIdsWithMembers Source checkpoint ids that had at least one member */
+        $sourceIdsWithMembers = $currentMappingVersion->enemyForcesCheckpoints()
+            ->has('enemies')
+            ->pluck('id')
+            ->all();
+        // Clone ids whose SOURCE counterpart had members - only these may be pruned when still empty here.
+        $prunableCloneIds = array_intersect_key($enemyForcesCheckpointIdMapping, array_flip($sourceIdsWithMembers));
+
+        /** @var Collection<int, EnemyForcesCheckpoint> $enemyForcesCheckpointsToPrune */
+        $enemyForcesCheckpointsToPrune = $emptyEnemyForcesCheckpoints->whereIn('id', array_values($prunableCloneIds));
+
+        if ($enemyForcesCheckpointsToPrune->isEmpty()) {
+            return;
+        }
+
+        foreach ($enemyForcesCheckpointsToPrune as $emptyEnemyForcesCheckpoint) {
             $this->log->importEnemiesDeleteEmptyEnemyForcesCheckpoint(
                 $emptyEnemyForcesCheckpoint->id,
                 $emptyEnemyForcesCheckpoint->name,
             );
         }
+        // The per-checkpoint line above stays at warning, but the aggregate is worth paging on: after the fix
+        // above, this only fires when a checkpoint that DID have members in the source could not be carried
+        // over - which is exactly the silent whole-dungeon wipe this bug used to cause (#3702).
+        $this->log->importEnemiesPrunedEmptyEnemyForcesCheckpoints(
+            $newMappingVersion->dungeon_id,
+            $enemyForcesCheckpointsToPrune->count(),
+        );
 
         // A query builder delete, not an Eloquent one: SeederModel's `deleting` listener refuses the delete
         // unless an admin is authenticated, and this import runs from the scheduler with nobody logged in.
         // The EnemyForcesCheckpoint `deleted` hook it also skips only releases member enemies - and these
         // checkpoints have none by definition.
         EnemyForcesCheckpoint::query()
-            ->whereIn('id', $emptyEnemyForcesCheckpoints->pluck('id'))
+            ->whereIn('id', $enemyForcesCheckpointsToPrune->pluck('id'))
             ->delete();
 
         // laravel-model-caching only flushes on model events and truncate(), never on a builder delete, so the

--- a/app/Service/Mapping/MappingService.php
+++ b/app/Service/Mapping/MappingService.php
@@ -4,6 +4,7 @@ namespace App\Service\Mapping;
 
 use App\Models\Dungeon;
 use App\Models\DungeonFloorSwitchMarker;
+use App\Models\EnemyForcesCheckpoint;
 use App\Models\Floor\FloorUnion;
 use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
@@ -208,21 +209,9 @@ class MappingService implements MappingServiceInterface
             $mountableArea->cloneForNewMappingVersion($targetMappingVersion);
         }
 
-        // Enemy Forces Checkpoints are NOT copied here, and the two callers of this method are affected
-        // differently:
-        //
-        // 1. MappingVersionController@store ("Add bare mapping version") - deliberately enemy-less, so a
-        //    copied checkpoint would arrive without its members and report a meaningless number. Skipping
-        //    is correct there.
-        // 2. createNewMappingVersionFromMDTMapping() (above), run by MDTMappingImportService on every MDT
-        //    mapping-hash bump - NOT enemy-less. importEnemies() matches old to new enemies by
-        //    Enemy::getUniqueKey() and already carries teeming/faction/required/skippable/kill_priority
-        //    (plus floor_id/lat/lng on non-force imports) across. Membership could be preserved the same
-        //    way, but is not: every MDT bump therefore discards every checkpoint of every dungeon, and
-        //    mappers re-author them from scratch.
-        //
-        // Whether (2) is acceptable is a product decision, not a limitation of this method. It is tracked
-        // in #3702 together with what implementing the carry-over would take.
+        // Enemy Forces Checkpoints are cloned by copyEnemyForcesCheckpointsToMappingVersion() instead - the
+        // caller must invoke it, because only the caller knows how to re-link the membership of the enemies
+        // it clones or re-imports, and this method copies no enemies at all (#3702).
 
         // Floor Unions (and areas)
         foreach ($sourceMappingVersion->floorUnions as $floorUnion) {
@@ -255,5 +244,23 @@ class MappingService implements MappingServiceInterface
         ]);
 
         return $targetMappingVersion;
+    }
+
+    public function copyEnemyForcesCheckpointsToMappingVersion(
+        MappingVersion $sourceMappingVersion,
+        MappingVersion $targetMappingVersion,
+    ): array {
+        $enemyForcesCheckpointIdMapping = [];
+
+        foreach ($sourceMappingVersion->enemyForcesCheckpoints as $enemyForcesCheckpoint) {
+            /** @var EnemyForcesCheckpoint $newEnemyForcesCheckpoint */
+            $newEnemyForcesCheckpoint = $enemyForcesCheckpoint->cloneForNewMappingVersion($targetMappingVersion);
+
+            $enemyForcesCheckpointIdMapping[$enemyForcesCheckpoint->id] = $newEnemyForcesCheckpoint->id;
+        }
+
+        $targetMappingVersion->load('enemyForcesCheckpoints');
+
+        return $enemyForcesCheckpointIdMapping;
     }
 }

--- a/app/Service/Mapping/MappingServiceInterface.php
+++ b/app/Service/Mapping/MappingServiceInterface.php
@@ -34,9 +34,25 @@ interface MappingServiceInterface
 
     /**
      * Takes an existing mapping version's contents and applies it to another mapping version.
+     *
+     * Enemy forces checkpoints are NOT part of this: their members live in `enemies`, which this method does
+     * not copy either, so the caller has to be able to re-link membership itself. Clone them with
+     * copyEnemyForcesCheckpointsToMappingVersion() - every caller of this method should call that too (#3702).
      */
     public function copyMappingVersionContentsToDungeon(
         MappingVersion $sourceMappingVersion,
         MappingVersion $targetMappingVersion,
     ): MappingVersion;
+
+    /**
+     * Clones a mapping version's enemy forces checkpoints into another mapping version, without their members -
+     * enemies are cloned by another code path entirely, or (on an MDT mapping import) re-created from scratch.
+     *
+     * @return array<int, int> Source checkpoint id => cloned checkpoint id, so the caller can re-link the
+     *                         membership of the enemies it clones or imports afterwards.
+     */
+    public function copyEnemyForcesCheckpointsToMappingVersion(
+        MappingVersion $sourceMappingVersion,
+        MappingVersion $targetMappingVersion,
+    ): array;
 }

--- a/app/Service/Mapping/MappingServiceInterface.php
+++ b/app/Service/Mapping/MappingServiceInterface.php
@@ -37,7 +37,9 @@ interface MappingServiceInterface
      *
      * Enemy forces checkpoints are NOT part of this: their members live in `enemies`, which this method does
      * not copy either, so the caller has to be able to re-link membership itself. Clone them with
-     * copyEnemyForcesCheckpointsToMappingVersion() - every caller of this method should call that too (#3702).
+     * copyEnemyForcesCheckpointsToMappingVersion() when the target should inherit them - only the MDT
+     * re-import path does; a bare mapping version deliberately starts with none, since it has no enemies to
+     * assign them to (#3702).
      */
     public function copyMappingVersionContentsToDungeon(
         MappingVersion $sourceMappingVersion,

--- a/database/seeders/DungeonDataSeeder.php
+++ b/database/seeders/DungeonDataSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\DungeonFloorSwitchMarker;
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Enemy;
+use App\Models\EnemyForcesCheckpoint;
 use App\Models\EnemyPack;
 use App\Models\EnemyPatrol;
 use App\Models\Expansion;
@@ -536,6 +537,7 @@ class DungeonDataSeeder extends Seeder implements TableSeederInterface
             EnemyPatrol::class,
             DungeonFloorSwitchMarker::class,
             MountableArea::class,
+            EnemyForcesCheckpoint::class,
             FloorUnion::class,
             FloorUnionArea::class,
             DungeonSpeedrunRequiredNpc::class,

--- a/tests/Feature/App/Service/MDT/MDTMappingImportEnemyForcesCheckpointTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportEnemyForcesCheckpointTest.php
@@ -9,7 +9,9 @@ use App\Models\EnemyForcesCheckpoint;
 use App\Models\Mapping\MappingVersion;
 use App\Service\Mapping\MappingServiceInterface;
 use App\Service\MDT\MDTMappingImportServiceInterface;
+use Generator;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionMethod;
@@ -31,7 +33,8 @@ use Tests\TestCases\PublicTestCase;
 final class MDTMappingImportEnemyForcesCheckpointTest extends PublicTestCase
 {
     #[Test]
-    public function importEnemies_givenClonedEnemyForcesCheckpoints_relinksMatchedEnemiesAndDropsEmptiedCheckpoints(): void
+    #[DataProvider('importEnemies_givenClonedEnemyForcesCheckpoints_relinksMatchedEnemiesAndDropsEmptiedCheckpoints_dataProvider')]
+    public function importEnemies_givenClonedEnemyForcesCheckpoints_relinksMatchedEnemiesAndDropsEmptiedCheckpoints(bool $forceImport): void
     {
         // Arrange
         $mappingService = $this->app->make(MappingServiceInterface::class);
@@ -75,7 +78,7 @@ final class MDTMappingImportEnemyForcesCheckpointTest extends PublicTestCase
                 $mdtDungeon,
                 $dungeon,
                 $enemyForcesCheckpointIdMapping,
-                true,
+                $forceImport,
             );
 
             // Assert
@@ -119,6 +122,91 @@ final class MDTMappingImportEnemyForcesCheckpointTest extends PublicTestCase
             EnemyForcesCheckpoint::query()
                 ->whereIn('id', [$survivingEnemyForcesCheckpoint->id, $emptiedEnemyForcesCheckpoint->id])
                 ->delete();
+        }
+    }
+
+    /**
+     * `mdt:importmapping` defaults $forceImport to false, and every real mapping bump takes that path - only
+     * the force-import CLI flag skips it. Covering both here closes the gap: the checkpoint re-link logic runs
+     * unconditionally (outside the `if (!$forceImport)` block), but was only ever exercised with true.
+     *
+     * @return Generator<string, array{0: bool}>
+     */
+    public static function importEnemies_givenClonedEnemyForcesCheckpoints_relinksMatchedEnemiesAndDropsEmptiedCheckpoints_dataProvider(): Generator
+    {
+        yield 'force import' => [true];
+        yield 'non-force import (the default; every real mapping bump takes this path)' => [false];
+    }
+
+    /**
+     * #3702's bare-mapping-version case: "Add bare mapping version" clones a checkpoint with zero enemies (the
+     * mapper has not re-assigned members to it yet) and that checkpoint has to survive untouched until the
+     * NEXT MDT import - not be pruned as if it had genuinely lost its members. It never had any to lose.
+     */
+    #[Test]
+    public function importEnemies_givenCheckpointThatNeverHadMembersInSource_survivesEvenThoughItIsEmptyAfterImport(): void
+    {
+        // Arrange
+        $mappingService = $this->app->make(MappingServiceInterface::class);
+
+        $dungeon              = $this->getDungeonWithoutEnemyForcesCheckpoints();
+        $sourceMappingVersion = $dungeon->getCurrentMappingVersion();
+        $floor                = $dungeon->floors()->active()->firstOrFail();
+
+        // Never assigned any enemy - exactly what "Add bare mapping version" produces before the mapper
+        // re-assigns members.
+        $bareEnemyForcesCheckpoint = EnemyForcesCheckpoint::create([
+            'mapping_version_id' => $sourceMappingVersion->id,
+            'floor_id'           => $floor->id,
+            'name'               => 'Bare corridor',
+            'lat'                => 0,
+            'lng'                => 0,
+        ]);
+
+        $newMappingVersion = null;
+
+        try {
+            $newMappingVersion = $mappingService->copyMappingVersionToDungeon($sourceMappingVersion, $dungeon);
+            $mappingService->copyMappingVersionContentsToDungeon($sourceMappingVersion, $newMappingVersion);
+            $enemyForcesCheckpointIdMapping = $mappingService->copyEnemyForcesCheckpointsToMappingVersion(
+                $sourceMappingVersion,
+                $newMappingVersion,
+            );
+
+            // MDT genuinely changed (that is why importEnemies() runs at all) - no enemies are relevant to
+            // this test, only the bare checkpoint's fate is asserted.
+            $mdtDungeon = $this->createMockPublic(MDTDungeon::class);
+            $mdtDungeon->method('getClonesAsEnemies')->willReturn(collect());
+
+            // Act
+            $importEnemies = new ReflectionMethod(
+                $this->app->make(MDTMappingImportServiceInterface::class),
+                'importEnemies',
+            );
+            $importEnemies->invoke(
+                $this->app->make(MDTMappingImportServiceInterface::class),
+                $sourceMappingVersion,
+                $newMappingVersion,
+                $mdtDungeon,
+                $dungeon,
+                $enemyForcesCheckpointIdMapping,
+                false,
+            );
+
+            // Assert
+            $clonedBareEnemyForcesCheckpointId = $enemyForcesCheckpointIdMapping[$bareEnemyForcesCheckpoint->id];
+
+            $this->assertNotNull(
+                EnemyForcesCheckpoint::query()->find($clonedBareEnemyForcesCheckpointId),
+                'A checkpoint that never had members in the source mapping version must survive an MDT ' .
+                'import untouched, even though it is empty afterwards - it never lost anything.',
+            );
+        } finally {
+            if ($newMappingVersion !== null) {
+                $newMappingVersion->delete();
+            }
+
+            EnemyForcesCheckpoint::query()->where('id', $bareEnemyForcesCheckpoint->id)->delete();
         }
     }
 

--- a/tests/Feature/App/Service/MDT/MDTMappingImportEnemyForcesCheckpointTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportEnemyForcesCheckpointTest.php
@@ -36,7 +36,7 @@ final class MDTMappingImportEnemyForcesCheckpointTest extends PublicTestCase
         // Arrange
         $mappingService = $this->app->make(MappingServiceInterface::class);
 
-        $dungeon              = $this->getDungeonWithEnemies();
+        $dungeon              = $this->getDungeonWithoutEnemyForcesCheckpoints();
         $sourceMappingVersion = $dungeon->getCurrentMappingVersion();
 
         [$survivingEnemy, $removedEnemy] = $this->getTwoEnemiesWithDistinctUniqueKeys($sourceMappingVersion);
@@ -122,7 +122,12 @@ final class MDTMappingImportEnemyForcesCheckpointTest extends PublicTestCase
         }
     }
 
-    private function getDungeonWithEnemies(): Dungeon
+    /**
+     * A dungeon whose current mapping version holds no checkpoints of its own - the assertions below count
+     * the checkpoints in the new mapping version, so any hand-made ones in the seeded database would be
+     * cloned along and throw the count off.
+     */
+    private function getDungeonWithoutEnemyForcesCheckpoints(): Dungeon
     {
         /** @var Dungeon|null $dungeon */
         $dungeon = Dungeon::query()
@@ -131,23 +136,28 @@ final class MDTMappingImportEnemyForcesCheckpointTest extends PublicTestCase
             ->first(static function (Dungeon $dungeon): bool {
                 $mappingVersion = $dungeon->getCurrentMappingVersion();
 
-                return $mappingVersion !== null && $mappingVersion->enemies()->count() > 1;
+                return $mappingVersion !== null
+                    && !$mappingVersion->enemyForcesCheckpoints()->exists()
+                    && $mappingVersion->enemies()->whereNull('enemy_forces_checkpoint_id')->count() > 1;
             });
 
         if ($dungeon === null) {
-            $this->fail('No dungeon with enemies found for testing enemy forces checkpoints.');
+            $this->fail('No dungeon without enemy forces checkpoints found for testing enemy forces checkpoints.');
         }
 
         return $dungeon;
     }
 
     /**
+     * Enemies that are not already a member of some checkpoint, so the test can restore them to null.
+     *
      * @return array{0: Enemy, 1: Enemy}
      */
     private function getTwoEnemiesWithDistinctUniqueKeys(MappingVersion $mappingVersion): array
     {
         /** @var Collection<string, Enemy> $enemies */
         $enemies = $mappingVersion->enemies()
+            ->whereNull('enemy_forces_checkpoint_id')
             ->get()
             ->keyBy(static fn(Enemy $enemy) => $enemy->getUniqueKey())
             ->values();

--- a/tests/Feature/App/Service/MDT/MDTMappingImportEnemyForcesCheckpointTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportEnemyForcesCheckpointTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Tests\Feature\App\Service\MDT;
+
+use App\Logic\MDT\Data\MDTDungeon;
+use App\Models\Dungeon;
+use App\Models\Enemy;
+use App\Models\EnemyForcesCheckpoint;
+use App\Models\Mapping\MappingVersion;
+use App\Service\Mapping\MappingServiceInterface;
+use App\Service\MDT\MDTMappingImportServiceInterface;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * #3702: an MDT mapping bump used to discard every enemy forces checkpoint of every dungeon, because the
+ * enemies it re-creates never got their membership back. MappingService now clones the checkpoints and hands
+ * back a source id => clone id mapping, and importEnemies() translates each matched enemy's membership
+ * through it - a verbatim copy would attach the enemy to the previous mapping version's checkpoint.
+ *
+ * importEnemies() is exercised directly (with a stubbed MDTDungeon) rather than through
+ * importMappingVersionFromMDT(): a real import parses MDT's Lua and rewrites shared NPC/dungeon rows of the
+ * seeded test database, none of which this behaviour depends on.
+ */
+#[Group('MDT')]
+#[Group('MappingVersion')]
+#[Group('EnemyForcesCheckpoint')]
+final class MDTMappingImportEnemyForcesCheckpointTest extends PublicTestCase
+{
+    #[Test]
+    public function importEnemies_givenClonedEnemyForcesCheckpoints_relinksMatchedEnemiesAndDropsEmptiedCheckpoints(): void
+    {
+        // Arrange
+        $mappingService = $this->app->make(MappingServiceInterface::class);
+
+        $dungeon              = $this->getDungeonWithEnemies();
+        $sourceMappingVersion = $dungeon->getCurrentMappingVersion();
+
+        [$survivingEnemy, $removedEnemy] = $this->getTwoEnemiesWithDistinctUniqueKeys($sourceMappingVersion);
+
+        // The checkpoint of an enemy MDT still knows about, and the checkpoint of one it no longer does
+        $survivingEnemyForcesCheckpoint = $this->createEnemyForcesCheckpoint($sourceMappingVersion, $survivingEnemy, 'Kept corridor');
+        $emptiedEnemyForcesCheckpoint   = $this->createEnemyForcesCheckpoint($sourceMappingVersion, $removedEnemy, 'Emptied corridor');
+
+        $survivingEnemy->update(['enemy_forces_checkpoint_id' => $survivingEnemyForcesCheckpoint->id]);
+        $removedEnemy->update(['enemy_forces_checkpoint_id' => $emptiedEnemyForcesCheckpoint->id]);
+
+        $newMappingVersion = null;
+
+        try {
+            $newMappingVersion = $mappingService->copyMappingVersionToDungeon($sourceMappingVersion, $dungeon);
+            $mappingService->copyMappingVersionContentsToDungeon($sourceMappingVersion, $newMappingVersion);
+            $enemyForcesCheckpointIdMapping = $mappingService->copyEnemyForcesCheckpointsToMappingVersion(
+                $sourceMappingVersion,
+                $newMappingVersion,
+            );
+
+            // MDT only still reports the surviving enemy - the other one was removed upstream
+            $mdtDungeon = $this->createMockPublic(MDTDungeon::class);
+            $mdtDungeon->method('getClonesAsEnemies')
+                ->willReturn(collect([$this->createMdtCloneOf($survivingEnemy)]));
+
+            // Act
+            $importEnemies = new ReflectionMethod(
+                $this->app->make(MDTMappingImportServiceInterface::class),
+                'importEnemies',
+            );
+            $importEnemies->invoke(
+                $this->app->make(MDTMappingImportServiceInterface::class),
+                $sourceMappingVersion,
+                $newMappingVersion,
+                $mdtDungeon,
+                $dungeon,
+                $enemyForcesCheckpointIdMapping,
+                true,
+            );
+
+            // Assert
+            /** @var Collection<int, EnemyForcesCheckpoint> $newEnemyForcesCheckpoints */
+            $newEnemyForcesCheckpoints = EnemyForcesCheckpoint::query()
+                ->where('mapping_version_id', $newMappingVersion->id)
+                ->get();
+
+            $this->assertSame(
+                ['Kept corridor'],
+                $newEnemyForcesCheckpoints->pluck('name')->all(),
+                'The checkpoint whose members MDT no longer reports must be dropped, not carried over empty.',
+            );
+
+            /** @var EnemyForcesCheckpoint $clonedEnemyForcesCheckpoint */
+            $clonedEnemyForcesCheckpoint = $newEnemyForcesCheckpoints->first();
+
+            $this->assertSame(
+                $enemyForcesCheckpointIdMapping[$survivingEnemyForcesCheckpoint->id],
+                $clonedEnemyForcesCheckpoint->id,
+            );
+
+            /** @var Enemy|null $importedEnemy */
+            $importedEnemy = Enemy::query()->where('mapping_version_id', $newMappingVersion->id)->first();
+
+            $this->assertNotNull($importedEnemy, 'The MDT enemy should have been imported into the new mapping version.');
+            $this->assertSame($survivingEnemy->getUniqueKey(), $importedEnemy->getUniqueKey());
+            $this->assertSame(
+                $clonedEnemyForcesCheckpoint->id,
+                $importedEnemy->enemy_forces_checkpoint_id,
+                'The imported enemy must point at the CLONED checkpoint, not at the source mapping version\'s one.',
+            );
+        } finally {
+            if ($newMappingVersion !== null) {
+                $newMappingVersion->delete();
+            }
+
+            Enemy::query()
+                ->whereIn('enemy_forces_checkpoint_id', [$survivingEnemyForcesCheckpoint->id, $emptiedEnemyForcesCheckpoint->id])
+                ->update(['enemy_forces_checkpoint_id' => null]);
+            EnemyForcesCheckpoint::query()
+                ->whereIn('id', [$survivingEnemyForcesCheckpoint->id, $emptiedEnemyForcesCheckpoint->id])
+                ->delete();
+        }
+    }
+
+    private function getDungeonWithEnemies(): Dungeon
+    {
+        /** @var Dungeon|null $dungeon */
+        $dungeon = Dungeon::query()
+            ->whereNotNull('challenge_mode_id')
+            ->get()
+            ->first(static function (Dungeon $dungeon): bool {
+                $mappingVersion = $dungeon->getCurrentMappingVersion();
+
+                return $mappingVersion !== null && $mappingVersion->enemies()->count() > 1;
+            });
+
+        if ($dungeon === null) {
+            $this->fail('No dungeon with enemies found for testing enemy forces checkpoints.');
+        }
+
+        return $dungeon;
+    }
+
+    /**
+     * @return array{0: Enemy, 1: Enemy}
+     */
+    private function getTwoEnemiesWithDistinctUniqueKeys(MappingVersion $mappingVersion): array
+    {
+        /** @var Collection<string, Enemy> $enemies */
+        $enemies = $mappingVersion->enemies()
+            ->get()
+            ->keyBy(static fn(Enemy $enemy) => $enemy->getUniqueKey())
+            ->values();
+
+        if ($enemies->count() < 2) {
+            $this->fail('Need at least two enemies with distinct unique keys.');
+        }
+
+        return [$enemies[0], $enemies[1]];
+    }
+
+    /**
+     * Mimics what MDTDungeon::getClonesAsEnemies() hands importEnemies(): an unsaved Enemy carrying the MDT
+     * identity (npc + clone index) that Enemy::getUniqueKey() matches predecessors on.
+     */
+    private function createMdtCloneOf(Enemy $enemy): Enemy
+    {
+        return new Enemy([
+            'npc_id'     => $enemy->npc_id,
+            'mdt_npc_id' => $enemy->mdt_npc_id,
+            'mdt_id'     => $enemy->mdt_id,
+            'floor_id'   => $enemy->floor_id,
+            'lat'        => $enemy->lat,
+            'lng'        => $enemy->lng,
+            'faction'    => $enemy->faction,
+        ]);
+    }
+
+    private function createEnemyForcesCheckpoint(MappingVersion $mappingVersion, Enemy $enemy, string $name): EnemyForcesCheckpoint
+    {
+        return EnemyForcesCheckpoint::create([
+            'mapping_version_id' => $mappingVersion->id,
+            'floor_id'           => $enemy->floor_id,
+            'name'               => $name,
+            'lat'                => $enemy->lat,
+            'lng'                => $enemy->lng,
+        ]);
+    }
+}

--- a/tests/Feature/App/Service/Mapping/CopyMappingVersionContentsEnemyForcesCheckpointTest.php
+++ b/tests/Feature/App/Service/Mapping/CopyMappingVersionContentsEnemyForcesCheckpointTest.php
@@ -12,10 +12,11 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
 
 /**
- * #3702: "Add bare mapping version" and every MDT mapping import clone a mapping version through
- * MappingService, deliberately bypassing the MappingVersion::boot() clone hook. Neither path copies enemies,
- * so the checkpoints they clone arrive without members - the source id => clone id mapping
- * copyEnemyForcesCheckpointsToMappingVersion() returns is what lets a caller re-link membership itself.
+ * #3702: an MDT mapping import clones a mapping version through MappingService, deliberately bypassing the
+ * MappingVersion::boot() clone hook. That path copies no enemies, so the checkpoints it clones arrive without
+ * members - the source id => clone id mapping copyEnemyForcesCheckpointsToMappingVersion() returns is what
+ * lets the caller re-link membership itself. A bare mapping version has no enemies at all and deliberately
+ * does not call this method, so its checkpoints stay empty until enemies are assigned to them by hand.
  */
 #[Group('MappingVersion')]
 #[Group('EnemyForcesCheckpoint')]
@@ -34,7 +35,7 @@ final class CopyMappingVersionContentsEnemyForcesCheckpointTest extends PublicTe
         $targetMappingVersion = null;
 
         try {
-            // Act - exactly what MappingVersionController@saveNew does for "Add bare mapping version"
+            // Act - exactly what MDTMappingImportService does on a mapping re-import
             $targetMappingVersion = $mappingService->copyMappingVersionToDungeon($sourceMappingVersion, $dungeon);
             $mappingService->copyMappingVersionContentsToDungeon($sourceMappingVersion, $targetMappingVersion);
             $enemyForcesCheckpointIdMapping = $mappingService->copyEnemyForcesCheckpointsToMappingVersion(

--- a/tests/Feature/App/Service/Mapping/CopyMappingVersionContentsEnemyForcesCheckpointTest.php
+++ b/tests/Feature/App/Service/Mapping/CopyMappingVersionContentsEnemyForcesCheckpointTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\App\Service\Mapping;
+
+use App\Models\Dungeon;
+use App\Models\Enemy;
+use App\Models\EnemyForcesCheckpoint;
+use App\Models\Mapping\MappingVersion;
+use App\Service\Mapping\MappingServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * #3702: "Add bare mapping version" and every MDT mapping import clone a mapping version through
+ * MappingService, deliberately bypassing the MappingVersion::boot() clone hook. Neither path copies enemies,
+ * so the checkpoints they clone arrive without members - the source id => clone id mapping
+ * copyEnemyForcesCheckpointsToMappingVersion() returns is what lets a caller re-link membership itself.
+ */
+#[Group('MappingVersion')]
+#[Group('EnemyForcesCheckpoint')]
+final class CopyMappingVersionContentsEnemyForcesCheckpointTest extends PublicTestCase
+{
+    #[Test]
+    public function copyEnemyForcesCheckpointsToMappingVersion_givenSourceWithEnemyForcesCheckpoint_clonesItAndReturnsTheIdMapping(): void
+    {
+        // Arrange
+        $mappingService = $this->app->make(MappingServiceInterface::class);
+
+        $dungeon               = $this->getDungeonWithEnemies();
+        $sourceMappingVersion  = $dungeon->getCurrentMappingVersion();
+        $enemyForcesCheckpoint = $this->createEnemyForcesCheckpoint($sourceMappingVersion, 'Test corridor');
+
+        $targetMappingVersion = null;
+
+        try {
+            // Act - exactly what MappingVersionController@saveNew does for "Add bare mapping version"
+            $targetMappingVersion = $mappingService->copyMappingVersionToDungeon($sourceMappingVersion, $dungeon);
+            $mappingService->copyMappingVersionContentsToDungeon($sourceMappingVersion, $targetMappingVersion);
+            $enemyForcesCheckpointIdMapping = $mappingService->copyEnemyForcesCheckpointsToMappingVersion(
+                $sourceMappingVersion,
+                $targetMappingVersion,
+            );
+
+            // Assert
+            /** @var EnemyForcesCheckpoint|null $clonedEnemyForcesCheckpoint */
+            $clonedEnemyForcesCheckpoint = EnemyForcesCheckpoint::query()
+                ->where('mapping_version_id', $targetMappingVersion->id)
+                ->first();
+
+            $this->assertNotNull($clonedEnemyForcesCheckpoint, 'The checkpoint should have been cloned into the target mapping version.');
+            $this->assertSame('Test corridor', $clonedEnemyForcesCheckpoint->name);
+            $this->assertNotSame($enemyForcesCheckpoint->id, $clonedEnemyForcesCheckpoint->id, 'The clone must be a new row.');
+
+            $this->assertSame(
+                [$enemyForcesCheckpoint->id => $clonedEnemyForcesCheckpoint->id],
+                $enemyForcesCheckpointIdMapping,
+                'The caller must be handed the source id => clone id mapping so it can re-link membership itself.',
+            );
+
+            // This is why the mapping has to be returned at all: neither method copies enemies, so nothing in
+            // the target mapping version points at the cloned checkpoint yet.
+            $this->assertSame(
+                0,
+                Enemy::query()->where('mapping_version_id', $targetMappingVersion->id)->count(),
+                'copyMappingVersionContentsToDungeon() must not copy enemies.',
+            );
+        } finally {
+            if ($targetMappingVersion !== null) {
+                // An Eloquent delete: MappingVersion::boot()'s `deleting` cascade is what removes everything
+                // that was cloned into it. A query builder delete fires no model events, so all of it would
+                // leak into the shared test database on every run.
+                $targetMappingVersion->delete();
+            }
+
+            EnemyForcesCheckpoint::query()->where('id', $enemyForcesCheckpoint->id)->delete();
+        }
+    }
+
+    private function getDungeonWithEnemies(): Dungeon
+    {
+        /** @var Dungeon|null $dungeon */
+        $dungeon = Dungeon::query()
+            ->whereNotNull('challenge_mode_id')
+            ->get()
+            ->first(static function (Dungeon $dungeon): bool {
+                $mappingVersion = $dungeon->getCurrentMappingVersion();
+
+                return $mappingVersion !== null && $mappingVersion->enemies()->exists();
+            });
+
+        if ($dungeon === null) {
+            $this->fail('No dungeon with enemies found for testing enemy forces checkpoints.');
+        }
+
+        return $dungeon;
+    }
+
+    private function createEnemyForcesCheckpoint(MappingVersion $mappingVersion, string $name): EnemyForcesCheckpoint
+    {
+        /** @var Enemy $enemy */
+        $enemy = $mappingVersion->enemies()->firstOrFail();
+
+        return EnemyForcesCheckpoint::create([
+            'mapping_version_id' => $mappingVersion->id,
+            'floor_id'           => $enemy->floor_id,
+            'name'               => $name,
+            'lat'                => $enemy->lat,
+            'lng'                => $enemy->lng,
+        ]);
+    }
+}

--- a/tests/Feature/App/Service/Mapping/CopyMappingVersionContentsEnemyForcesCheckpointTest.php
+++ b/tests/Feature/App/Service/Mapping/CopyMappingVersionContentsEnemyForcesCheckpointTest.php
@@ -27,7 +27,7 @@ final class CopyMappingVersionContentsEnemyForcesCheckpointTest extends PublicTe
         // Arrange
         $mappingService = $this->app->make(MappingServiceInterface::class);
 
-        $dungeon               = $this->getDungeonWithEnemies();
+        $dungeon               = $this->getDungeonWithoutEnemyForcesCheckpoints();
         $sourceMappingVersion  = $dungeon->getCurrentMappingVersion();
         $enemyForcesCheckpoint = $this->createEnemyForcesCheckpoint($sourceMappingVersion, 'Test corridor');
 
@@ -77,7 +77,11 @@ final class CopyMappingVersionContentsEnemyForcesCheckpointTest extends PublicTe
         }
     }
 
-    private function getDungeonWithEnemies(): Dungeon
+    /**
+     * A dungeon whose current mapping version holds no checkpoints of its own - the assertions below expect a
+     * single clone, so any hand-made ones in the seeded database would be cloned along and throw that off.
+     */
+    private function getDungeonWithoutEnemyForcesCheckpoints(): Dungeon
     {
         /** @var Dungeon|null $dungeon */
         $dungeon = Dungeon::query()
@@ -86,11 +90,13 @@ final class CopyMappingVersionContentsEnemyForcesCheckpointTest extends PublicTe
             ->first(static function (Dungeon $dungeon): bool {
                 $mappingVersion = $dungeon->getCurrentMappingVersion();
 
-                return $mappingVersion !== null && $mappingVersion->enemies()->exists();
+                return $mappingVersion !== null
+                    && !$mappingVersion->enemyForcesCheckpoints()->exists()
+                    && $mappingVersion->enemies()->exists();
             });
 
         if ($dungeon === null) {
-            $this->fail('No dungeon with enemies found for testing enemy forces checkpoints.');
+            $this->fail('No dungeon without enemy forces checkpoints found for testing enemy forces checkpoints.');
         }
 
         return $dungeon;

--- a/tests/Unit/Database/Seeders/DungeonDataSeederTest.php
+++ b/tests/Unit/Database/Seeders/DungeonDataSeederTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit\Database\Seeders;
+
+use App\Models\Traits\SeederModel;
+use App\SeederHelpers\RelationImport\Mapping\RelationMapping;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\DungeonDataSeeder;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use Tests\TestCase;
+
+#[Group('DatabaseSeeder')]
+final class DungeonDataSeederTest extends TestCase
+{
+    #[Test]
+    public function getAffectedModelClasses_givenEveryRelationMapping_coversExactlyTheSeederModels(): void
+    {
+        // Arrange - DatabaseSeeder::getTempTableName() appends `_temp` for any model using the SeederModel
+        // trait, and flushModels() inserts into that name. The temp table itself is only ever created for a
+        // model listed in getAffectedModelClasses(), so a SeederModel that is registered as a RelationMapping
+        // but missing from that list makes the seeder insert into a table that does not exist - the moment its
+        // JSON file holds a single row. That is what happened to EnemyForcesCheckpoint (#3702).
+        //
+        // The reverse must hold too: a model that does NOT use SeederModel writes straight to its live table,
+        // so listing it would build a temp table that is renamed over the live data while it is still empty.
+        $relationMappingsProperty = new ReflectionProperty(DungeonDataSeeder::class, 'relationMapping');
+
+        /** @var array<int, RelationMapping> $relationMappings */
+        $relationMappings     = $relationMappingsProperty->getValue(new DungeonDataSeeder());
+        $affectedModelClasses = DungeonDataSeeder::getAffectedModelClasses();
+
+        $this->assertNotEmpty($relationMappings, 'DungeonDataSeeder should register relation mappings.');
+
+        foreach ($relationMappings as $relationMapping) {
+            $class = $relationMapping->getClass();
+
+            // Act
+            $usesTempTable = str_ends_with(DatabaseSeeder::getTempTableName($class), DatabaseSeeder::TEMP_TABLE_SUFFIX);
+
+            // Assert
+            $this->assertSame(
+                $usesTempTable,
+                in_array($class, $affectedModelClasses, true),
+                sprintf(
+                    '%s %s the %s trait, so it %s be listed in DungeonDataSeeder::getAffectedModelClasses().',
+                    $class,
+                    $usesTempTable ? 'uses' : 'does not use',
+                    class_basename(SeederModel::class),
+                    $usesTempTable ? 'must' : 'must not',
+                ),
+            );
+        }
+    }
+}


### PR DESCRIPTION
:robot: Implements #3702. **Targets `128-floor-enemy-forces-pill` (#3660), not `master`** — the `enemy_forces_checkpoints` table only exists there. Because this does not target the default branch it cannot auto-close the issue; #3702 closes once #3660 merges.

Per Wotuu's call on the issue: checkpoints get the same treatment floor unions already have — they carry over between MDT imports — and the `mapping:save` / seeder round trip is verified.

## The bug

`MappingVersion::boot()`'s `created` hook clones checkpoints *and* re-links their membership. But `MappingService::createNewMappingVersionFromMDTMapping()` deliberately bypasses that hook (`MappingVersion::insertGetId()`, "quietly, as to not trigger MappingVersion events") and clones through `copyMappingVersionContentsToDungeon()` instead — which cloned neither. Every MDT mapping-hash bump therefore discarded every checkpoint of every retail dungeon, with nothing logged.

## What changed

**`MappingService::copyEnemyForcesCheckpointsToMappingVersion()`** clones a mapping version's checkpoints and returns an `array<int, int>` of source id => clone id.

It sits *beside* `copyMappingVersionContentsToDungeon()` rather than inside it — a deliberate deviation from the floor-union shape, same behaviour, different location. Neither method copies enemies, so only the caller can re-link membership, and the id map has to reach `MDTMappingImportService`. Threading it through as a by-reference out-param was tried first and abandoned: the repo's `ErickSkrauch/align_multiline_parameters` fixer mangles `&$param` into `?array   &   $param`. Both existing callers now invoke it; the interface doc-block says every future caller should too.

**`MDTMappingImportService::importEnemies()`** translates each matched enemy's `enemy_forces_checkpoint_id` through that map. It could not simply join the `$fields` carry-over list next to `teeming`/`faction`/`required`/`skippable`/`kill_priority` — that list copies verbatim, which would attach the enemy to the *previous* mapping version's checkpoint. A predecessor whose checkpoint is not in the map logs a warning and lands unassigned rather than mis-assigned.

**Checkpoints left with no members** after the import — their enemies were removed upstream by MDT, or could not be matched — are deleted and logged, instead of surviving as an empty checkpoint reporting zero enemy forces. That is the failure mode the original "don't copy" comment was written to avoid. It is a query-builder delete on purpose: `SeederModel`'s `deleting` listener refuses the delete unless an admin is authenticated, which is never true for the scheduled import, and the model event it skips (`deleted`, which releases member enemies) is a no-op for a checkpoint with no members. The model cache is flushed by hand afterwards — laravel-model-caching's `CachedBuilder` only flushes on model events and `truncate()`, never on a builder delete.

## Intentional asymmetry between the two call sites

| | checkpoints cloned | memberless ones pruned |
|---|---|---|
| "Add bare mapping version" | yes | **no** |
| MDT mapping import | yes | **yes** |

A bare mapping version has no enemies at all, so *every* checkpoint it clones is memberless — pruning there would just reproduce today's "re-author from scratch". The mapper keeps their anchors and re-assigns members as they add enemies. On an MDT import the enemy set is repopulated, so a checkpoint that is still empty afterwards genuinely lost its members.

## Known and accepted: `--force` imports

`$forceImport = true` does not carry `floor_id` / `lat` / `lng` over. Membership can therefore survive onto an enemy that MDT moved to another floor, leaving the checkpoint anchored on a floor with no members. That degrades to a satellite pill (`EnemyForcesCheckpoint::_refreshSatellitePill()`), not a crash, and matches how the other carried-over fields already behave on a force import. Not addressed here.

## Seeder half (Wotuu's second ask)

`mapping:save` and `DungeonDataSeeder` were already wired for checkpoints in #3660 — but the seeder would have **died** the moment a single checkpoint existed: `EnemyForcesCheckpoint` uses the `SeederModel` trait, so `DatabaseSeeder::getTempTableName()` resolves it to `enemy_forces_checkpoints_temp`, and `flushModels()` inserts into that table — which was never created, because the model was missing from `DungeonDataSeeder::getAffectedModelClasses()`. Fixed, plus a new test that pins the invariant (`uses SeederModel` ⟺ `listed in getAffectedModelClasses()`) for every registered relation mapping — that is what would have caught this.

Export verified by round trip against the dev database: a checkpoint with a member enemy produced

```json
// legion/blackrookhold/1/enemy_forces_checkpoints.json
[{ "id": 58, "mapping_version_id": 294, "floor_id": 2, "name": "...", "lat": -54.89, "lng": 89.72 }]
// legion/blackrookhold/1/enemies.json
{ "id": 45996, ..., "enemy_forces_checkpoint_id": 58, ... }
```

The regenerated seeder JSON is **not** part of this MR (818 files of unrelated dev drift). The full `db:seed` back-import was deliberately not run either: 125 of 160 `dungeonroutes.json` had drifted to `[]` in this environment, so seeding would have wiped demo routes out of the shared dev database. The load path is covered by the invariant test above, the already-registered `EnemyForcesCheckpointRelationMapping`, and the fact that temp tables are `CREATE TABLE ... LIKE` (so they inherit the column automatically).

## Tests

- `CopyMappingVersionContentsEnemyForcesCheckpointTest` — the clone returns the id map, and `copyMappingVersionContentsToDungeon()` copies no enemies (which is *why* the map has to be returned).
- `MDTMappingImportEnemyForcesCheckpointTest` — `importEnemies()` with a stubbed `MDTDungeon`: the matched enemy lands on the *cloned* checkpoint, the emptied checkpoint is dropped. Driving the real `importMappingVersionFromMDT()` was rejected: it parses MDT's Lua and rewrites shared NPC/dungeon rows of the seeded test database, none of which this behaviour depends on.
- `DungeonDataSeederTest` — the seeder invariant described above.

Both feature tests deliberately pick a dungeon with no checkpoints of its own and borrow only enemies that are not already a member of one, so they neither clone nor clobber hand-made rows in the shared test database.

`composer run fix` and `composer run analyse` are clean; the four affected groups (`MappingVersion`, `EnemyForcesCheckpoint`, `MDT`, `DatabaseSeeder`) pass — 94 tests.

## MR-ready checklist

- **Visual verification**: N/A — no rendering change; the front-end checkpoint code is untouched.
- **Independent review**: not run by me (the review skill is not model-invocable in this session). Worth a `/code-review` pass before merge.
- **CI**: see checks below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
