### PR TITLE
#3732 Enemy forces checkpoints follow the Pull number style setting

### DIFF
--- a/.claude/skills/headless-browser-verify/SKILL.md
+++ b/.claude/skills/headless-browser-verify/SKILL.md
@@ -20,6 +20,20 @@ mkdir -p .chrome-tmp && cp .claude/skills/headless-browser-verify/browse.js .chr
 
 No published ports, so every worktree stack can run its own chrome simultaneously.
 
+**In a worktree, `node_modules` must be a real directory, not a symlink.** `sh/worktree.sh create`
+does not provide one at all, and browse.js resolves `puppeteer` from `/var/www/node_modules` *inside*
+the container - where a host symlink into the main checkout does not resolve (only the worktree is
+mounted). A symlink is fine for `npx vitest` on the host but fails here with
+`Cannot find module 'puppeteer'`. Hardlink a copy instead - seconds, and it shares the main
+checkout's blocks:
+
+```sh
+cp -al /home/wouterkoppenol/Git/private/keystone.guru/node_modules ./node_modules
+rm -rf node_modules/.cache   # the only entries cp -al cannot link (root-owned); harmless
+```
+
+Delete it again before teardown.
+
 ## Running
 
 ```sh
@@ -59,6 +73,23 @@ both** to the PR, not just the branch shot.
   for master and `http://nginx/<page>` for the branch, same viewport.
 - Check the baseline is actually master: the page footer shows the built commit
   (`v15.3.2 (05d7dc)`); if the main checkout's assets are stale, rebuild there first.
+- **For a JS/CSS change, prefer an in-worktree baseline over the main stack.** The main checkout
+  often has no built asset for its own HEAD (`public/js/app-<sha>.js` missing), so its pages load
+  without JS and cannot serve a baseline at all — and building there to fix that touches the user's
+  checkout. Instead flip the changed files in place:
+
+  ```sh
+  git checkout HEAD~1 -- <changed files>   # or the merge-base commit
+  npm run development                       # host-side; ~10s incremental
+  # ...run the driver, save the "before" shots...
+  git checkout HEAD -- <changed files>
+  npm run development
+  ```
+
+  The asset filename is derived from **git HEAD**, which never moves during this, so nginx serves
+  the same URL throughout and only the bundle contents change. Confirm the restore with
+  `grep -c <new symbol> public/js/custom-<sha>.js` before moving on — a forgotten restore leaves the
+  worktree silently reverted.
 - **Exercise dynamic UI, not just page load.** JS-inserted content (map sidebar, dropdown menus)
   breaks differently from server-rendered HTML, and a regression can hit only the
   dynamically-inserted elements. Use `--click` and screenshot the opened/expanded state on both
@@ -96,6 +127,30 @@ Chrome's DevTools endpoint rejects `Host:` headers that are not an IP or localho
 resolves the `chrome` service name to its IP, fetches `/json/version` from the IP, rewrites the
 `webSocketDebuggerUrl` to that IP, and uses `puppeteer.connect`. Disconnect (do not close) so the
 browser stays warm for the next run.
+
+## Map settings: the page cannot write its own cookies
+
+`map.js` sets `cookieDefaultAttributes` to `{secure: true, sameSite: 'None'}` unless the environment
+is `ENVIRONMENT_LOCAL`, so **every `Cookies.set` the page makes is silently dropped over plain
+`http://nginx`**. Two consequences that will cost an hour each if you don't know them:
+
+- **Driving a setting through its state-manager setter does nothing.** Calling
+  `getState().setKillZonesNumberStyle('enemy_forces')` writes no cookie, so the matching getter keeps
+  returning the old value and the UI correctly does not change — which reads exactly like "my signal
+  wiring is broken". To set a value, use `page.setCookie(...)` **before** `page.goto` (puppeteer
+  writes it directly, bypassing the secure attribute). To test that a *signal registration* fires,
+  stub the getter and emit the signal yourself — which is all the setter does after writing:
+
+  ```js
+  await page.evaluate(() => { getState().getKillZonesNumberStyle = () => 'enemy_forces'; });
+  await page.evaluate(() => getState().signal('killzonesnumberstyle:changed'));
+  // then assert the element repainted — and that the OLD signal name does not repaint it
+  ```
+
+- **Every map page logs one benign console error.** `Exception! SyntaxError: "undefined" is not valid
+  JSON` comes from `map.js:658` doing `JSON.parse(Cookies.get('hidden_map_object_groups'))` on the
+  cookie `_initDefaults()` just failed to write. It is caught, pre-existing, and unrelated to
+  whatever you are verifying — do not chase it.
 
 ## Gotchas
 

