### PR TITLE
Stop the site header crashing once a season is seeded before it starts

### DIFF
--- a/app/Service/Dungeon/DungeonService.php
+++ b/app/Service/Dungeon/DungeonService.php
@@ -120,6 +120,16 @@ class DungeonService implements DungeonServiceInterface
         $currentSeason = $this->seasonService->getCurrentSeason($gameVersion->expansion);
         $nextSeason    = $currentSeason === null ? null : $this->seasonService->getNextSeason($currentSeason);
 
-        return ($nextSeason ?? $currentSeason)?->dungeons ?? $gameVersion->expansion->dungeons; // @phpstan-ignore nullsafe.neverNull
+        // Load the relation explicitly rather than reading it lazily. getNextSeason() returns a season out
+        // of a collection, so as soon as an upcoming season exists the lazy read trips preventLazyLoading
+        // and takes down every page that renders the header (HeaderComposer). This never fired before
+        // because getNextSeason() returned null while no future season was seeded, and the current season
+        // it fell back to is loaded as a single model, which the guard exempts.
+        //
+        // Deliberately dungeons()->get() and NOT loadMissing(): SeasonService keeps its season models in a
+        // service-level cache, so memoising the relation onto them makes it outlive the request and leak a
+        // stale dungeon list into later ones. That was measurable - loadMissing() turned the suite red with
+        // a route being created against the wrong dungeon.
+        return ($nextSeason ?? $currentSeason)?->dungeons()->get() ?? $gameVersion->expansion->dungeons;
     }
 }

--- a/tests/Feature/App/Service/Dungeon/DungeonService/GetDungeonsForGameVersionTest.php
+++ b/tests/Feature/App/Service/Dungeon/DungeonService/GetDungeonsForGameVersionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\App\Service\Dungeon\DungeonService;
+
+use App\Models\GameVersion\GameVersion;
+use App\Models\Season;
+use App\Service\Cookies\CookieServiceInterface;
+use App\Service\Dungeon\DungeonService;
+use App\Service\Dungeon\Logging\DungeonServiceLoggingInterface;
+use App\Service\GameVersion\GameVersionServiceInterface;
+use App\Service\Season\SeasonServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('DungeonService')]
+#[Group('GetDungeonsForGameVersion')]
+final class GetDungeonsForGameVersionTest extends PublicTestCase
+{
+    /**
+     * Builds the service with everything but the season service stubbed out - the season service is
+     * the only collaborator this method's behaviour depends on.
+     */
+    private function buildService(SeasonServiceInterface $seasonService): DungeonService
+    {
+        return new DungeonService(
+            $this->createMockPublic(CookieServiceInterface::class),
+            $seasonService,
+            $this->createMockPublic(DungeonServiceLoggingInterface::class),
+            $this->createMockPublic(GameVersionServiceInterface::class),
+        );
+    }
+
+    /**
+     * Scenario: a season has been seeded before its start date, so getNextSeason() returns a season
+     * instead of null. Reading its dungeons lazily throws, and because HeaderComposer calls this for
+     * the site header that takes down every page rendering layouts/sitepage.blade.php (#3746).
+     */
+    #[Test]
+    public function getDungeonsForGameVersion_givenAnUpcomingSeason_returnsThatSeasonsDungeons(): void
+    {
+        // Arrange - both seasons come out of a multi-row result on purpose. That is what
+        // SeasonService hands back, and preventLazyLoading only enforces on models loaded as part of
+        // a collection - a single-model load is exempt, which is why the current-season fallback
+        // never tripped this.
+        $seasons = Season::query()->orderByDesc('id')->limit(2)->get();
+
+        $this->assertCount(2, $seasons, 'Need at least two seeded seasons to load them as a collection');
+
+        $nextSeason    = $seasons->first();
+        $currentSeason = $seasons->last();
+
+        $seasonService = $this->createMockPublic(SeasonServiceInterface::class);
+        $seasonService->method('getCurrentSeason')->willReturn($currentSeason);
+        $seasonService->method('getNextSeason')->willReturn($nextSeason);
+
+        $gameVersion = GameVersion::firstWhere('key', GameVersion::GAME_VERSION_RETAIL);
+
+        // Act
+        $dungeons = $this->buildService($seasonService)->getDungeonsForGameVersion($gameVersion);
+
+        // Assert
+        $this->assertEqualsCanonicalizing(
+            $nextSeason->dungeons()->pluck('dungeons.id')->all(),
+            $dungeons->pluck('id')->all(),
+        );
+    }
+
+    /**
+     * Scenario: no season has been seeded ahead of its start date, so the method falls back to the
+     * current season. In production that season is loaded as a single model and the guard exempts
+     * it, which is why this path never crashed - it is loaded as a collection here so the fallback
+     * is covered by the same guarantee as the branch above.
+     */
+    #[Test]
+    public function getDungeonsForGameVersion_givenNoUpcomingSeason_returnsTheCurrentSeasonsDungeons(): void
+    {
+        // Arrange - loaded as a collection for the same reason as the test above
+        $seasons       = Season::query()->orderByDesc('id')->limit(2)->get();
+        $currentSeason = $seasons->last();
+
+        $seasonService = $this->createMockPublic(SeasonServiceInterface::class);
+        $seasonService->method('getCurrentSeason')->willReturn($currentSeason);
+        $seasonService->method('getNextSeason')->willReturn(null);
+
+        $gameVersion = GameVersion::firstWhere('key', GameVersion::GAME_VERSION_RETAIL);
+
+        // Act
+        $dungeons = $this->buildService($seasonService)->getDungeonsForGameVersion($gameVersion);
+
+        // Assert
+        $this->assertEqualsCanonicalizing(
+            $currentSeason->dungeons()->pluck('dungeons.id')->all(),
+            $dungeons->pluck('id')->all(),
+        );
+    }
+}


