### PR TITLE
#3717 Bump local MySQL from 5.7 to 8.0.42 to match production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ docker-compose/mysql-combatlog
 docker-compose/redis-data
 # Local restores of production database dumps
 docker-compose/mysql-prod*/
+# Backups taken before an in-place MySQL data dir upgrade (#3717)
+docker-compose/mysql*-upgrade-bak/
 
 # AI
 .ladebugermcp/

--- a/app/Logic/Datatables/DungeonRoutesDatatablesHandler.php
+++ b/app/Logic/Datatables/DungeonRoutesDatatablesHandler.php
@@ -120,8 +120,9 @@ class DungeonRoutesDatatablesHandler extends DatatablesHandler
      * would run once per pre-LIMIT grouped route of the whole filtered set on this public, unauthenticated
      * endpoint - not once per the handful of rows actually returned. This query runs once, over
      * mapping_versions alone (a small table), regardless of how many dungeon_routes are filtered/paged.
-     * MySQL 5.7 (this project's minimum) has no window functions, hence the self-join instead of
-     * ROW_NUMBER() OVER (PARTITION BY ...).
+     * The self-join predates #3717, when local dev still ran MySQL 5.7 and window functions were off
+     * the table. Every environment is on 8.0.42 now, so a ROW_NUMBER() OVER (PARTITION BY ...) rewrite
+     * is available - kept as-is here because it is correct and already runs once over a small table.
      *
      * @return array<string, int>
      */

--- a/app/Logic/Datatables/DungeonRoutesDatatablesHandler.php
+++ b/app/Logic/Datatables/DungeonRoutesDatatablesHandler.php
@@ -121,8 +121,8 @@ class DungeonRoutesDatatablesHandler extends DatatablesHandler
      * endpoint - not once per the handful of rows actually returned. This query runs once, over
      * mapping_versions alone (a small table), regardless of how many dungeon_routes are filtered/paged.
      * The self-join predates #3717, when local dev still ran MySQL 5.7 and window functions were off
-     * the table. Every environment is on 8.0.42 now, so a ROW_NUMBER() OVER (PARTITION BY ...) rewrite
-     * is available - kept as-is here because it is correct and already runs once over a small table.
+     * the table. Local dev and CI are on 8.0 now, so a ROW_NUMBER() OVER (PARTITION BY ...) rewrite is
+     * available there - kept as-is here because it is correct and already runs once over a small table.
      *
      * @return array<string, int>
      */

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mysql:8.0
+    image: mysql:8.0.42
     ports:
       - "3306:3306"
     environment:
@@ -15,7 +15,7 @@ services:
       retries: 10
 
   db-combatlog:
-    image: mysql:8.0
+    image: mysql:8.0.42
     ports:
       - "3307:3306"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,8 +153,13 @@ services:
   # Set DB_DATA_VARIANT=-prod in .env to mount the prod data copies instead
   # (mysql-prod / mysql-prod-combatlog), then recreate with `docker compose up -d db db-combatlog`.
   # Container names stay -prod either way so worktree.sh auto-attach keeps working.
+  #
+  # MySQL 8.0 performs a one-way in-place data dictionary upgrade the first time it starts on a
+  # 5.7 data dir — there is no downgrade path. Any data dir that has not been through that upgrade
+  # yet (a variant you have not started since #3717, or a restored 5.7 backup) must be cleanly shut
+  # down and copied aside *before* you point an 8.0 server at it.
   db:
-    image: mysql:5.7
+    image: mysql:8.0.42
     container_name: keystone.guru-db-prod
     restart: unless-stopped
     environment:
@@ -182,7 +187,7 @@ services:
       - keystone.guru
 
   db-combatlog:
-    image: mysql:5.7
+    image: mysql:8.0.42
     container_name: keystone.guru-db-prod-combatlog
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,9 +155,9 @@ services:
   # Container names stay -prod either way so worktree.sh auto-attach keeps working.
   #
   # MySQL 8.0 performs a one-way in-place data dictionary upgrade the first time it starts on a
-  # 5.7 data dir — there is no downgrade path. Any data dir that has not been through that upgrade
-  # yet (a variant you have not started since #3717, or a restored 5.7 backup) must be cleanly shut
-  # down and copied aside *before* you point an 8.0 server at it.
+  # 5.7 data dir — there is no downgrade path. All four data dirs were upgraded to 8.0.42 in #3717,
+  # so both variants are safe to mount; but if you ever restore a 5.7-era backup or copy in an old
+  # data dir, shut it down cleanly under 5.7 and copy it aside *before* pointing 8.0 at it.
   db:
     image: mysql:8.0.42
     container_name: keystone.guru-db-prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,11 @@ services:
       - "34006:3306"
     command:
       - '--default-authentication-plugin=mysql_native_password'
+      # MySQL 8.0 turns binary logging on by default; 5.7 had it off. With sync_binlog=1 that adds a
+      # second fsync per commit, which on a bind-mounted data dir halves write throughput (measured
+      # in #3717: 2000 single-row inserts went 9.5s -> 18.7s). Local dev has no replication and no
+      # point-in-time-recovery story, so the binlog is pure cost - this restores the 5.7 behaviour.
+      - '--skip-log-bin'
     volumes:
       # create_host_path: false makes compose fail loudly when the data dir is missing
       # (e.g. bad DB_DATA_VARIANT) instead of silently mounting a fresh empty dir that
@@ -201,6 +206,11 @@ services:
       - "34007:3306"
     command:
       - '--default-authentication-plugin=mysql_native_password'
+      # MySQL 8.0 turns binary logging on by default; 5.7 had it off. With sync_binlog=1 that adds a
+      # second fsync per commit, which on a bind-mounted data dir halves write throughput (measured
+      # in #3717: 2000 single-row inserts went 9.5s -> 18.7s). Local dev has no replication and no
+      # point-in-time-recovery story, so the binlog is pure cost - this restores the 5.7 behaviour.
+      - '--skip-log-bin'
     volumes:
       - type: bind
         source: ./docker-compose/mysql${DB_DATA_VARIANT:-}-combatlog

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,9 +155,10 @@ services:
   # Container names stay -prod either way so worktree.sh auto-attach keeps working.
   #
   # MySQL 8.0 performs a one-way in-place data dictionary upgrade the first time it starts on a
-  # 5.7 data dir — there is no downgrade path. All four data dirs were upgraded to 8.0.42 in #3717,
-  # so both variants are safe to mount; but if you ever restore a 5.7-era backup or copy in an old
-  # data dir, shut it down cleanly under 5.7 and copy it aside *before* pointing 8.0 at it.
+  # 5.7 data dir — there is no downgrade path. The maintainer's four data dirs were upgraded to
+  # 8.0.42 in #3717 (see that MR for the procedure), but yours are your own: if any local data dir
+  # is still 5.7 — including a restored 5.7-era backup or a copied-in old dir — shut it down
+  # cleanly under 5.7 and copy it aside *before* pointing 8.0 at it.
   db:
     image: mysql:8.0.42
     container_name: keystone.guru-db-prod


### PR DESCRIPTION
:robot: Closes #3717

Local dev ran `mysql:5.7` on both `db` and `db-combatlog` while production runs 8.0.42. Both services (and `docker-compose.ci.yml`, which was already on a floating `8.0` tag) are now pinned to **8.0.42**, so local, CI and production agree on one version.

## The upgrade was actually performed, not just declared

All four data dirs were upgraded in place on the maintainer's machine as part of this MR — the compose bump alone would have handed the next person an un-upgraded 5.7 data dir.

| step | result |
|---|---|
| `mysqlsh util check-for-server-upgrade` on both live 5.7 servers | **0 errors** on both (2 generic advisories, 1 notice) |
| clean shutdown before the flip | `mysqld: Shutdown complete` confirmed in both logs |
| filesystem backup of every data dir | `*.5.7-upgrade-bak` alongside each (gitignored) — rollback is a directory swap |
| in-place upgrade | `Server upgrade from '50700' to '80042' completed.` on all four, no errors |

Data dirs upgraded: `mysql-prod`, `mysql-prod-combatlog` (the live `DB_DATA_VARIANT=-prod` pair) **and** `mysql`, `mysql-combatlog` (the unset-variant pair). The non-prod pair was cycled through 5.7 first to guarantee a clean shutdown, then upgraded and shut down cleanly again. Doing both means flipping `DB_DATA_VARIANT` later can't trigger a surprise one-way upgrade.

Integrity after the flip: table sets byte-identical on both schemas, and exact row counts unchanged (`dungeon_routes` 507415, `enemies` 81665, `users` 74702, `mapping_versions` 556).

## ⚠️ The bump also introduced a performance regression — fixed here

**MySQL 8.0 enables binary logging by default; the `mysql:5.7` image did not.** With the default
`sync_binlog=1` that is a second `fsync` per commit, and it halves local write throughput. Measured
on this data dir (2000 single-row inserts):

| config | time | writes/sec |
|---|---|---|
| binlog **ON**, `flush=1` — what the bump gave us | 18.71 s | 107 |
| binlog **OFF**, `flush=1` — what 5.7 had | 9.55 s | 209 |

Verified from both ends: a throwaway `mysql:5.7` reports `log_bin OFF`, 8.0.42 reports `log_bin ON`.
Both services now pass `--skip-log-bin` — local dev has no replica and no PITR story, so the binlog
is pure cost, and skipping it restores exactly the write performance 5.7 had. Both servers now
report `log_bin 0`.

**Not applied, deliberately:** `innodb_flush_log_at_trx_commit=2` removes the *other* fsync and took
the same benchmark to **0.15 s** (13,200 writes/sec). 5.7 also ran `flush=1`, so that is new tuning
rather than restoring parity, and it trades away up to ~1s of committed transactions on a host
crash. Happy to add it if wanted — it is a one-line change.

## `--default-authentication-plugin=mysql_native_password`

Confirmed still accepted on 8.0.42 — the server logs a deprecation warning and starts normally. Kept, with the details recorded here rather than in a comment nobody would find:

- On **5.7 this flag was a no-op** — `mysql_native_password` was already the default. It only starts meaning something on 8.0.
- Every existing account (`root`, `homestead`) came through the upgrade still on `mysql_native_password`; account rows store their own plugin, so the flag has no effect on the upgraded data dirs either way. It only governs *fresh* data dir bootstraps.
- Dropping it is safe from the driver's side — verified against a throwaway fresh 8.0.42 data dir with no flag, where accounts bootstrap as `caching_sha2_password`: this project's PDO/mysqlnd (PHP 8.4.23) connects fine over plaintext as both `root` and `homestead`.
- Keeping it is still the smaller change, and it keeps a fresh bootstrap matching the data dirs everyone already has.
- ⚠️ MySQL **8.4 removes the option entirely** (`authentication_policy` replaces it) and stops loading the `mysql_native_password` plugin by default. Whoever bumps past 8.0.x has to deal with both — worth a follow-up issue at that point, not now.

## `ONLY_FULL_GROUP_BY`

The DoD asked for any issues surfaced by 8.0's stricter default to be fixed rather than silenced. **None surfaced, and structurally none can**, which is worth stating explicitly:

`config/database.php` sets `'strict' => false` on the `mysql`, `phpunit` and `tracker` connections, so Laravel pins the *session* `sql_mode` and the server default never applies. Verified on the upgraded server:

```
server default:            ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,...
session sql_mode(mysql):   NO_ENGINE_SUBSTITUTION
session sql_mode(phpunit): NO_ENGINE_SUBSTITUTION
session sql_mode(migrate): ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,...   <- 'strict' => true
```

The `migrate` connection does run with `ONLY_FULL_GROUP_BY` — but that was equally true on 5.7, since Laravel's strict mode is set per session and is version-independent. So 8.0 changes nothing here. Nothing was silenced to make this pass; no `strict` flag was widened.

## Also in this MR

`DungeonRoutesDatatablesHandler::getLatestMappingVersionIdsByDungeonAndGameVersion()` carried a comment saying "MySQL 5.7 (this project's minimum) has no window functions" — the exact constraint #3717 was filed to remove. This MR makes that claim false, so the comment now records why the self-join is *kept* (correct, runs once over a small table) rather than implying it is forced. The `ROW_NUMBER() OVER (PARTITION BY ...)` rewrite is now available if wanted; deliberately not done here, since rewriting a query on a public unauthenticated endpoint doesn't belong in an infra bump.

## Verification

- `composer run analyse` — **no errors**
- `composer run fix` — **0 of 3729 files changed**
- All 9 CI checks green (re-running after the final rebase)
- Full local suite against the upgraded data dir — **still outstanding**, see below
- Pages driven in real headless Chrome against the upgraded DB, all HTTP 200, zero uncaught page errors: discover (`/dungeonroutes`), a live route map (`/dAXdp5p` — 111 enemy markers, pull list, 265/290 enemy forces all rendered from the DB), `/admin/dungeons` (155 dungeons), `/admin/tools`, and `/dAXdp5p/edit`.

Two console messages showed up and were both chased down rather than waved off: broken thumbnails resolve to `http://localhost:8008/...`, a host-published port unreachable from inside the container, and `SyntaxError: "undefined" is not valid JSON` is `map.js:657` doing `JSON.parse(Cookies.get('hidden_map_object_groups'))` with no cookie set — already inside a `try`/`catch` that ignores it. Neither is DB-related.



## Outstanding before this leaves draft

1. **Full local suite run against the upgraded data dir.** Not yet completed. It was repeatedly
   restarted while chasing the runtime problem below, and the session ended before a clean run
   finished. CI already proves 8.0.42 *SQL* compatibility; this run's only job is proving the
   *upgraded data dir* is intact, which the row counts, identical table sets and rendered pages
   above already evidence.
2. **Cold independent review** per CLAUDE.md, then `gh pr ready 3731`.

### Why the local suite looked broken (not this MR)

While verifying, the local suite appeared to hang for over an hour. It was **not** the version bump:
`RepairBrokenThumbnailsTest` ran the real maintenance command unscoped against the 226k-row local
`dungeon_route_thumbnails` table — ~25 minutes per test method. That is already fixed on master by
#3722 / #3724 (`--dungeon-route-id`), and this branch is rebased onto it. The binlog regression above
was a genuine and separate finding from the same investigation.

## Rollback

The 5.7 data dirs are preserved as `docker-compose/{mysql,mysql-prod,mysql-combatlog,mysql-prod-combatlog}.5.7-upgrade-bak`
on the maintainer's machine (~44&nbsp;GB total, gitignored). Reverting means stopping the containers,
swapping a directory back and reverting this MR. **Delete them once you're happy** — there is no
downgrade path once they're gone.
