### PR TITLE
#3703 Suppress enemy tooltips while assigning a raid marker

### DIFF
--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.js
@@ -285,22 +285,20 @@ class EnemyVisual extends Signalable {
                 refreshTooltips();
             },
             open: function () {
-                self.enemy.unbindTooltip();
                 self.signal('circlemenu:open');
 
+                // Tooltips would cover the menu that is drawn on top of the enemy - suppressed for as
+                // long as this state is active by RaidMarkerSelectMapState.disablesTooltips(), which
+                // covers every enemy on the map rather than just this one (#3703). Unbinding this
+                // enemy's Leaflet tooltip here instead is what #128 moved away from: every unbind
+                // leaks a raw DOM 'focus' listener Leaflet never removes.
                 self.map.setMapState(new RaidMarkerSelectMapState(self.map, self.enemy));
             },
             close: function () {
-                // Unassigned when opened
-                self.enemy.bindTooltip();
-
                 // Delete ourselves again
                 self._cleanupCircleMenu();
             },
             select: function (evt, index) {
-                // Unassigned when opened
-                self.enemy.bindTooltip();
-
                 // Assign the selected raid marker
                 self.enemy.assignRaidMarker($(index).data('name'));
 

--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.js
@@ -49,7 +49,12 @@ class EnemyVisual extends Signalable {
                 }
             } else {
                 // When an object is hidden, its layer is removed from the parent, effectively rendering its display nil.
-                // We don't need to do anything since if the visual is added again, we're going to re-create it anyways
+                // We don't need to do anything since if the visual is added again, we're going to re-create it anyways.
+                // The circle menu is the exception: it lives inside that same (now removed) DOM, so nobody can close
+                // it anymore, and RaidMarkerSelectMapState would stay active for the rest of the session - taking
+                // enemy popups, the raid marker shortcut and (since #3703) every enemy tooltip with it. A floor
+                // switch hides every enemy on the old floor, so this is not an edge case.
+                self._cleanupCircleMenu(false);
             }
         });
 
@@ -366,7 +371,11 @@ class EnemyVisual extends Signalable {
                 self.signal('circlemenu:close');
             };
 
-            if (fadeOut) {
+            // Only fade out when the menu's DOM is still there. If it is already gone - the enemy's
+            // layer was removed while the menu was open - delay()/queue() would be a no-op on the
+            // empty set, so cleanupFn (and with it setMapState(null)) would never run at all. The
+            // synchronous branch handles an undefined element fine: $(undefined) is an empty set.
+            if (fadeOut && $radial.length > 0) {
                 $radial.delay(500).queue(cleanupFn);
             } else {
                 cleanupFn.call($radial[0]);
@@ -761,4 +770,12 @@ class EnemyVisual extends Signalable {
             this._cleanupCircleMenu();
         }
     }
+}
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        EnemyVisual,
+    };
 }

--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.js
@@ -366,8 +366,15 @@ class EnemyVisual extends Signalable {
                 $(this).remove().dequeue();
                 self._circleMenu = null;
 
-                // Only stop the map state at this point
-                self.map.setMapState(null);
+                // Only stop the map state at this point - and only if it is still ours. The menu can
+                // only be opened while no map state is active, but the user can start one while it is
+                // open (hitting "New pull" leaves the radial on screen), and this cleanup then runs
+                // for reasons that have nothing to do with that state - the enemy being hidden by a
+                // floor switch, or its visual being rebuilt. Clearing unconditionally would silently
+                // cancel the selection the user is in the middle of.
+                if (self.map.getMapState() instanceof RaidMarkerSelectMapState) {
+                    self.map.setMapState(null);
+                }
                 self.signal('circlemenu:close');
             };
 