### PR DESCRIPTION
:robot:

Closes #3746

Extracted from #3739 so it can merge on its own — that PR carries the whole Midnight S2 dry run and
is pinned to an unmerged MDT PTR branch, and this fix blocks anyone who seeds a future season
locally.

`DungeonService::getDungeonsForGameVersion()` read `$nextSeason->dungeons` lazily. `getNextSeason()`
returns a season out of `SeasonService`'s multi-row season cache, so `preventLazyLoading` enforces on
it — unlike the current season it falls back to, which is loaded as a single model and is exempt.

That made the crash **dormant rather than absent**. While no future season exists `getNextSeason()`
returns `null` and the lazy read never fires. Seed a season before its start date — normal practice
when preparing one — and it throws. `HeaderComposer` builds the site header with this, so it is not
scoped to one page: **every page rendering `layouts/sitepage.blade.php` 500s in dev and logs a
violation in production.**

It did exactly that on the local dev site while #3739 was seeding Midnight S2 — every page including
`/` returned 500 with `Attempted to lazy load [dungeons] on model [App\Models\Season]`.

## The fix

```diff
-return ($nextSeason ?? $currentSeason)?->dungeons ?? $gameVersion->expansion->dungeons;
+return ($nextSeason ?? $currentSeason)?->dungeons()->get() ?? $gameVersion->expansion->dungeons;
```

`dungeons()->get()` and deliberately **not** `loadMissing()`: `SeasonService` keeps its season models
in a service-level cache, so memoising the relation onto them makes it outlive the request and leak a
stale dungeon list into later ones. That was measured in #3739 — `loadMissing()` turned the suite red
with a route being created against the wrong dungeon.

## Tests

Two, both in a new `GetDungeonsForGameVersionTest` alongside the existing `GetDungeonContextTest`:
the upcoming-season branch and the current-season fallback. **Both fail with a
`LazyLoadingViolationException` without the one-line change** — verified by stashing it and re-running.

They load the seasons as a collection on purpose. A single-model load is exempt from the guard, which
is precisely why the fallback path never tripped it, so a test that fetched one season with `first()`
would pass with or without the fix and prove nothing.

The file is identical to #3739's version of it, so that PR's diff collapses on rebase once this
merges.