--- a/.claude/skills/worktree-docker/SKILL.md
+++ b/.claude/skills/worktree-docker/SKILL.md
@@ -51,7 +51,31 @@ docker compose exec -T app composer run fix
 docker compose exec -T app composer run analyse
 ```
 
+Note the `docker compose exec -T app` prefix is not optional for `composer run fix` / `analyse`:
+run on the host they abort in `vendor/composer/platform_check.php` (the host PHP is the wrong
+version).
+
 Open `http://localhost:<port>` in a browser to view the worktree's front-end.
+
+## No `node_modules` — front-end work needs one
+
+`create` does not install node modules, so `npx vitest`, `npm run development` and anything that
+resolves `puppeteer` all fail until you provide one. Hardlink the main checkout's copy (seconds,
+shares its blocks):
+
+```bash
+cp -al ../../keystone.guru/node_modules ./node_modules
+rm -rf node_modules/.cache   # the only entries cp -al cannot link (root-owned); harmless
+```
+
+A **symlink** also works for host-side commands (`npx vitest`) but NOT for anything running inside
+the `app` container — only the worktree is bind-mounted, so a symlink pointing into the main
+checkout dangles there. Use the hardlink copy if you need either. Delete it before
+`sh/worktree.sh remove`.
+
+A JS/CSS change is only visible in the worktree's browser after `npm run development` (host-side);
+the served filename is `public/js/app-<git HEAD sha>.js`, so a fresh worktree serves nothing until
+that first build.
 
 ## How the isolation works
 

--- a/lang/en_US/view_common.php
+++ b/lang/en_US/view_common.php
@@ -189,7 +189,7 @@ return [
         ],
         'pullsettings' => [
             'pull_number_style'                 => 'Pull number style',
-            'pull_number_style_title'           => 'This controls how the pulls sidebar displays numbers.',
+            'pull_number_style_title'           => 'This controls how the pulls sidebar and enemy forces checkpoints display numbers.',
             'pull_number_style_percentage'      => 'Percentage',
             'pull_number_style_enemy_forces'    => 'Enemy forces',
             'show_floor_breakdown'              => 'Show floor breakdown',

--- a/resources/assets/js/custom/mapstate/enemyselection/enemyforcescheckpointenemyselection.js
+++ b/resources/assets/js/custom/mapstate/enemyselection/enemyforcescheckpointenemyselection.js
@@ -88,7 +88,7 @@ class EnemyForcesCheckpointEnemySelection extends EnemySelection {
             }
         );
 
-        getState().register('mapnumberstyle:changed', this, this._refreshSnackbar.bind(this));
+        getState().register('killzonesnumberstyle:changed', this, this._refreshSnackbar.bind(this));
         this.map.register('enemyforcescheckpoint:memberschanged', this, this._refreshSnackbar.bind(this));
     }
 
@@ -102,7 +102,7 @@ class EnemyForcesCheckpointEnemySelection extends EnemySelection {
             this.snackbarId = null;
         }
 
-        getState().unregister('mapnumberstyle:changed', this);
+        getState().unregister('killzonesnumberstyle:changed', this);
         this.map.unregister('enemyforcescheckpoint:memberschanged', this);
     }
 
