### PR TITLE
#3730 Fix raid marker circle menu re-opening during its close animation

### DIFF
--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.circlemenu.test.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.circlemenu.test.js
@@ -183,4 +183,33 @@ describe('EnemyVisual circle menu teardown (#3723)', () => {
         expect(self._circleMenu).toBeNull();
         expect(setMapStateCalls[1]).toBeNull();
     });
+
+    test('_cleanupCircleMenu_givenARebuildLandsWhileTheMenuIsFadingOut_doesNotReportAReopenableMenu', () => {
+        // Arrange: the menu opened normally, then the user closed it - the close/select callback's
+        // default fadeOut=true call, which queues cleanupFn 500ms out and leaves _circleMenu non-null
+        // in the meantime
+        const {self, setMapStateCalls} = makeOpenCircleMenu();
+        vi.advanceTimersByTime(1000);
+        EnemyVisual.prototype._cleanupCircleMenu.call(self, true);
+        expect(setMapStateCalls).toHaveLength(1);
+
+        // Act: a rebuild lands inside that 500ms window - killzone:attached, overpulled:changed, an
+        // Echo object:changed - and buildVisual() calls this exact form to tear down before rebuilding
+        const hadCircleMenu = EnemyVisual.prototype._cleanupCircleMenu.call(self, false);
+
+        // Assert: not reported as an interrupted, reopenable menu (#3730) - the menu the user just
+        // dismissed must not be treated as one buildVisual() should put back afterwards. Nothing about
+        // the already-queued fade-out is disturbed either.
+        expect(hadCircleMenu).toBe(false);
+        expect(document.getElementById('map_enemy_raid_marker_radial_42')).not.toBeNull();
+        expect(setMapStateCalls).toHaveLength(1);
+
+        // Act: the original fade-out still completes on its own
+        vi.advanceTimersByTime(1000);
+
+        // Assert
+        expect(document.getElementById('map_enemy_raid_marker_radial_42')).toBeNull();
+        expect(self._circleMenu).toBeNull();
+        expect(setMapStateCalls[1]).toBeNull();
+    });
 });

--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.circlemenu.test.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.circlemenu.test.js
@@ -212,4 +212,29 @@ describe('EnemyVisual circle menu teardown (#3723)', () => {
         expect(self._circleMenu).toBeNull();
         expect(setMapStateCalls[1]).toBeNull();
     });
+
+    test('_cleanupCircleMenu_givenTheRebuildDetachesTheRadialWhileClosing_stillEndsTheMapStateLater', () => {
+        // Arrange: the menu opened normally, then the user closed it, queuing the 500ms fade-out
+        const {self, container, setMapStateCalls} = makeOpenCircleMenu();
+        vi.advanceTimersByTime(1000);
+        EnemyVisual.prototype._cleanupCircleMenu.call(self, true);
+        expect(setMapStateCalls).toHaveLength(1);
+
+        // Act: a rebuild lands inside that window - the no-op call from #3730 above - and then goes
+        // on to replace the enemy's icon HTML entirely (buildVisual() -> layer.setIcon()), which
+        // detaches the still-fading radial from the document exactly like Leaflet destroying the
+        // enemy's icon natively does elsewhere (#3723)
+        EnemyVisual.prototype._cleanupCircleMenu.call(self, false);
+        container.remove();
+
+        // Act: the original fade-out's queue still runs against the now-detached radial
+        vi.advanceTimersByTime(1000);
+
+        // Assert: cleanupFn must not have been skipped just because its target left the document -
+        // the plugin's own jQuery set (self._circleMenu) stays valid regardless (#3723), so the map
+        // state this menu started still gets ended, exactly once
+        expect(self._circleMenu).toBeNull();
+        expect(setMapStateCalls).toHaveLength(2);
+        expect(setMapStateCalls[1]).toBeNull();
+    });
 });