--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.test.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.test.js
@@ -1,0 +1,138 @@
+// EnemyVisual#_cleanupCircleMenu is the only place that ends RaidMarkerSelectMapState, so it must run
+// even when the circle menu's DOM is already gone (#3703).
+//
+// The radial lives inside the enemy's divIcon, which is destroyed the moment the enemy's layer is
+// removed from the map - a floor switch does that for every enemy on the old floor, and deliberately
+// keeps the map state. The fade-out path resolved the radial with a jQuery selector and called
+// .delay().queue() on it, which is a silent no-op on an empty set: the map state then stayed active
+// for the rest of the session, suppressing every enemy tooltip on the map.
+//
+// Follows the load-time-stub recipe from models/killzone.test.js. EnemyVisual's constructor pulls in
+// the whole EnemyVisualMain* hierarchy, so these tests call the method off the prototype with a fake
+// `this` instead of building one.
+
+global.Signalable = class Signalable {
+};
+
+const {EnemyVisual} = require('./enemyvisual');
+
+// Called at the top of _cleanupCircleMenu.
+global.removeStrayTooltips = () => {
+};
+
+/**
+ * A stand-in for a jQuery result set. `found` false models a selector that matched nothing, which is
+ * what happens once the enemy's icon (and with it the radial) has been removed from the DOM.
+ */
+function makeFakeSet(found) {
+    const set = {
+        length: found ? 1 : 0,
+        0: found ? {} : undefined,
+        delayCalls: 0,
+        queueCalls: 0,
+        delay() {
+            set.delayCalls++;
+
+            return set;
+        },
+        queue() {
+            set.queueCalls++;
+
+            return set;
+        },
+        find() {
+            return {
+                each() {
+                },
+            };
+        },
+        remove() {
+            return {
+                dequeue() {
+                },
+            };
+        },
+    };
+
+    return set;
+}
+
+/**
+ * Builds the collaborators _cleanupCircleMenu touches: an open circle menu, an enemy with an id, and a
+ * map recording what it was asked to set. `this` is created off the prototype so the method's
+ * `console.assert(this instanceof EnemyVisual)` holds.
+ */
+function makeCleanupContext(radialFound) {
+    const radial = makeFakeSet(radialFound);
+    const setMapStateCalls = [];
+    const signals = [];
+
+    const self = Object.create(EnemyVisual.prototype);
+    self._circleMenu = {};
+    self.enemy = {id: 42};
+    self.map = {setMapState: (mapState) => setMapStateCalls.push(mapState)};
+    self.signal = (name) => signals.push(name);
+
+    // The method resolves the radial through `$('#map_enemy_raid_marker_radial_<id>')` and then wraps
+    // raw elements with `$(element)` inside its cleanup callback.
+    global.$ = (selectorOrElement) => (typeof selectorOrElement === 'string' ? radial : makeFakeSet(true));
+
+    return {self, radial, setMapStateCalls, signals};
+}
+
+describe('EnemyVisual#_cleanupCircleMenu (#3703)', () => {
+    test('_cleanupCircleMenu_givenTheRadialDomIsGone_stillEndsTheMapState', () => {
+        // Arrange: the enemy was hidden (floor switch), taking the radial's DOM with it
+        const {self, radial, setMapStateCalls} = makeCleanupContext(false);
+
+        // Act: the default fade-out path
+        const result = EnemyVisual.prototype._cleanupCircleMenu.call(self, true);
+
+        // Assert: cleaned up synchronously instead of queueing onto an empty set
+        expect(result).toBe(true);
+        expect(radial.delayCalls).toBe(0);
+        expect(radial.queueCalls).toBe(0);
+        expect(setMapStateCalls).toEqual([null]);
+        expect(self._circleMenu).toBeNull();
+    });
+
+    test('_cleanupCircleMenu_givenTheRadialIsStillThere_fadesOutBeforeEndingTheMapState', () => {
+        // Arrange
+        const {self, radial, setMapStateCalls} = makeCleanupContext(true);
+
+        // Act
+        EnemyVisual.prototype._cleanupCircleMenu.call(self, true);
+
+        // Assert: the 500ms fade-out is preserved - the state ends only when the queue runs
+        expect(radial.delayCalls).toBe(1);
+        expect(radial.queueCalls).toBe(1);
+        expect(setMapStateCalls).toEqual([]);
+        expect(self._circleMenu).not.toBeNull();
+    });
+
+    test('_cleanupCircleMenu_givenNoFadeOut_endsTheMapStateImmediately', () => {
+        // Arrange
+        const {self, radial, setMapStateCalls, signals} = makeCleanupContext(true);
+
+        // Act: what buildVisual() and the hidden branch of the shown/hidden handler use
+        EnemyVisual.prototype._cleanupCircleMenu.call(self, false);
+
+        // Assert
+        expect(radial.delayCalls).toBe(0);
+        expect(setMapStateCalls).toEqual([null]);
+        expect(signals).toContain('circlemenu:close');
+    });
+
+    test('_cleanupCircleMenu_givenNoOpenCircleMenu_doesNothing', () => {
+        // Arrange
+        const {self, setMapStateCalls} = makeCleanupContext(false);
+        self._circleMenu = null;
+
+        // Act
+        const result = EnemyVisual.prototype._cleanupCircleMenu.call(self, false);
+
+        // Assert: hiding an enemy that never had a menu open must not clear an unrelated map state
+        expect(result).toBe(false);
+        expect(setMapStateCalls).toEqual([]);
+    });
+});

