### PR TITLE
#3705 Add feedback notification when (de-)favoriting a route from the header

### DIFF
--- a/lang/en_US/js.php
+++ b/lang/en_US/js.php
@@ -278,6 +278,8 @@ return [
     'sidebar_enemy_skippable_info_label'                                   => 'A skippable enemy is an enemy that can be skipped without using invisibility potions or Rogue Shroud. These enemies may be excluded from your routes once you mark enemies as overpulled during a live session.',
     'user_report_enemy_success'                                            => 'Report sent successfully. Thank you for helping improve Keystone.guru!',
     'dungeonroute_report_enemy_success'                                    => 'Report sent successfully. Thank you for helping improve Keystone.guru!',
+    'dungeonroute_favorite_added_success'                                  => 'Route added to your favorites',
+    'dungeonroute_favorite_removed_success'                                => 'Route removed from your favorites',
     'tag_delete_success'                                                   => 'Tag removed successfully',
     'tag_create_success'                                                   => 'Tag created successfully',
     'killzone_sidebar_kill_location_label'                                 => 'Kill location',

--- a/resources/assets/js/custom/inline/common/maps/map.favorite.test.js
+++ b/resources/assets/js/custom/inline/common/maps/map.favorite.test.js
@@ -1,0 +1,75 @@
+// #3705: (de-)favoriting a route via the header control gave no feedback. `_favorite()` now shows
+// a success notification once the AJAX call resolves.
+//
+// Follows the global-script recipe from models/killzone.test.js / enemyselection.tooltips.test.js:
+// stub the collaborators the class body touches at load time, then require the source. Only
+// `InlineCode` is needed at load time (for `extends`); `SettingsTabMap`/`SettingsTabPull` are only
+// `new`'d inside the constructor, so plain stub classes are enough - none of their real behaviour
+// is exercised here.
+
+globalThis.$ = globalThis.jQuery = require('jquery');
+
+const {InlineCode} = require('../../inlinecode');
+globalThis.InlineCode = InlineCode;
+
+globalThis.SettingsTabMap = class SettingsTabMap {
+};
+globalThis.SettingsTabPull = class SettingsTabPull {
+};
+
+const {CommonMapsMap} = require('./map');
+
+describe('CommonMapsMap._favorite', () => {
+    let ajaxSpy;
+    let publicKey;
+
+    beforeEach(() => {
+        publicKey = 'the_public_key';
+
+        globalThis.getState = vi.fn(() => ({
+            getMapContext: () => ({getPublicKey: () => publicKey}),
+        }));
+
+        globalThis.lang = {get: (key) => key};
+        globalThis.showSuccessNotification = vi.fn();
+
+        ajaxSpy = vi.spyOn($, 'ajax').mockImplementation((options) => {
+            options.success({});
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    /**
+     * @returns {CommonMapsMap}
+     */
+    function buildMap() {
+        return new CommonMapsMap('map', 'common/maps/map', {});
+    }
+
+    it('_favorite_givenTrue_postsAndShowsAddedNotification', () => {
+        // Act
+        buildMap()._favorite(true);
+
+        // Assert
+        expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'POST',
+            url: `/ajax/${publicKey}/favorite`,
+        }));
+        expect(showSuccessNotification).toHaveBeenCalledWith('js.dungeonroute_favorite_added_success');
+    });
+
+    it('_favorite_givenFalse_deletesAndShowsRemovedNotification', () => {
+        // Act
+        buildMap()._favorite(false);
+
+        // Assert
+        expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'DELETE',
+            url: `/ajax/${publicKey}/favorite`,
+        }));
+        expect(showSuccessNotification).toHaveBeenCalledWith('js.dungeonroute_favorite_removed_success');
+    });
+});

--- a/resources/assets/js/custom/inline/common/maps/map.js
+++ b/resources/assets/js/custom/inline/common/maps/map.js
@@ -738,7 +738,7 @@ class CommonMapsMap extends InlineCode {
             url: `/ajax/${getState().getMapContext().getPublicKey()}/favorite`,
             dataType: 'json',
             success: function (json) {
-
+                showSuccessNotification(lang.get(value ? 'js.dungeonroute_favorite_added_success' : 'js.dungeonroute_favorite_removed_success'));
             }
         });
     }
@@ -935,4 +935,12 @@ class CommonMapsMap extends InlineCode {
         getState().unregister('snackbar:add', this);
         getState().unregister('snackbar:remove', this);
     }
+}
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        CommonMapsMap,
+    };
 }


### PR DESCRIPTION
:robot: Closes #3705

## Summary
- The header favorite star (route view + edit pages, both rendered via `common.maps.controls.header` / `CommonMapsMap`) gave no feedback when clicked, so the user couldn't tell whether the favorite/unfavorite AJAX call succeeded.
- `_favorite()` in `map.js` now shows a success toast (reusing the existing `showSuccessNotification` used elsewhere, e.g. route/enemy reports) once the request resolves, with distinct added/removed copy.
- Errors are already handled by the global `defaultAjaxErrorFn` (`$.ajaxSetup`), so no separate error-path change was needed.
- New JS-consumed lang keys (`js.dungeonroute_favorite_added_success` / `_removed_success`) were added to `lang/en_US/js.php` — since these are baked into the release JS lang bundle, this change needs a full release, not a hotfix.

## Test plan
- [x] New Vitest unit test (`map.favorite.test.js`) covering both the add (POST) and remove (DELETE) paths and their respective toast text.
- [x] Full `npx vitest run` suite passes (302/302).
- [x] `composer run fix` / `composer run analyse` clean (no PHP logic changed, only a lang array).
- [x] Manually verified in headless Chrome on both the route **view** and **edit** pages: clicking the star toggles the favorite and shows the correct toast each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review notes
An independent fresh-context review found no blocking issues; approved. It flagged two pre-existing,
out-of-scope observations (not introduced by this change), left as follow-ups rather than fixed here:
- The `#favorite` hidden-input `change` handler (`map.js:455-456`) can never fire (hidden inputs don't
  match `:checked` / dispatch native `change`); the only live path is the `.favorite_star` click handler.
- The optimistic star-flip happens before the AJAX call resolves, with no request lock/debounce, so
  rapid double-toggling could race and/or leave the star visually out of sync on a failed request.