@@ -119,7 +119,7 @@ class EnemyForcesCheckpointEnemySelection extends EnemySelection {
         let enemyForces = enemyForcesCheckpoint.getEnemyForces();
 
         let amount;
-        if (getState().getMapNumberStyle() === NUMBER_STYLE_ENEMY_FORCES) {
+        if (getState().getKillZonesNumberStyle() === NUMBER_STYLE_ENEMY_FORCES) {
             amount = lang.get('js.enemy_forces_checkpoint_snackbar_enemy_forces', {enemyForces: enemyForces});
         } else {
             amount = lang.get('js.enemy_forces_checkpoint_snackbar_percentage', {

--- a/resources/assets/js/custom/mapstate/enemyselection/enemyforcescheckpointenemyselection.numberstyle.test.js
+++ b/resources/assets/js/custom/mapstate/enemyselection/enemyforcescheckpointenemyselection.numberstyle.test.js
@@ -1,0 +1,89 @@
+// The snackbar shown while an admin assigns enemies to a checkpoint says how much that checkpoint
+// currently holds. Like the checkpoint's own pill and tooltip, that figure is a group total, so it
+// follows the "Pull number style" setting - not "Enemy number style", which governs the numbers drawn
+// on individual enemies.
+//
+// Follows the global-script recipe from models/killzone.test.js: stub the collaborators the class
+// bodies touch at LOAD time, then require the source.
+
+global.Signalable = class Signalable {
+};
+global.LeafletKillZoneIconEditMode = {};
+global.NUMBER_STYLE_ENEMY_FORCES = 'enemy_forces';
+global.NUMBER_STYLE_PERCENTAGE = 'percentage';
+
+// The real inheritance chain - the subclass references its base as a bare global (they are
+// concatenated into one bundle).
+const {MapState} = require('../mapstate');
+global.MapState = MapState;
+const {MapObjectMapState} = require('../mapobjectmapstate');
+global.MapObjectMapState = MapObjectMapState;
+const {EnemySelection} = require('./enemyselection');
+global.EnemySelection = EnemySelection;
+
+const {EnemyForcesCheckpointEnemySelection} = require('./enemyforcescheckpointenemyselection');
+
+/**
+ * Runs `_refreshSnackbar()` against a hand-rolled `this`, so no constructor (and none of its snackbar
+ * / Leaflet wiring) has to run, and returns the text written into each snackbar element by selector.
+ *
+ * The two number style settings are deliberately given OPPOSING values, so a test can tell which of
+ * the two was consulted.
+ *
+ * @param options {{killZonesNumberStyle: String, mapNumberStyle: String}}
+ * @returns {Object<String, String>}
+ */
+function refreshSnackbar({killZonesNumberStyle, mapNumberStyle}) {
+    const writtenText = {};
+
+    const checkpoint = {
+        name: 'Corridor',
+        getEnemies: () => [{id: 1}, {id: 2}],
+        getEnemyForces: () => 20,
+    };
+
+    global.getState = () => ({
+        getKillZonesNumberStyle: () => killZonesNumberStyle,
+        getMapNumberStyle: () => mapNumberStyle,
+    });
+
+    // Echo the key back with its parameters, so a test can assert both which branch ran and the value.
+    global.lang = {get: (key, params = {}) => `${key}:${JSON.stringify(params)}`};
+    global.getFormattedPercentage = (amount, total) => `${Math.round((amount / total) * 100)}%`;
+    global.$ = (selector) => ({text: (text) => (writtenText[selector] = text)});
+
+    EnemyForcesCheckpointEnemySelection.prototype._refreshSnackbar.call({
+        getMapObject: () => checkpoint,
+        map: {enemyForcesManager: {getEnemyForcesRequired: () => 100}},
+    });
+
+    return writtenText;
+}
+
+describe('EnemyForcesCheckpointEnemySelection._refreshSnackbar number style', () => {
+    it('refreshSnackbar_givenPullNumberStyleIsEnemyForces_rendersRawEnemyForces', () => {
+        // Arrange / Act
+        const writtenText = refreshSnackbar({
+            killZonesNumberStyle: NUMBER_STYLE_ENEMY_FORCES,
+            mapNumberStyle: NUMBER_STYLE_PERCENTAGE,
+        });
+
+        // Assert
+        expect(writtenText['#map_enemy_forces_checkpoint_edit_snackbar_summary'])
+            .toContain('js.enemy_forces_checkpoint_snackbar_enemy_forces');
+    });
+
+    it('refreshSnackbar_givenPullNumberStyleIsPercentage_rendersAPercentage', () => {
+        // Arrange / Act
+        const writtenText = refreshSnackbar({
+            killZonesNumberStyle: NUMBER_STYLE_PERCENTAGE,
+            mapNumberStyle: NUMBER_STYLE_ENEMY_FORCES,
+        });
+
+        // Assert
+        // The opposing "Enemy number style" value must not be able to reach the snackbar.
+        expect(writtenText['#map_enemy_forces_checkpoint_edit_snackbar_summary'])
+            .toContain('js.enemy_forces_checkpoint_snackbar_percentage');
+        expect(writtenText['#map_enemy_forces_checkpoint_edit_snackbar_summary']).toContain('20%');
+    });
+});

--- a/resources/assets/js/custom/models/enemyforcescheckpoint.js
+++ b/resources/assets/js/custom/models/enemyforcescheckpoint.js
@@ -56,7 +56,7 @@ class EnemyForcesCheckpoint extends VersionableMapObject {
         this.map.register('map:mapobjectgroupsloaded', this, function () {
             self.refreshPill();
         });
-        getState().register('mapnumberstyle:changed', this, function () {
+        getState().register('killzonesnumberstyle:changed', this, function () {
             self.refreshPill();
         });
         getState().getMapContext().register('teeming:changed', this, function () {
@@ -305,7 +305,7 @@ class EnemyForcesCheckpoint extends VersionableMapObject {
         let enemyForces = this.getEnemyForces();
 
         let tooltipText;
-        if (getState().getMapNumberStyle() === NUMBER_STYLE_ENEMY_FORCES) {
+        if (getState().getKillZonesNumberStyle() === NUMBER_STYLE_ENEMY_FORCES) {
             tooltipText = lang.get('js.enemy_forces_checkpoint_tooltip_enemy_forces', {name: name, enemyForces: enemyForces});
         } else {
             tooltipText = lang.get('js.enemy_forces_checkpoint_tooltip_percentage', {
@@ -332,7 +332,7 @@ class EnemyForcesCheckpoint extends VersionableMapObject {
         this._removeSatellitePill();
 
         this.map.unregister('map:mapobjectgroupsloaded', this);
-        getState().unregister('mapnumberstyle:changed', this);
+        getState().unregister('killzonesnumberstyle:changed', this);
         getState().getMapContext().unregister('teeming:changed', this);
         getState().unregister('floorid:changed', this);
 
@@ -344,7 +344,7 @@ class EnemyForcesCheckpoint extends VersionableMapObject {
 
     /**
      * Builds the pill's markup: how much enemy forces you need before entering this checkpoint, following
-     * the "Enemy number style" map setting.
+     * the "Pull number style" setting - a checkpoint is a group total, like a pull, not a per-enemy number.
      * @returns {String}
      * @private
      */
@@ -357,7 +357,7 @@ class EnemyForcesCheckpoint extends VersionableMapObject {
         let requiredBefore = Math.max(0, enemyForcesRequired - enemyForces);
 
         let value;
-        if (getState().getMapNumberStyle() === NUMBER_STYLE_ENEMY_FORCES) {
+        if (getState().getKillZonesNumberStyle() === NUMBER_STYLE_ENEMY_FORCES) {
             value = lang.get('js.enemy_forces_checkpoint_pill_enemy_forces', {enemyForces: requiredBefore});
         } else {
             value = lang.get('js.enemy_forces_checkpoint_pill_percentage', {

--- a/resources/assets/js/custom/models/enemyforcescheckpoint.test.js
+++ b/resources/assets/js/custom/models/enemyforcescheckpoint.test.js
@@ -15,7 +15,11 @@ global.VersionableMapObject = class VersionableMapObject {
         this.map = map;
         this.layer = layer;
     }
+
+    bindTooltip() {}
 };
+global.NUMBER_STYLE_ENEMY_FORCES = 'enemy_forces';
+global.NUMBER_STYLE_PERCENTAGE = 'percentage';
 global.MAP_OBJECT_GROUP_ENEMY = 'enemy';
 global.MAP_OBJECT_GROUP_ENEMY_FORCES_CHECKPOINT = 'enemyforcescheckpoint';
 
@@ -139,6 +143,115 @@ describe('EnemyForcesCheckpoint._refreshSatellitePill', () => {
 
         // Assert
         expect(checkpoint._satelliteLayerGroup).toBeNull();
+    });
+});
+
+/**
+ * Builds a checkpoint with just the collaborators the pill and the tooltip reach for.
+ *
+ * The two number style settings are deliberately given OPPOSING values, so a test can tell which of
+ * the two was consulted: a checkpoint is a group total (like a pull), so it must follow "Pull number
+ * style" and never "Enemy number style" - which is about the numbers drawn on individual enemies.
+ *
+ * @param options {{killZonesNumberStyle: String, mapNumberStyle: String}}
+ */
+function createCheckpointForNumberStyle({killZonesNumberStyle, mapNumberStyle}) {
+    const enemyMapObjectGroup = {
+        objects: {
+            1: {id: 1, enemy_forces_checkpoint_id: 55, floor_id: 1, source_floor_id: null},
+        },
+    };
+
+    const checkpoint = Object.create(EnemyForcesCheckpoint.prototype);
+    checkpoint.id = 55;
+    checkpoint.floor_id = 1;
+    checkpoint.name = 'Corridor';
+    checkpoint.layer = {bindTooltip: (text) => (checkpoint._boundTooltipText = text)};
+    checkpoint.map = {
+        options: {noUI: false},
+        mapObjectGroupManager: {
+            getByName: (name) => (name === 'enemy' ? enemyMapObjectGroup : false),
+        },
+        enemyForcesManager: {
+            getEnemyForcesForEnemies: () => 20,
+            getEnemyForcesRequired: () => 100,
+        },
+    };
+
+    global.getState = () => ({
+        getCurrentFloor: () => ({id: 1}),
+        getKillZonesNumberStyle: () => killZonesNumberStyle,
+        getMapNumberStyle: () => mapNumberStyle,
+    });
+
+    // Echo the key back with its parameters, so a test can assert both which branch ran and the value.
+    global.lang = {get: (key, params = {}) => `${key}:${JSON.stringify(params)}`};
+    global.getFormattedPercentage = (amount, total) => `${Math.round((amount / total) * 100)}%`;
+    global.Handlebars = {templates: {map_enemy_forces_checkpoint_pill: ({value}) => `<div>${value}</div>`}};
+
+    return checkpoint;
+}
+
+describe('EnemyForcesCheckpoint number style', () => {
+    it('getPillHtml_givenPullNumberStyleIsEnemyForces_rendersRawEnemyForces', () => {
+        // Arrange
+        const checkpoint = createCheckpointForNumberStyle({
+            killZonesNumberStyle: NUMBER_STYLE_ENEMY_FORCES,
+            mapNumberStyle: NUMBER_STYLE_PERCENTAGE,
+        });
+
+        // Act
+        const html = checkpoint._getPillHtml();
+
+        // Assert
+        // 100 required - 20 held by this checkpoint = 80 needed before entering.
+        expect(html).toContain('js.enemy_forces_checkpoint_pill_enemy_forces');
+        expect(html).toContain('80');
+    });
+
+    it('getPillHtml_givenPullNumberStyleIsPercentage_rendersAPercentage', () => {
+        // Arrange
+        const checkpoint = createCheckpointForNumberStyle({
+            killZonesNumberStyle: NUMBER_STYLE_PERCENTAGE,
+            mapNumberStyle: NUMBER_STYLE_ENEMY_FORCES,
+        });
+
+        // Act
+        const html = checkpoint._getPillHtml();
+
+        // Assert
+        // The opposing "Enemy number style" value must not be able to reach the pill.
+        expect(html).toContain('js.enemy_forces_checkpoint_pill_percentage');
+        expect(html).toContain('80%');
+    });
+
+    it('bindTooltip_givenPullNumberStyleIsEnemyForces_rendersRawEnemyForces', () => {
+        // Arrange
+        const checkpoint = createCheckpointForNumberStyle({
+            killZonesNumberStyle: NUMBER_STYLE_ENEMY_FORCES,
+            mapNumberStyle: NUMBER_STYLE_PERCENTAGE,
+        });
+
+        // Act
+        checkpoint.bindTooltip();
+
+        // Assert
+        expect(checkpoint._boundTooltipText).toContain('js.enemy_forces_checkpoint_tooltip_enemy_forces');
+    });
+
+    it('bindTooltip_givenPullNumberStyleIsPercentage_rendersAPercentage', () => {
+        // Arrange
+        const checkpoint = createCheckpointForNumberStyle({
+            killZonesNumberStyle: NUMBER_STYLE_PERCENTAGE,
+            mapNumberStyle: NUMBER_STYLE_ENEMY_FORCES,
+        });
+
+        // Act
+        checkpoint.bindTooltip();
+
+        // Assert
+        expect(checkpoint._boundTooltipText).toContain('js.enemy_forces_checkpoint_tooltip_percentage');
+        expect(checkpoint._boundTooltipText).toContain('20%');
     });
 });
 


### PR DESCRIPTION
:robot: Closes #3732

Enemy forces checkpoints displayed their value (percentage vs. raw enemy forces) based on the **Enemy number style** setting. They now follow **Pull number style** instead.

`getMapNumberStyle()` governs the numbers drawn on individual enemies (`enemyvisualmainenemyforces.js`). Every "how much enemy forces is this group worth" display - the pulls sidebar, kill zone tooltips, enemy pack tooltips - reads `getKillZonesNumberStyle()`. A checkpoint is a group total, so it belongs with the latter.

### Changes

| File | What |
| --- | --- |
| `models/enemyforcescheckpoint.js` | pill markup, tooltip text, and the `killzonesnumberstyle:changed` register/unregister pair |
| `mapstate/enemyselection/enemyforcescheckpointenemyselection.js` | admin edit snackbar + its register/unregister pair |
| `lang/en_US/view_common.php` | the Pull number style help text said "pulls sidebar" only |

The register/unregister pairs move together with the getters, so toggling **Pull number style** still repaints the pill, tooltip and snackbar live.

### Behaviour change worth a conscious ack

Both settings default to percentage in `statemanager.js`, but `map.js` seeds the cookies on every map page load as `map_number_style: 'enemy_forces'` / `kill_zones_number_style: 'percentage'`. So **any user who never touched the Pull toggle sees checkpoint pills flip from raw enemy forces to a percentage** - that's the default experience, and checkpoints already shipped (`8defc3f55` is in v15.8.0 / v15.8.1).

Percentage seems right for "how much you need before entering" (it matches the pill's own `fa-percent` placement icon), but it is a visible change for existing users rather than a silent one. Two notes:
- Cookie-less headless renders (thumbnails) are unaffected - both `statemanager.js` fallbacks are percentage, before and after.
- In a `pulls => false` embed the settings modal isn't rendered, so a viewer there has no toggle and is stuck with the default.

### Tests

- `enemyforcescheckpoint.test.js` - 4 new tests over `_getPillHtml()` and `bindTooltip()`
- `enemyforcescheckpointenemyselection.numberstyle.test.js` (new) - 2 tests over `_refreshSnackbar()`

Each test sets the two number style settings to **opposing** values, so it fails if the wrong one is consulted - verified by mutation (revert the fix: all 6 fail; re-apply: all pass). Full vitest suite: 322 passed. `composer run fix` / `analyse` clean.

Verified in real headless Chrome, both the cookie path and the live-repaint path - see the comments below.

### Also included: two skill doc updates

The last commit is docs only (`.claude/skills/headless-browser-verify`, `.claude/skills/worktree-docker`). Verifying this fix ran into three undocumented traps - a worktree has no `node_modules`, the main checkout usually can't serve a master baseline for a JS change, and `map.js`'s secure cookies mean the page can't write its own settings over plain HTTP (so state-manager setters silently no-op, and every map page logs one benign `JSON.parse` console error). Per `.claude/CLAUDE.md` that knowledge belongs in-repo, and it's adjacent enough to this MR to not be worth its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