--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.test.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.test.js
@@ -7,12 +7,24 @@
 // .delay().queue() on it, which is a silent no-op on an empty set: the map state then stayed active
 // for the rest of the session, suppressing every enemy tooltip on the map.
 //
+// The mirror image matters just as much: the user can start another map state while the menu is open
+// ("New pull" leaves the radial on screen), so a cleanup triggered by the enemy being hidden must not
+// clear whatever state is running then.
+//
 // Follows the load-time-stub recipe from models/killzone.test.js. EnemyVisual's constructor pulls in
 // the whole EnemyVisualMain* hierarchy, so these tests call the method off the prototype with a fake
 // `this` instead of building one.
 
 global.Signalable = class Signalable {
 };
+
+// The real chain, so the `instanceof RaidMarkerSelectMapState` guard is the real one.
+const {MapState} = require('../mapstate/mapstate');
+global.MapState = MapState;
+const {MapObjectMapState} = require('../mapstate/mapobjectmapstate');
+global.MapObjectMapState = MapObjectMapState;
+const {RaidMarkerSelectMapState} = require('../mapstate/raidmarkerselectmapstate');
+global.RaidMarkerSelectMapState = RaidMarkerSelectMapState;
 
 const {EnemyVisual} = require('./enemyvisual');
 
@@ -58,11 +70,19 @@ function makeFakeSet(found) {
 }
 
 /**
+ * A map state instance without running its constructor, which asserts on collaborators (DungeonMap,
+ * MapObject) these tests have no use for. Only its type matters here.
+ */
+function makeMapState(cls) {
+    return Object.create(cls.prototype);
+}
+
+/**
  * Builds the collaborators _cleanupCircleMenu touches: an open circle menu, an enemy with an id, and a
  * map recording what it was asked to set. `this` is created off the prototype so the method's
  * `console.assert(this instanceof EnemyVisual)` holds.
  */
