### PR TITLE
#3723 Keep the raid marker circle menu from discarding or stranding a map state

### DIFF
--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.circlemenu.test.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.circlemenu.test.js
@@ -1,0 +1,186 @@
+// Integration coverage for the raid marker circle menu's teardown (#3723).
+//
+// Unlike enemyvisual.test.js - which hands _cleanupCircleMenu() a hand-rolled jQuery stand-in to pin
+// its guards - these tests run the real jQuery and the real zikes-circlemenu plugin against a real
+// (jsdom) DOM, because both findings are about the plugin's own jQuery state on a *detached* node:
+//
+//  - The plugin registers its `open` hook as a jQuery handler on the radial <ul> itself and fires it
+//    from a setTimeout. Leaflet destroys the enemy's icon with a native removeChild, which does not
+//    run jQuery's cleanData, so that handler survives the enemy being hidden. Cleaning up by
+//    re-querying `#map_enemy_raid_marker_radial_<id>` matched nothing at that point, leaving the
+//    pending timer free to start a RaidMarkerSelectMapState for a menu that no longer exists - with
+//    _circleMenu already nulled, nothing could ever end that state again.
+//  - The same re-query made the Bootstrap Tooltip disposal loop a no-op, leaking one instance per
+//    tooltip item (Bootstrap keys them by element in a plain Map, not a WeakMap).
+//
+// Both are fixed by cleaning up off `self._circleMenu`, which *is* the plugin's own jQuery set and
+// stays valid on a detached node.
+
+// Real jQuery, replacing the minimal stub from test/setup.js. Must be global before the plugin is
+// required: it is an IIFE closing over the `jQuery` global.
+global.$ = global.jQuery = require('jquery');
+require('zikes-circlemenu');
+
+const fs = require('fs');
+const path = require('path');
+const HandlebarsRuntime = require('handlebars');
+
+global.Signalable = class Signalable {
+};
+
+// Stand-ins for the collaborators the map state constructors assert on. The fakes below are built as
+// instances of these so those assertions hold.
+global.DungeonMap = class DungeonMap {
+};
+global.MapObject = class MapObject {
+};
+
+// The real chain, so the map state the menu starts is the real one.
+const {MapState} = require('../mapstate/mapstate');
+global.MapState = MapState;
+const {MapObjectMapState} = require('../mapstate/mapobjectmapstate');
+global.MapObjectMapState = MapObjectMapState;
+const {RaidMarkerSelectMapState} = require('../mapstate/raidmarkerselectmapstate');
+global.RaidMarkerSelectMapState = RaidMarkerSelectMapState;
+
+const {EnemyVisual} = require('./enemyvisual');
+
+// The real radial markup, so the tooltip items the disposal loop looks for are the real ones.
+const radialTemplate = HandlebarsRuntime.compile(
+    fs.readFileSync(
+        path.join(__dirname, '../../handlebars/map_enemy_raid_marker_template.handlebars'),
+        'utf8'
+    )
+);
+
+global.Handlebars = {templates: {map_enemy_raid_marker_template: radialTemplate}};
+global.getHandlebarsDefaultVariables = () => ({});
+global.refreshTooltips = () => {
+};
+global.removeStrayTooltips = () => {
+};
+global.c = {map: {enemy: {calculateMargin: () => 4}}};
+
+/**
+ * Opens the circle menu on an enemy the way _openRaidMarkerMenu() does, without advancing any timers:
+ * the plugin fires its `open` hook - and with it setMapState() - from a setTimeout, so on return the
+ * menu is on screen but no map state has started yet.
+ */
+function makeOpenCircleMenu() {
+    const id = 42;
+
+    document.body.innerHTML = `<div id="map_enemy_visual_${id}"><div class="enemy_icon"></div></div>`;
+    const container = document.getElementById(`map_enemy_visual_${id}`);
+
+    const setMapStateCalls = [];
+    const signals = [];
+    let mapState = null;
+
+    const self = Object.create(EnemyVisual.prototype);
+    self._circleMenu = null;
+    self.enemy = Object.assign(new global.MapObject(), {id: id});
+    self.mainVisual = {getSize: () => ({iconSize: [30, 30]})};
+    self.map = Object.assign(new global.DungeonMap(), {
+        getMapState: () => mapState,
+        setMapState: (newMapState) => {
+            mapState = newMapState;
+            setMapStateCalls.push(newMapState);
+        },
+    });
+    self.signal = (name) => signals.push(name);
+
+    EnemyVisual.prototype._initCircleMenu.call(self);
+
+    // Bootstrap Tooltip instances as they exist once refreshTooltips() has run over the new radial.
+    const tooltips = [...container.querySelectorAll('[data-bs-toggle="tooltip"]')].map((element) => {
+        const tooltip = {element: element, disposed: false, dispose: () => (tooltip.disposed = true)};
+
+        return tooltip;
+    });
+    global.bootstrap = {
+        Tooltip: {
+            getInstance: (element) => tooltips.find((tooltip) => tooltip.element === element) ?? null,
+        },
+    };
+
+    return {self, container, setMapStateCalls, signals, tooltips};
+}
+
+describe('EnemyVisual circle menu teardown (#3723)', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    test('_initCircleMenu_givenTheMenuFinishesOpening_startsTheRaidMarkerSelectMapState', () => {
+        // Arrange
+        const {setMapStateCalls} = makeOpenCircleMenu();
+        expect(setMapStateCalls).toEqual([]);
+
+        // Act: the plugin's open hook only fires a macrotask later
+        vi.advanceTimersByTime(1000);
+
+        // Assert
+        expect(setMapStateCalls).toHaveLength(1);
+        expect(setMapStateCalls[0]).toBeInstanceOf(RaidMarkerSelectMapState);
+    });
+
+    test('_cleanupCircleMenu_givenTheEnemyIsHiddenBeforeTheMenuOpens_neverStartsTheMapState', () => {
+        // Arrange: the menu is on screen, its open hook still pending
+        const {self, container, setMapStateCalls, signals} = makeOpenCircleMenu();
+
+        // Act: Leaflet drops the enemy's icon (a floor switch, a faction toggle, an Echo update). A
+        // native removal, so the radial keeps its jQuery handlers - then the hidden branch cleans up.
+        container.remove();
+        EnemyVisual.prototype._cleanupCircleMenu.call(self, false);
+        vi.advanceTimersByTime(1000);
+
+        // Assert: no map state was ever started, so nothing is left that only the (now gone) menu
+        // could have ended
+        expect(setMapStateCalls).toEqual([]);
+        expect(self._circleMenu).toBeNull();
+        expect(signals).toContain('circlemenu:close');
+        expect(signals).not.toContain('circlemenu:open');
+    });
+
+    test('_cleanupCircleMenu_givenTheRadialWasAlreadyDetached_stillDisposesItsTooltips', () => {
+        // Arrange
+        const {self, container, tooltips} = makeOpenCircleMenu();
+        expect(tooltips).not.toHaveLength(0);
+
+        // Act
+        container.remove();
+        EnemyVisual.prototype._cleanupCircleMenu.call(self, false);
+        vi.advanceTimersByTime(1000);
+
+        // Assert: Bootstrap keys instances by element in a plain Map, so skipping this leaks one per
+        // tooltip item for the rest of the session
+        expect(tooltips.every((tooltip) => tooltip.disposed)).toBe(true);
+    });
+
+    test('_cleanupCircleMenu_givenTheRadialIsStillOnScreen_fadesOutBeforeRemovingIt', () => {
+        // Arrange: the menu opened normally, so a map state of ours is running
+        const {self, setMapStateCalls} = makeOpenCircleMenu();
+        vi.advanceTimersByTime(1000);
+        expect(document.getElementById('map_enemy_raid_marker_radial_42')).not.toBeNull();
+
+        // Act: the default fade-out path, as used by the close and select callbacks
+        EnemyVisual.prototype._cleanupCircleMenu.call(self, true);
+
+        // Assert: still on screen while it animates out
+        expect(document.getElementById('map_enemy_raid_marker_radial_42')).not.toBeNull();
+        expect(setMapStateCalls).toHaveLength(1);
+
+        // Act: once the 500ms fade-out has run
+        vi.advanceTimersByTime(1000);
+
+        // Assert
+        expect(document.getElementById('map_enemy_raid_marker_radial_42')).toBeNull();
+        expect(self._circleMenu).toBeNull();
+        expect(setMapStateCalls[1]).toBeNull();
+    });
+});