--- a/resources/assets/js/custom/enemyvisuals/enemyvisual.js
+++ b/resources/assets/js/custom/enemyvisuals/enemyvisual.js
@@ -30,6 +30,10 @@ class EnemyVisual extends Signalable {
         this.cachedRadius = 0;
 
         this._circleMenu = null;
+        // True for the entire 500ms fade-out queued by _cleanupCircleMenu(true) - the window in which
+        // _circleMenu is still non-null (nothing else marks a menu that is on its way out rather than
+        // open) but must not be treated as reopenable by buildVisual() (#3730).
+        this._circleMenuClosing = false;
 
         // Can be set to force the building of a visual when it's shown again
         this._forceBuildVisualOnShow = false;
@@ -325,6 +329,11 @@ class EnemyVisual extends Signalable {
 
     /**
      * Cleans up the circle menu, removing it from the object completely.
+     *
+     * A no-op while the menu is already mid fade-out (a previous call already queued cleanupFn below):
+     * without this, buildVisual() calling in here to tear down for a rebuild would see a menu the user
+     * is actively closing as one that just got interrupted, and put it right back afterwards (#3730).
+     * The already-queued cleanupFn is left alone to finish the teardown once its delay elapses.
      * @param fadeOut {boolean}
      * @return true if the menu was cleaned up, false if it was not
      * @private
@@ -334,7 +343,7 @@ class EnemyVisual extends Signalable {
 
         let self = this;
 
-        let shouldCleanUp = self._circleMenu !== null;
+        let shouldCleanUp = self._circleMenu !== null && !self._circleMenuClosing;
 
         if (shouldCleanUp) {
             // Remove any stray tooltip bubbles left over from hovering the circle menu items.
@@ -371,6 +380,7 @@ class EnemyVisual extends Signalable {
                 // nulled here, nothing could ever end that state again (#3723).
                 $radial.remove().dequeue();
                 self._circleMenu = null;
+                self._circleMenuClosing = false;
 
                 // Only stop the map state at this point - and only if it is still ours. The menu can
                 // only be opened while no map state is active, but the user can start one while it is
@@ -396,6 +406,7 @@ class EnemyVisual extends Signalable {
             // length check used to stand in for), and jQuery's queue drains on a detached element
             // just fine - it is keyed off the element's data, not off the document tree.
             if (fadeOut && $radial.length > 0 && document.contains($radial[0])) {
+                self._circleMenuClosing = true;
                 $radial.delay(500).queue(cleanupFn);
             } else {
                 cleanupFn();


### PR DESCRIPTION
:robot: Closes #3730

## Summary
`EnemyVisual#_cleanupCircleMenu()` only nulls `_circleMenu` once its queued 500ms fade-out actually
runs (started from the plugin's `close`/`select` callbacks). During that window `_circleMenu` is
still non-null, so a rebuild landing inside it - `killzone:attached`, `overpulled:changed`, an Echo
`object:changed` - has `buildVisual()` call `_cleanupCircleMenu(false)` to tear down before
rebuilding. That call saw the menu the user just dismissed as one that got interrupted mid-rebuild
(`hadCircleMenu === true`), and `_canReopenCircleMenu()` didn't help since the map state hadn't ended
yet either - so the menu popped back open and restarted `RaidMarkerSelectMapState`.

Fix: a new `_circleMenuClosing` flag, set for the duration of the queued fade-out. While it's set,
`_cleanupCircleMenu()` is a no-op and reports "no menu was cleaned up" - the already-queued cleanup
is left to finish on its own once its delay elapses. `_circleMenu` itself stays non-null throughout
(not nulled eagerly), so the existing `_circleMenu === null` guards in `_openRaidMarkerMenu()` and
`_mouseOut()` are untouched.

## Test plan
- [x] New regression test in `enemyvisual.circlemenu.test.js` reproducing the exact race: open the
  menu, close it (starts the fade), then call `_cleanupCircleMenu(false)` as `buildVisual()` would -
  asserts it's no longer reported as reopenable, and that the original fade-out still completes
  normally afterwards. Confirmed this test fails without the fix (reverted the source change locally
  and re-ran it).
- [x] Second regression test covering the rebuild also detaching the still-fading radial from the
  document (the enemy's icon HTML gets replaced mid-fade) - the queued cleanup must still end the map
  state once its delay elapses rather than being silently skipped.
- [x] Full JS suite green (`npx vitest run`, 330 tests).
- [x] Independent fresh-context review of the diff: no issues found.

## Visual verification
No static visual delta exists between master and this branch - the change is purely to internal
event-timing/state-machine logic (a flag guarding a callback re-entrancy window), not to markup,
styling, or layout, so a before/after screenshot pair would be pixel-identical and wouldn't show
anything meaningful. Loaded an existing route in headless Chrome as a smoke test instead (page loads
cleanly, map and enemies render normally, no new console/page errors) to confirm no regression from
the change. The actual race-condition fix - which requires precise sub-500ms timing against the real
raid-marker plugin - is exercised directly against real jQuery and the real `zikes-circlemenu` plugin
in `enemyvisual.circlemenu.test.js`, which is a stronger check than a manual UI reproduction would be.