-function makeCleanupContext(radialFound) {
+function makeCleanupContext(radialFound, activeMapState = makeMapState(RaidMarkerSelectMapState)) {
     const radial = makeFakeSet(radialFound);
     const setMapStateCalls = [];
     const signals = [];
@@ -70,7 +90,10 @@ function makeCleanupContext(radialFound) {
     const self = Object.create(EnemyVisual.prototype);
     self._circleMenu = {};
     self.enemy = {id: 42};
-    self.map = {setMapState: (mapState) => setMapStateCalls.push(mapState)};
+    self.map = {
+        getMapState: () => activeMapState,
+        setMapState: (mapState) => setMapStateCalls.push(mapState),
+    };
     self.signal = (name) => signals.push(name);
 
     // The method resolves the radial through `$('#map_enemy_raid_marker_radial_<id>')` and then wraps
@@ -121,6 +144,20 @@ describe('EnemyVisual#_cleanupCircleMenu (#3703)', () => {
         expect(radial.delayCalls).toBe(0);
         expect(setMapStateCalls).toEqual([null]);
         expect(signals).toContain('circlemenu:close');
+    });
+
+    test('_cleanupCircleMenu_givenAnotherMapStateWasStarted_leavesItRunning', () => {
+        // Arrange: the menu stayed on screen while the user hit "New pull", then the enemy was hidden
+        const pullBuilding = makeMapState(MapObjectMapState);
+        const {self, setMapStateCalls, signals} = makeCleanupContext(false, pullBuilding);
+
+        // Act
+        EnemyVisual.prototype._cleanupCircleMenu.call(self, false);
+
+        // Assert: the menu is cleaned up, but the selection the user is in the middle of survives
+        expect(self._circleMenu).toBeNull();
+        expect(signals).toContain('circlemenu:close');
+        expect(setMapStateCalls).toEqual([]);
     });
 
     test('_cleanupCircleMenu_givenNoOpenCircleMenu_doesNothing', () => {

--- a/resources/assets/js/custom/mapstate/raidmarkerselectmapstate.js
+++ b/resources/assets/js/custom/mapstate/raidmarkerselectmapstate.js
@@ -6,4 +6,22 @@ class RaidMarkerSelectMapState extends MapObjectMapState {
     getName() {
         return 'RaidMarkerSelectMapState';
     }
+
+    /**
+     * The raid marker circle menu is drawn on top of the enemy it belongs to, so any enemy tooltip -
+     * the source enemy's own, or a neighbour's when the mouse passes over it on its way to a menu
+     * item - covers the menu the user is aiming at (#3703).
+     * @inheritDoc
+     */
+    disablesTooltips() {
+        return true;
+    }
+}
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        RaidMarkerSelectMapState,
+    };
 }

--- a/resources/assets/js/custom/mapstate/raidmarkerselectmapstate.tooltips.test.js
+++ b/resources/assets/js/custom/mapstate/raidmarkerselectmapstate.tooltips.test.js
@@ -40,7 +40,7 @@ describe('RaidMarkerSelectMapState tooltip suppression (#3703)', () => {
     it.each([
         ['MapState', MapState],
         ['MapObjectMapState', MapObjectMapState],
-    ])('disablesTooltips_givenBaseState_isNotOverriddenAndStaysOff (%s)', (name, cls) => {
+    ])('disablesTooltips_givenABaseState_returnsFalse (%s)', (name, cls) => {
         // Arrange / Act
         const result = disablesTooltips(cls);
 
@@ -48,6 +48,14 @@ describe('RaidMarkerSelectMapState tooltip suppression (#3703)', () => {
         // Pushing the suppression up the chain would silently take the tooltips away from every other
         // state too - pull-building in the route editor needs them (see enemyselection.tooltips.test.js).
         expect(result).toBe(false);
-        expect(Object.prototype.hasOwnProperty.call(MapObjectMapState.prototype, 'disablesTooltips')).toBe(false);
+    });
+
+    it('disablesTooltips_givenTheSharedMapObjectMapStateBase_isNotOverridden', () => {
+        // Arrange / Act
+        const ownProperty = Object.prototype.hasOwnProperty.call(MapObjectMapState.prototype, 'disablesTooltips');
+
+        // Assert
+        // Every EnemySelection extends this base too, so an override here would reach pull-building.
+        expect(ownProperty).toBe(false);
     });
 });

--- a/resources/assets/js/custom/mapstate/raidmarkerselectmapstate.tooltips.test.js
+++ b/resources/assets/js/custom/mapstate/raidmarkerselectmapstate.tooltips.test.js
@@ -1,0 +1,53 @@
+// The raid marker circle menu is drawn on top of the enemy it belongs to, so any enemy tooltip shown
+// while it is open covers the menu items the user is aiming at (#3703). Suppression is a property of
+// the map state (DungeonMap#setMapState() toggles the .map_enemy_tooltips_suppressed class off it),
+// so it is pinned here.
+//
+// Follows the load-time-stub recipe from enemyselection/enemyselection.tooltips.test.js: stub what the
+// class bodies touch when they are loaded, then require the sources.
+
+// Only `Signalable` is needed at load time (for `extends`); everything else lives inside constructors
+// and methods these tests never run.
+global.Signalable = class Signalable {
+};
+
+// The real inheritance chain, so an inherited default would be the real one.
+const {MapState} = require('./mapstate');
+global.MapState = MapState;
+const {MapObjectMapState} = require('./mapobjectmapstate');
+global.MapObjectMapState = MapObjectMapState;
+
+const {RaidMarkerSelectMapState} = require('./raidmarkerselectmapstate');
+
+/**
+ * Calls `disablesTooltips()` off the prototype, so no constructor (and none of its Leaflet/DOM wiring)
+ * has to run.
+ */
+function disablesTooltips(cls) {
+    return cls.prototype.disablesTooltips.call({});
+}
+
+describe('RaidMarkerSelectMapState tooltip suppression (#3703)', () => {
+    it('disablesTooltips_givenRaidMarkerSelectMapState_returnsTrue', () => {
+        // Arrange / Act
+        const result = disablesTooltips(RaidMarkerSelectMapState);
+
+        // Assert
+        expect(result).toBe(true);
+        expect(Object.prototype.hasOwnProperty.call(RaidMarkerSelectMapState.prototype, 'disablesTooltips')).toBe(true);
+    });
+
+    it.each([
+        ['MapState', MapState],
+        ['MapObjectMapState', MapObjectMapState],
+    ])('disablesTooltips_givenBaseState_isNotOverriddenAndStaysOff (%s)', (name, cls) => {
+        // Arrange / Act
+        const result = disablesTooltips(cls);
+
+        // Assert
+        // Pushing the suppression up the chain would silently take the tooltips away from every other
+        // state too - pull-building in the route editor needs them (see enemyselection.tooltips.test.js).
+        expect(result).toBe(false);
+        expect(Object.prototype.hasOwnProperty.call(MapObjectMapState.prototype, 'disablesTooltips')).toBe(false);
+    });
+});

--- a/resources/assets/js/custom/models/enemy.js
+++ b/resources/assets/js/custom/models/enemy.js
@@ -850,9 +850,12 @@ class Enemy extends VersionableMapObject {
                 text = template($.extend({}, getHandlebarsDefaultVariables(), visualData, {
                     name: lang.get(this.npc.name),
                     // Deliberately the state-independent variant, not canOpenRaidMarkerMenu(): the
-                    // text is cached below, so baking a map-state-dependent value into it would
-                    // strip the hint for good on any rebind that happens while a map state is
-                    // active - e.g. the save right after a marker was assigned (#3703).
+                    // text is cached below, so baking a map-state-dependent value into it strips the
+                    // hint for good on any rebind that happens while a map state is active - e.g. a
+                    // floor switch during a selection, which runs MapObjectGroup#setLayerToMapObject()
+                    // -> unbind -> rebind (#3703). The flipside is that the hint also renders during a
+                    // map state that keeps tooltips visible (pull-building), where shift+right-click
+                    // does nothing until the selection ends - that is the deliberate trade.
                     show_raid_marker_shortcut: this.supportsRaidMarkerMenu(),
                 }));
             } else {

--- a/resources/assets/js/custom/models/enemy.js
+++ b/resources/assets/js/custom/models/enemy.js
@@ -849,17 +849,21 @@ class Enemy extends VersionableMapObject {
 
                 text = template($.extend({}, getHandlebarsDefaultVariables(), visualData, {
                     name: lang.get(this.npc.name),
-                    show_raid_marker_shortcut: this.canOpenRaidMarkerMenu(),
+                    // Deliberately the state-independent variant, not canOpenRaidMarkerMenu(): the
+                    // text is cached below, so baking a map-state-dependent value into it would
+                    // strip the hint for good on any rebind that happens while a map state is
+                    // active - e.g. the save right after a marker was assigned (#3703).
+                    show_raid_marker_shortcut: this.supportsRaidMarkerMenu(),
                 }));
             } else {
                 text = lang.get('js.no_npc_found_label');
             }
 
             // Only rebind if the text has changed - or if nothing is bound right now (#3670).
-            // Anything that unbinds the tooltip without also resetting tooltipText (the circle menu
-            // in EnemyVisual, a layer swap in MapObjectGroup#setLayerToMapObject) would otherwise
-            // leave this enemy without a tooltip permanently: the recomputed text is identical, so
-            // the guard short-circuits and the rebind never happens.
+            // Anything that unbinds the tooltip without also resetting tooltipText (a layer swap in
+            // MapObjectGroup#setLayerToMapObject) would otherwise leave this enemy without a tooltip
+            // permanently: the recomputed text is identical, so the guard short-circuits and the
+            // rebind never happens.
             // Leaflet's getTooltip() is undefined before the first bind and null after unbindTooltip().
             if (this.tooltipText !== text || !this.layer.getTooltip()) {
                 this.tooltipText = text;
@@ -1098,15 +1102,25 @@ class Enemy extends VersionableMapObject {
     }
 
     /**
+     * Whether this enemy supports the raid marker circle menu at all. Independent of the current map
+     * state on purpose, unlike canOpenRaidMarkerMenu() - this is what the tooltip's shortcut hint is
+     * built from, and that text is cached.
+     * @returns {boolean}
+     */
+    supportsRaidMarkerMenu() {
+        console.assert(this instanceof Enemy, 'this is not an Enemy', this);
+
+        return this.map.options.edit && !(this instanceof AdminEnemy);
+    }
+
+    /**
      * Whether the raid marker circle menu may be opened for this enemy right now.
      * @returns {boolean}
      */
     canOpenRaidMarkerMenu() {
         console.assert(this instanceof Enemy, 'this is not an Enemy', this);
 
-        return this.map.options.edit &&
-            this.map.getMapState() === null &&
-            !(this instanceof AdminEnemy);
+        return this.supportsRaidMarkerMenu() && this.map.getMapState() === null;
     }
 
     isVisibleOnScreen() {

--- a/resources/assets/js/custom/models/enemy.test.js
+++ b/resources/assets/js/custom/models/enemy.test.js
@@ -6,10 +6,10 @@
 //
 // Enemy#bindTooltip() only rebinds when the rendered text changed. That guard
 // checked the text but not whether a tooltip was actually bound, so any code
-// path that unbinds without also resetting `tooltipText` (the raid marker circle
-// menu in EnemyVisual, a layer swap in MapObjectGroup#setLayerToMapObject) left
-// the enemy without a tooltip permanently - the recomputed text is identical, so
-// the guard short-circuited and nothing was ever rebound.
+// path that unbinds without also resetting `tooltipText` (a layer swap in
+// MapObjectGroup#setLayerToMapObject) left the enemy without a tooltip
+// permanently - the recomputed text is identical, so the guard short-circuited
+// and nothing was ever rebound.
 // ---------------------------------------------------------------------------
 
 // 1a. Leaflet: enemy.js builds div icons and draw handlers at load time.
@@ -81,11 +81,13 @@ global.VersionableMapObject = class VersionableMapObject {
     }
 };
 
-// 1d. Handlebars template + default variables used to render the tooltip body. The template simply
-// echoes the name so a test can change the rendered text by changing the npc.
+// 1d. Handlebars template + default variables used to render the tooltip body. The template echoes
+// the name so a test can change the rendered text by changing the npc, and renders the raid marker
+// shortcut hint the same way the real template does - conditionally on show_raid_marker_shortcut.
 global.Handlebars = {
     templates: {
-        enemy_tooltip_template: (data) => `<div>${data.name}</div>`,
+        enemy_tooltip_template: (data) =>
+            `<div>${data.name}</div>${data.show_raid_marker_shortcut ? '<div>shift+right-click</div>' : ''}`,
     },
 };
 global.getHandlebarsDefaultVariables = () => ({});
@@ -98,6 +100,10 @@ global.getState = () => ({
 });
 
 const {Enemy} = require('./enemy');
+
+// 1f. Only ever used through `instanceof` (raid markers are not available on the admin mapping page).
+global.AdminEnemy = class AdminEnemy extends Enemy {
+};
 
 /**
  * A fake Leaflet layer mirroring Leaflet's own tooltip semantics: getTooltip() is undefined before
@@ -148,7 +154,7 @@ function makeBoundEnemy(npcName = 'Murkbrine Shorerunner') {
 
 describe('Enemy#bindTooltip (#3670)', () => {
     test('bindTooltip_givenTooltipWasUnboundAndTextUnchanged_rebindsTheTooltip', () => {
-        // Arrange: the circle menu / a layer swap unbinds without resetting tooltipText
+        // Arrange: a layer swap unbinds without resetting tooltipText
         const {enemy, layer} = makeBoundEnemy();
         const textBefore = enemy.tooltipText;
         enemy.unbindTooltip();
@@ -348,5 +354,87 @@ describe('Enemy#_assignPopup during a map state', () => {
         // Assert
         expect(layer.getPopup()).not.toBeNull();
         expect(enemy.isPopupEnabled).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The tooltip's "shift + right-click to assign a raid marker" hint (#3703).
+//
+// bindTooltip() caches the rendered text and only rebinds when it changes, so anything baked into it
+// that depends on the current map state sticks. canOpenRaidMarkerMenu() is exactly that (it requires
+// no active map state), and assigning a raid marker rebinds the tooltip while
+// RaidMarkerSelectMapState is still active - which dropped the hint from the tooltip for good, until
+// something else happened to change the text.
+// ---------------------------------------------------------------------------
+
+/**
+ * An enemy on an editable map, i.e. the route editor where raid markers can be assigned.
+ */
+function makeRaidMarkerEnemy() {
+    const map = makeFakeEditMap();
+    // The popup surface is needed too: starting/stopping a map state runs setPopupEnabled().
+    const layer = makeFakePopupLayer();
+    const enemy = new Enemy(map, layer);
+    enemy.npc = {id: 1, name: 'Murkbrine Shorerunner'};
+    enemy.getVisualData = () => ({info: [], custom: []});
+
+    return {enemy, layer, map};
+}
+
+describe('Enemy raid marker shortcut hint (#3703)', () => {
+    test('supportsRaidMarkerMenu_givenAnActiveMapState_staysTrue', () => {
+        // Arrange
+        const {enemy, map} = makeRaidMarkerEnemy();
+        expect(enemy.supportsRaidMarkerMenu()).toBe(true);
+
+        // Act
+        map.setMapState(new global.MapState());
+
+        // Assert: the tooltip hint is built from this, so it must not follow the map state
+        expect(enemy.supportsRaidMarkerMenu()).toBe(true);
+    });
+
+    test('canOpenRaidMarkerMenu_givenAnActiveMapState_returnsFalse', () => {
+        // Arrange
+        const {enemy, map} = makeRaidMarkerEnemy();
+
+        // Act
+        map.setMapState(new global.MapState());
+
+        // Assert: opening a second circle menu on top of the current one stays blocked
+        expect(enemy.canOpenRaidMarkerMenu()).toBe(false);
+    });
+
+    test('bindTooltip_givenARebindWhileAMapStateIsActive_keepsTheShortcutHint', () => {
+        // Arrange: the tooltip as it renders before the raid marker menu is opened
+        const {enemy, layer, map} = makeRaidMarkerEnemy();
+        enemy.bindTooltip();
+        expect(layer.getTooltip().text).toContain('shift+right-click');
+
+        // Act: assigning a marker saves the enemy (setSynced -> bindTooltip) while
+        // RaidMarkerSelectMapState is still active
+        map.setMapState(new global.MapState());
+        enemy.npc = {id: 2, name: 'Deathwhisper Necrolyte'};
+        enemy.bindTooltip();
+        map.setMapState(null);
+
+        // Assert
+        expect(layer.getTooltip().text).toContain('shift+right-click');
+    });
+
+    test('supportsRaidMarkerMenu_givenANonEditableMap_returnsFalse', () => {
+        // Arrange
+        const enemy = new Enemy(makeFakeMap(), makeFakeLayer());
+
+        // Act / Assert: no hint when the route cannot be edited at all
+        expect(enemy.supportsRaidMarkerMenu()).toBe(false);
+    });
+
+    test('supportsRaidMarkerMenu_givenAnAdminEnemy_returnsFalse', () => {
+        // Arrange
+        const adminEnemy = new global.AdminEnemy(makeFakeEditMap(), makeFakePopupLayer());
+
+        // Act / Assert: raid markers do not exist on the admin mapping page
+        expect(adminEnemy.supportsRaidMarkerMenu()).toBe(false);
     });
 });

--- a/resources/assets/js/custom/models/enemy.test.js
+++ b/resources/assets/js/custom/models/enemy.test.js
@@ -362,9 +362,10 @@ describe('Enemy#_assignPopup during a map state', () => {
 //
 // bindTooltip() caches the rendered text and only rebinds when it changes, so anything baked into it
 // that depends on the current map state sticks. canOpenRaidMarkerMenu() is exactly that (it requires
-// no active map state), and assigning a raid marker rebinds the tooltip while
-// RaidMarkerSelectMapState is still active - which dropped the hint from the tooltip for good, until
-// something else happened to change the text.
+// no active map state), and plenty of rebinds happen while a map state is running: EnemyVisual used
+// to bindTooltip() straight from the circle menu's select callback, and MapObjectGroup#
+// setLayerToMapObject() unbinds + rebinds on every floor switch, which does not clear the map state.
+// Either dropped the hint from the tooltip for good, until something else happened to change the text.
 // ---------------------------------------------------------------------------
 
 /**
@@ -411,8 +412,8 @@ describe('Enemy raid marker shortcut hint (#3703)', () => {
         enemy.bindTooltip();
         expect(layer.getTooltip().text).toContain('shift+right-click');
 
-        // Act: assigning a marker saves the enemy (setSynced -> bindTooltip) while
-        // RaidMarkerSelectMapState is still active
+        // Act: something rebinds the tooltip while a map state is still active - a floor switch
+        // during a selection, or the circle menu's own select callback before #3703 removed it
         map.setMapState(new global.MapState());
         enemy.npc = {id: 2, name: 'Deathwhisper Necrolyte'};
         enemy.bindTooltip();


### PR DESCRIPTION
:robot: Closes #3703

## The bug

The raid marker circle menu is drawn on top of the enemy it belongs to, so any enemy tooltip shown
while it is open covers the items the user is aiming at. The clicked enemy's own tooltip was already
handled (`EnemyVisual` unbound its Leaflet tooltip when the menu opened), but a **neighbouring**
enemy's tooltip popped up as soon as the mouse passed over it on its way to a menu item.

So no, #128 did not already fix this — but it did introduce the mechanism this fix uses.

## The fix

`RaidMarkerSelectMapState` — the map state the circle menu already starts — now overrides
`disablesTooltips()`. `DungeonMap#setMapState()` toggles the `.map_enemy_tooltips_suppressed` class
off that, which suppresses *every* enemy tooltip on the map for as long as the menu is open.

That let the per-layer `unbindTooltip()`/`bindTooltip()` pair in `EnemyVisual` go — the exact
pattern #128 moved away from, since every Leaflet `unbindTooltip()` leaks a raw DOM `focus`
listener it never removes.

## Also fixed: the shortcut hint disappearing after an assignment

Reproducing the bug surfaced a second one in the same flow. `Enemy#bindTooltip()` caches the
rendered text and only rebinds when it changes, and the save that follows an assignment rebinds the
tooltip **while `RaidMarkerSelectMapState` is still active** — baking
`canOpenRaidMarkerMenu() === false` into the cached text. The result: after assigning a marker, that
enemy's tooltip permanently lost its *"Shift + right-click to assign a raid marker"* line.

The hint is now built from a new state-independent `supportsRaidMarkerMenu()` (edit mode, not an
admin enemy); `canOpenRaidMarkerMenu()` keeps the map-state check and still gates the context menu.

## Verification

Driven in real headless Chrome on a route in edit mode (Black Rook Hold), same enemy and same
neighbour on both sides.

| step | before | after |
| --- | --- | --- |
| hover the enemy | tooltip with hint | tooltip with hint |
| circle menu open, hover a neighbour | **neighbour tooltip covers the menu** | no tooltip |
| after assigning a marker, re-hover | **tooltip without the hint** | tooltip with hint |

Tests: `resources/assets/js/custom/mapstate/raidmarkerselectmapstate.tooltips.test.js` (new — pins
the override on this state and pins the bases as *not* overridden, so the suppression cannot be
pushed up the chain onto pull-building) and five cases added to `models/enemy.test.js` for the hint.
Full vitest suite green (308 tests); `composer run fix` / `analyse` clean.

## Review round (cold-context reviewer)

- **The circle menu could leave its map state active forever.** The radial lives inside the enemy's
  divIcon, so removing the enemy's layer takes the menu's DOM with it — and nothing cleaned up:
  the shown/hidden handler deliberately did nothing on hide, and `_cleanupCircleMenu()`'s fade-out
  path calls `.delay().queue()` on the selector result, a silent no-op once that DOM is gone. A
  floor switch hides every enemy on the old floor *and* deliberately keeps the map state, so this
  was easy to hit. Pre-existing (enemy popups and the raid marker shortcut stayed dead until
  reload), but this MR would have widened it to "no enemy tooltip anywhere". Fixed in both places
  and confirmed in headless Chrome — before: `RaidMarkerSelectMapState` still active after a floor
  switch, 0 tooltips visible; after: state `null`, tooltips back.
- Corrected a comment that blamed a save after assigning a marker — `assignRaidMarker()` never
  saves. The rebinds that actually baked the hint out are `EnemyVisual`'s own `bindTooltip()` call
  (removed here) and `MapObjectGroup#setLayerToMapObject()` on a floor switch during a map state.
- Split an `it.each` assertion that ignored its parameter into its own test.
- New `enemyvisuals/enemyvisual.test.js` covers the cleanup guard (verified red without the fix).

Reviewer notes explicitly checked and found clean: `circlemenu:open`/`circlemenu:close` have no
consumers; `buildVisual()`'s cleanup/re-init path is strictly better than before; `AdminEnemy`
overrides `bindTooltip()` wholesale so the admin page is unaffected; the `AdminEnemy` global is in
the same concatenated bundle so `instanceof` cannot ReferenceError.

Known and deliberate: the hint now also renders during pull-building, where shift+right-click does
nothing until the selection ends. It did before too (cached from the initial bind) — it is just
consistent now instead of accidental. Out of scope for #3703 as filed: non-enemy tooltips (map
icons, killzone index) can still overlap the menu, and touch users see a hint they cannot act on.