--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.js
@@ -333,7 +333,6 @@ class EnemyVisual extends Signalable {
         console.assert(this instanceof EnemyVisual, 'this is not an EnemyVisual!', this);
 
         let self = this;
-        let id = self.enemy.id;
 
         let shouldCleanUp = self._circleMenu !== null;
 
@@ -348,22 +347,29 @@ class EnemyVisual extends Signalable {
             // destroyed a moment later anyway, in cleanupFn below.
             removeStrayTooltips();
 
-            // Delay it by 500 ms so the animations have a chance to complete
-            let $radial = $(`#map_enemy_raid_marker_radial_${id}`);
+            // The radial as the circle menu plugin itself holds it, rather than re-resolving it by id:
+            // this set stays valid once the enemy's icon has been removed from the DOM (Leaflet does
+            // that natively, so the detached radial keeps all of its jQuery data), where the selector
+            // matches nothing at all. Everything below depends on that (#3723).
+            let $radial = self._circleMenu;
             let cleanupFn = function () {
                 // Dispose each item's Bootstrap Tooltip instance before removing its DOM. Safe to do
                 // here (unlike eagerly above): by now any in-flight show/hide transition has settled,
                 // either immediately (fadeOut = false) or after the 500ms delay below. Bootstrap keys
                 // instances by element in a plain Map (not a WeakMap), so skipping this would leak a
                 // Tooltip instance for every marker assigned/cleared this session.
-                $(this).find('[data-bs-toggle="tooltip"]').each(function () {
+                $radial.find('[data-bs-toggle="tooltip"]').each(function () {
                     let tooltip = bootstrap.Tooltip.getInstance(this);
                     if (tooltip !== null) {
                         tooltip.dispose();
                     }
                 });
 
-                $(this).remove().dequeue();
+                // Also detaches the plugin's own jQuery handlers - among them the one that fires its
+                // `open` hook, which is triggered from a setTimeout and would otherwise still start a
+                // RaidMarkerSelectMapState for a menu that no longer exists. With _circleMenu already
+                // nulled here, nothing could ever end that state again (#3723).
+                $radial.remove().dequeue();
                 self._circleMenu = null;
 
                 // Only stop the map state at this point - and only if it is still ours. The menu can
@@ -378,18 +384,41 @@ class EnemyVisual extends Signalable {
                 self.signal('circlemenu:close');
             };
 
-            // Only fade out when the menu's DOM is still there. If it is already gone - the enemy's
-            // layer was removed while the menu was open - delay()/queue() would be a no-op on the
-            // empty set, so cleanupFn (and with it setMapState(null)) would never run at all. The
-            // synchronous branch handles an undefined element fine: $(undefined) is an empty set.
-            if (fadeOut && $radial.length > 0) {
+            // Only fade out when the menu's DOM is still on screen. If it is already detached - the
+            // enemy's layer was removed while the menu was open - there is nothing left to animate,
+            // and delay()/queue() would sit on a queue nothing ever drains, so cleanupFn (and with it
+            // setMapState(null)) would never run at all. This has to be an explicit
+            // document.contains() check: the set is the plugin's own, so its length stays 1 whether
+            // the radial is attached or not.
+            if (fadeOut && $radial.length > 0 && document.contains($radial[0])) {
                 $radial.delay(500).queue(cleanupFn);
             } else {
-                cleanupFn.call($radial[0]);
+                cleanupFn();
             }
         }
 
         return shouldCleanUp;
+    }
+
+    /**
+     * Whether a circle menu that was open before the visual got rebuilt may be put back on screen.
+     * Re-opening it starts a RaidMarkerSelectMapState (see the plugin's open callback), so it must
+     * honour the same invariant _cleanupCircleMenu() does at the other end: the user can start a map
+     * state while the menu is open, and several of those rebuild the enemy visual (EditMapState,
+     * DeleteMapState and the EnemySelection states). Re-opening regardless would replace the state
+     * the user just started with a raid marker selection they did not ask for (#3723).
+     *
+     * Not to be confused with Enemy#canOpenRaidMarkerMenu(), which gates opening a menu from scratch
+     * and requires no map state at all.
+     * @returns {boolean}
+     * @private
+     */
+    _canReopenCircleMenu() {
+        console.assert(this instanceof EnemyVisual, 'this is not an EnemyVisual!', this);
+
+        let mapState = this.map.getMapState();
+
+        return mapState === null || mapState instanceof RaidMarkerSelectMapState;
     }
 
     /**
@@ -502,7 +531,7 @@ class EnemyVisual extends Signalable {
             // $(`#map_enemy_visual_${data.id}`).mouseout(this._mouseOut.bind(this));
 
             // Restore circle menu
-            if (hadCircleMenu && reopenCircleMenu) {
+            if (hadCircleMenu && reopenCircleMenu && this._canReopenCircleMenu()) {
                 this._initCircleMenu(false);
             }
 

--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.js
@@ -386,10 +386,15 @@ class EnemyVisual extends Signalable {
 
             // Only fade out when the menu's DOM is still on screen. If it is already detached - the
             // enemy's layer was removed while the menu was open - there is nothing left to animate,
-            // and delay()/queue() would sit on a queue nothing ever drains, so cleanupFn (and with it
-            // setMapState(null)) would never run at all. This has to be an explicit
-            // document.contains() check: the set is the plugin's own, so its length stays 1 whether
-            // the radial is attached or not.
+            // and sitting out the 500ms would leave the plugin's own handlers on that detached radial
+            // for the duration: its `open` hook may still be pending, in which case it starts a
+            // RaidMarkerSelectMapState for a menu nobody can see, suppressing every enemy tooltip
+            // until this cleanup gets around to ending it again.
+            //
+            // Whether the radial is attached has to be asked explicitly: the set is the plugin's own,
+            // so its length stays 1 either way (a selector would have gone empty, which is what the
+            // length check used to stand in for), and jQuery's queue drains on a detached element
+            // just fine - it is keyed off the element's data, not off the document tree.
             if (fadeOut && $radial.length > 0 && document.contains($radial[0])) {
                 $radial.delay(500).queue(cleanupFn);
             } else {
@@ -436,6 +441,10 @@ class EnemyVisual extends Signalable {
 
         if (enemyMapObjectGroup.isMapObjectVisible(this.enemy)) {
 
+            // Runs synchronously, and ends RaidMarkerSelectMapState if that was ours. That does not
+            // re-enter this method only because RaidMarkerSelectMapState#shouldRebuildEnemyVisuals()
+            // is false (inherited from MapState) - the map:mapstatechanged handler above would
+            // otherwise rebuild us from inside this call.
             let hadCircleMenu = this._cleanupCircleMenu(false);
 
             let template = Handlebars.templates['map_enemy_visual_template'];
@@ -802,9 +811,11 @@ class EnemyVisual extends Signalable {
         this.enemy.unregister('enemy:set_raid_marker', this);
         this.map.unregister('map:mapstatechanged', this);
 
-        if (this._circleMenu !== null) {
-            this._cleanupCircleMenu();
-        }
+        // Without fading out: this visual is being discarded, so there is nobody left to animate for,
+        // and a queued cleanup would end up calling setMapState(null) half a second later on behalf
+        // of an object that no longer exists. _cleanupCircleMenu() no-ops on its own when no menu is
+        // open, so it needs no guard here.
+        this._cleanupCircleMenu(false);
     }
 }
 

--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.test.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.test.js
@@ -129,14 +129,16 @@ describe('EnemyVisual#_cleanupCircleMenu (#3703)', () => {
         document.body.innerHTML = '';
     });
 
-    test('_cleanupCircleMenu_givenTheRadialDomIsGone_stillEndsTheMapState', () => {
+    test('_cleanupCircleMenu_givenTheRadialDomIsGone_cleansUpWithoutWaitingForTheFadeOut', () => {
         // Arrange: the enemy was hidden (floor switch), taking the radial's DOM with it
         const {self, radial, setMapStateCalls} = makeCleanupContext(false);
 
         // Act: the default fade-out path
         const result = EnemyVisual.prototype._cleanupCircleMenu.call(self, true);
 
-        // Assert: cleaned up synchronously instead of queueing onto a queue nothing drains
+        // Assert: nothing to animate, so the plugin's handlers come off and the map state ends now
+        // rather than 500ms from now - long enough for a pending open hook to start a state for a
+        // menu nobody can see
         expect(result).toBe(true);
         expect(radial.delayCalls).toBe(0);
         expect(radial.queueCalls).toBe(0);
@@ -214,6 +216,10 @@ global.EditMapState = class EditMapState extends MapState {
 global.DeleteMapState = class DeleteMapState extends MapState {
 };
 global.EnemySelection = class EnemySelection extends MapState {
+    // Matching the real base, which the states that draw a selection border override.
+    drawsEnemyEditBorder() {
+        return false;
+    }
 };
 global.Handlebars = {templates: {map_enemy_visual_template: () => '<div></div>'}};
 global.c = {map: {enemy: {calculateMargin: () => 4}}};
@@ -302,6 +308,18 @@ describe('EnemyVisual#buildVisual circle menu re-open (#3723)', () => {
         expect(initCalls).toEqual([]);
     });
 
+    test('buildVisual_givenAPullIsBeingBuilt_leavesTheCircleMenuClosed', () => {
+        // Arrange: the most common way to get here - attaching the enemy to a killzone rebuilds its
+        // visual while the enemy selection for that pull is still running
+        const {self, initCalls} = makeBuildVisualContext(new global.EnemySelection());
+
+        // Act
+        EnemyVisual.prototype.buildVisual.call(self);
+
+        // Assert
+        expect(initCalls).toEqual([]);
+    });
+
     test('buildVisual_givenReopeningIsNotWanted_leavesTheCircleMenuClosed', () => {
         // Arrange: assigning a raid marker rebuilds the visual with the menu deliberately closed
         const {self, initCalls} = makeBuildVisualContext(null);
@@ -345,10 +363,14 @@ function makeVisual() {
                 handlers[event] = callback;
             }
         },
+        unregister: () => {
+        },
     });
     const map = Object.assign(new global.DungeonMap(), {
         getMapState: () => null,
         register: () => {
+        },
+        unregister: () => {
         },
     });
 
@@ -361,7 +383,7 @@ function makeVisual() {
 }
 
 describe('EnemyVisual shown/hidden handling (#3723)', () => {
-    test('hidden_givenAnEnemyIsHidden_cleansUpTheCircleMenuWithoutFadingOut', () => {
+    test('constructor_givenTheEnemyIsHidden_cleansUpTheCircleMenuWithoutFadingOut', () => {
         // Arrange
         const {visual, handlers} = makeVisual();
         const cleanupCalls = [];
@@ -375,7 +397,7 @@ describe('EnemyVisual shown/hidden handling (#3723)', () => {
         expect(cleanupCalls).toEqual([false]);
     });
 
-    test('shown_givenAnEnemyIsShownWithoutAVisual_buildsItInsteadOfCleaningUp', () => {
+    test('constructor_givenTheEnemyIsShownWithoutAVisual_buildsItInsteadOfCleaningUp', () => {
         // Arrange
         const {visual, handlers} = makeVisual();
         const cleanupCalls = [];
@@ -389,5 +411,19 @@ describe('EnemyVisual shown/hidden handling (#3723)', () => {
         // Assert
         expect(buildCalls).toBe(1);
         expect(cleanupCalls).toEqual([]);
+    });
+
+    test('cleanup_givenAnOpenCircleMenu_cleansItUpWithoutFadingOut', () => {
+        // Arrange
+        const {visual} = makeVisual();
+        const cleanupCalls = [];
+        visual._cleanupCircleMenu = (fadeOut) => cleanupCalls.push(fadeOut);
+
+        // Act: the visual is being discarded (a layer swap, the map being torn down)
+        visual.cleanup();
+
+        // Assert: a queued cleanup would call setMapState(null) 500ms later on behalf of a visual
+        // that no longer exists - and it has already unregistered from map:mapstatechanged by then
+        expect(cleanupCalls).toEqual([false]);
     });
 });

--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.test.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.test.js
@@ -9,16 +9,34 @@
 //
 // The mirror image matters just as much: the user can start another map state while the menu is open
 // ("New pull" leaves the radial on screen), so a cleanup triggered by the enemy being hidden must not
-// clear whatever state is running then.
+// clear whatever state is running then - and neither must the re-open that follows a rebuild (#3723).
 //
-// Follows the load-time-stub recipe from models/killzone.test.js. EnemyVisual's constructor pulls in
-// the whole EnemyVisualMain* hierarchy, so these tests call the method off the prototype with a fake
-// `this` instead of building one.
+// Follows the load-time-stub recipe from models/killzone.test.js. Most tests here call the method off
+// the prototype with a fake `this`, since EnemyVisual's constructor pulls in the whole
+// EnemyVisualMain* hierarchy; the ones covering what that constructor wires up stub setVisualType()
+// instead, which is the only part of it that needs that hierarchy.
+//
+// What the circle menu plugin's own jQuery state does on a detached radial - the reason cleaning up
+// off `_circleMenu` rather than off a selector matters at all - is covered against real jQuery and
+// the real plugin in enemyvisual.circlemenu.test.js.
 
 global.Signalable = class Signalable {
 };
 
-// The real chain, so the `instanceof RaidMarkerSelectMapState` guard is the real one.
+// Collaborators the constructor asserts on. The fakes below are instances of these, so the assertions
+// hold and the console stays quiet.
+global.DungeonMap = class DungeonMap {
+};
+global.Enemy = class Enemy {
+};
+global.L = {
+    Layer: class Layer {
+    },
+    divIcon: class divIcon {
+    },
+};
+
+// The real chain, so the `instanceof RaidMarkerSelectMapState` guards are the real ones.
 const {MapState} = require('../mapstate/mapstate');
 global.MapState = MapState;
 const {MapObjectMapState} = require('../mapstate/mapobjectmapstate');
@@ -33,13 +51,19 @@ global.removeStrayTooltips = () => {
 };
 
 /**
- * A stand-in for a jQuery result set. `found` false models a selector that matched nothing, which is
- * what happens once the enemy's icon (and with it the radial) has been removed from the DOM.
+ * A stand-in for the jQuery set the circle menu plugin hands back. It always holds exactly one
+ * element - the plugin's set does not shrink when the enemy's icon is removed from the DOM - so
+ * whether that element is still attached is what decides the fade-out.
  */
-function makeFakeSet(found) {
+function makeFakeSet(attached) {
+    const element = document.createElement('ul');
+    if (attached) {
+        document.body.appendChild(element);
+    }
+
     const set = {
-        length: found ? 1 : 0,
-        0: found ? {} : undefined,
+        length: 1,
+        0: element,
         delayCalls: 0,
         queueCalls: 0,
         delay() {
@@ -59,10 +83,11 @@ function makeFakeSet(found) {
             };
         },
         remove() {
-            return {
-                dequeue() {
-                },
-            };
+            element.remove();
+
+            return set;
+        },
+        dequeue() {
         },
     };
 
@@ -82,13 +107,13 @@ function makeMapState(cls) {
  * map recording what it was asked to set. `this` is created off the prototype so the method's
  * `console.assert(this instanceof EnemyVisual)` holds.
  */
-function makeCleanupContext(radialFound, activeMapState = makeMapState(RaidMarkerSelectMapState)) {
-    const radial = makeFakeSet(radialFound);
+function makeCleanupContext(radialAttached, activeMapState = makeMapState(RaidMarkerSelectMapState)) {
+    const radial = makeFakeSet(radialAttached);
     const setMapStateCalls = [];
     const signals = [];
 
     const self = Object.create(EnemyVisual.prototype);
-    self._circleMenu = {};
+    self._circleMenu = radial;
     self.enemy = {id: 42};
     self.map = {
         getMapState: () => activeMapState,
@@ -96,14 +121,14 @@ function makeCleanupContext(radialFound, activeMapState = makeMapState(RaidMarke
     };
     self.signal = (name) => signals.push(name);
 
-    // The method resolves the radial through `$('#map_enemy_raid_marker_radial_<id>')` and then wraps
-    // raw elements with `$(element)` inside its cleanup callback.
-    global.$ = (selectorOrElement) => (typeof selectorOrElement === 'string' ? radial : makeFakeSet(true));
-
     return {self, radial, setMapStateCalls, signals};
 }
 
 describe('EnemyVisual#_cleanupCircleMenu (#3703)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
     test('_cleanupCircleMenu_givenTheRadialDomIsGone_stillEndsTheMapState', () => {
         // Arrange: the enemy was hidden (floor switch), taking the radial's DOM with it
         const {self, radial, setMapStateCalls} = makeCleanupContext(false);
@@ -111,7 +136,7 @@ describe('EnemyVisual#_cleanupCircleMenu (#3703)', () => {
         // Act: the default fade-out path
         const result = EnemyVisual.prototype._cleanupCircleMenu.call(self, true);
 
-        // Assert: cleaned up synchronously instead of queueing onto an empty set
+        // Assert: cleaned up synchronously instead of queueing onto a queue nothing drains
         expect(result).toBe(true);
         expect(radial.delayCalls).toBe(0);
         expect(radial.queueCalls).toBe(0);
@@ -171,5 +196,198 @@ describe('EnemyVisual#_cleanupCircleMenu (#3703)', () => {
         // Assert: hiding an enemy that never had a menu open must not clear an unrelated map state
         expect(result).toBe(false);
         expect(setMapStateCalls).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Rebuilding the visual re-opens a circle menu that was open, and re-opening it starts a
+// RaidMarkerSelectMapState. Several of the map states that trigger that rebuild in the first place
+// (EditMapState, DeleteMapState, the EnemySelection states) would therefore be replaced by a raid
+// marker selection the user never asked for (#3723).
+// ---------------------------------------------------------------------------
+
+global.MAP_OBJECT_GROUP_ENEMY = 'enemy';
+global.KillZone = class KillZone {
+};
+global.EditMapState = class EditMapState extends MapState {
+};
+global.DeleteMapState = class DeleteMapState extends MapState {
+};
+global.EnemySelection = class EnemySelection extends MapState {
+};
+global.Handlebars = {templates: {map_enemy_visual_template: () => '<div></div>'}};
+global.c = {map: {enemy: {calculateMargin: () => 4}}};
+global.getState = () => ({
+    getEnemyDisplayType: () => 'enemy_forces',
+    getMapZoomLevel: () => 1,
+    getUnkilledEnemyOpacity: () => 50,
+    getUnkilledImportantEnemyOpacity: () => 100,
+});
+
+// buildVisual() merges its template data with $.extend.
+global.$ = Object.assign(() => makeFakeSet(true), {
+    extend: (target, ...sources) => Object.assign(target, ...sources),
+});
+
+/**
+ * An EnemyVisual whose circle menu was open when the rebuild started. Everything buildVisual() does
+ * beyond deciding whether to put that menu back - resolving jQuery selectors, sizing the icon,
+ * creating modifiers - is stubbed out on the instance.
+ */
+function makeBuildVisualContext(activeMapState) {
+    const initCalls = [];
+
+    const self = Object.create(EnemyVisual.prototype);
+    self._highlighted = false;
+    self._modifiers = [];
+    self.enemy = {
+        id: 42,
+        is_mdt: false,
+        getKillZone: () => null,
+        getOverpulledKillZoneId: () => null,
+        isObsolete: () => false,
+        isImportant: () => false,
+        isDeletable: () => false,
+        isSelectable: () => false,
+        isEditable: () => false,
+    };
+    self.layer = {
+        setIcon: () => {
+        },
+    };
+    self.mainVisual = {
+        _getTemplateData: () => ({}),
+        getSize: () => ({iconSize: [30, 30]}),
+    };
+    self.map = {
+        getMapState: () => activeMapState,
+        mapObjectGroupManager: {getByName: () => ({isMapObjectVisible: () => true})},
+    };
+    self.signal = () => {
+    };
+
+    // The menu was open: report it as cleaned up, then record whether it is put back.
+    self._cleanupCircleMenu = () => true;
+    self._initCircleMenu = (fadeIn) => initCalls.push(fadeIn);
+    self._createModifiers = () => [];
+    self.refreshJQuerySelectors = () => {
+    };
+    self.refreshSize = () => {
+    };
+
+    return {self, initCalls};
+}
+
+describe('EnemyVisual#buildVisual circle menu re-open (#3723)', () => {
+    test('buildVisual_givenNoMapState_reopensTheCircleMenu', () => {
+        // Arrange: the rebuild came from something that leaves no map state behind (a killzone
+        // attach, an enemy being marked obsolete)
+        const {self, initCalls} = makeBuildVisualContext(null);
+
+        // Act
+        EnemyVisual.prototype.buildVisual.call(self);
+
+        // Assert: back on screen, without fading in a second time
+        expect(initCalls).toEqual([false]);
+    });
+
+    test('buildVisual_givenTheUserStartedAnotherMapState_leavesTheCircleMenuClosed', () => {
+        // Arrange: the menu was open when the user hit "Edit", which rebuilds every enemy visual
+        const {self, initCalls} = makeBuildVisualContext(new global.EditMapState());
+
+        // Act
+        EnemyVisual.prototype.buildVisual.call(self);
+
+        // Assert: re-opening would have replaced EditMapState with a RaidMarkerSelectMapState
+        expect(initCalls).toEqual([]);
+    });
+
+    test('buildVisual_givenReopeningIsNotWanted_leavesTheCircleMenuClosed', () => {
+        // Arrange: assigning a raid marker rebuilds the visual with the menu deliberately closed
+        const {self, initCalls} = makeBuildVisualContext(null);
+
+        // Act
+        EnemyVisual.prototype.buildVisual.call(self, false);
+
+        // Assert
+        expect(initCalls).toEqual([]);
+    });
+
+    test('_canReopenCircleMenu_givenOurOwnMapState_returnsTrue', () => {
+        // Arrange: a cleanup that ran while the menu's own state was active leaves it in place, so
+        // the re-open has to accept it too
+        const self = Object.create(EnemyVisual.prototype);
+        self.map = {getMapState: () => makeMapState(RaidMarkerSelectMapState)};
+
+        // Act & Assert
+        expect(EnemyVisual.prototype._canReopenCircleMenu.call(self)).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The hidden branch of the shown/hidden handler is what makes the cleanup happen on a floor switch at
+// all. It is wired up in the constructor, so covering it means running that constructor (#3723).
+// ---------------------------------------------------------------------------
+
+/**
+ * A real EnemyVisual, with setVisualType() - the one part of the constructor that needs the whole
+ * EnemyVisualMain* hierarchy - stubbed out. Also returns the callbacks it registered on the enemy.
+ */
+function makeVisual() {
+    const handlers = {};
+
+    const enemy = Object.assign(new global.Enemy(), {
+        id: 42,
+        shouldBeVisible: () => true,
+        isVisible: () => false,
+        register: (events, context, callback) => {
+            for (const event of [].concat(events)) {
+                handlers[event] = callback;
+            }
+        },
+    });
+    const map = Object.assign(new global.DungeonMap(), {
+        getMapState: () => null,
+        register: () => {
+        },
+    });
+
+    vi.spyOn(EnemyVisual.prototype, 'setVisualType').mockImplementation(() => {
+    });
+
+    const visual = new EnemyVisual(map, enemy, new global.L.Layer());
+
+    return {visual, handlers};
+}
+
+describe('EnemyVisual shown/hidden handling (#3723)', () => {
+    test('hidden_givenAnEnemyIsHidden_cleansUpTheCircleMenuWithoutFadingOut', () => {
+        // Arrange
+        const {visual, handlers} = makeVisual();
+        const cleanupCalls = [];
+        visual._cleanupCircleMenu = (fadeOut) => cleanupCalls.push(fadeOut);
+
+        // Act: a floor switch hides every enemy on the old floor, destroying the radial's DOM
+        handlers.hidden({data: {visible: false}});
+
+        // Assert: nothing is left to animate out, and the cleanup must not be skipped - it is the
+        // only thing that can end a RaidMarkerSelectMapState
+        expect(cleanupCalls).toEqual([false]);
+    });
+
+    test('shown_givenAnEnemyIsShownWithoutAVisual_buildsItInsteadOfCleaningUp', () => {
+        // Arrange
+        const {visual, handlers} = makeVisual();
+        const cleanupCalls = [];
+        let buildCalls = 0;
+        visual._cleanupCircleMenu = (fadeOut) => cleanupCalls.push(fadeOut);
+        visual.buildVisual = () => buildCalls++;
+
+        // Act
+        handlers.shown({data: {visible: true}});
+
+        // Assert
+        expect(buildCalls).toBe(1);
+        expect(cleanupCalls).toEqual([]);
     });
 });


### PR DESCRIPTION
:robot: Closes #3723

Follow-up to #3703 / #3719: the three findings a cold review raised after that MR had already merged.

### 1. `buildVisual()` re-opened the menu over a map state it did not start

`_cleanupCircleMenu()` only ends `RaidMarkerSelectMapState` if that is still the active state, so a
selection the user started while the menu was open survives the cleanup. The re-open path did not
honour the same invariant: every map state whose `shouldRebuildEnemyVisuals()` is `true`
(`EditMapState`, `DeleteMapState`, `MDTEnemySelection`, `EnemyPatrolEnemySelection`,
`EnemyForcesCheckpointEnemySelection`) rebuilds the visual, and the re-init then replaced the state
the user had just started with a `RaidMarkerSelectMapState`.

Guarded with a new `_canReopenCircleMenu()` — `null` or a `RaidMarkerSelectMapState` only. Named to
keep it apart from `Enemy#canOpenRaidMarkerMenu()`, which gates opening a menu from scratch and
requires no map state at all.

### 2. Hiding the enemy inside the same tick the menu opens stranded the map state

`zikes-circlemenu` fires its `open` hook — which calls `setMapState(new RaidMarkerSelectMapState(...))`
— from a `setTimeout`, and registers that hook as a jQuery handler on the radial `<ul>` itself. If the
enemy was hidden inside that window (a floor switch, a faction/teeming toggle, an Echo update), the
cleanup re-queried `#map_enemy_raid_marker_radial_<id>` and matched nothing: Leaflet removes the icon
with a native `removeChild`, which never runs jQuery's `cleanData`, so the handler survived on the
detached node. The pending timer then started a map state for a menu that no longer existed, with
`_circleMenu` already nulled — `_cleanupCircleMenu()` early-returns forever after that, and
`canOpenRaidMarkerMenu()` blocks opening another one. Enemy popups, the raid marker shortcut and every
enemy tooltip stayed dead for the rest of the session.

Cleanup now runs off `self._circleMenu` — the plugin's own jQuery set, which stays valid on a detached
node, so `.remove()` strips the pending handler — and decides the fade-out with an explicit
`document.contains()` check, since that set's `length` is 1 either way.

### 3. Bootstrap Tooltip instances leaked once the menu's DOM was gone

The disposal loop re-queried the same way, so it matched nothing on a detached radial and leaked one
Tooltip instance per item (Bootstrap keys them by element in a plain `Map`, not a `WeakMap`) every
time an enemy was hidden with the menu open. Same fix.

### 4. Tests

- `enemyvisual.circlemenu.test.js` (new): real jQuery + the real `zikes-circlemenu` plugin against a
  real DOM, which is what findings 2 and 3 need — both are about the plugin's own jQuery state on a
  detached node, which a hand-rolled `$` stub cannot model. Verified red on master: the "hidden before
  the menu opens" test lands a `RaidMarkerSelectMapState` on a menu that is gone, and the tooltips are
  never disposed.
- `enemyvisual.test.js`: covers the re-open guard through `buildVisual()` itself (not just the helper),
  and closes the `hidden`-branch gap from the issue by running the constructor with `setVisualType()`
  stubbed. `_cleanupCircleMenu`'s existing tests now model the radial as an always-length-1 set on a
  real (attached or detached) DOM node, matching what the plugin actually hands back.
- Each guard was mutation-checked: removing it turns the matching test red.

Full JS suite: 326 passed.

No visual verification — this is interaction/state behaviour with no rendering change, and the menu
itself is unchanged. The scenarios are pinned by the tests above instead.

### Cold review

Reviewed by a fresh-context agent; it found no correctness defect in the fix, and independently
mutation-checked the tests (6 go red on a revert to master). Its findings, all addressed in the second
commit:

- The `document.contains()` guard's comment claimed a detached radial's `delay()/queue()` would never
  drain. That is **false** — verified empirically: jQuery's queue is keyed off the element's data, not
  the document tree. It was true on master, where `$radial` came from a selector and went *empty*, and
  the rewrite kept the old conclusion under a new mechanism. Reworded to the real reason (not sitting
  out 500ms with the plugin's handlers still on a radial nobody can see, where a pending `open` hook
  can start a map state in the meantime), along with the matching test name and comment. The guard
  itself stays.
- `cleanup()` faded the menu out, so a discarded visual would call `setMapState(null)` 500ms later —
  after it had already unregistered from `map:mapstatechanged`. Now cleans up synchronously; the
  redundant null check went with it.
- Documented why the synchronous cleanup in `buildVisual()` cannot re-enter it
  (`RaidMarkerSelectMapState#shouldRebuildEnemyVisuals()` is `false`).
- Test naming: the `shown`/`hidden` cases are constructor wiring, so they are named after the
  constructor now. Added the pull-building case (an `EnemySelection` state), which is how the re-open
  guard is most often reached in practice.

Re-opening the menu when a rebuild lands inside its 500ms *close* animation is a separate, pre-existing
hole — `_circleMenu` cannot express "closing" vs "open". Filed as #3730 rather than papered over here.

Full JS suite after the review round: 328 passed.
