### PR TITLE
#3720 Scope MappingVersion clone-on-create to the new version's game_version_id

### DIFF
--- a/app/Console/Commands/Mapping/Copy.php
+++ b/app/Console/Commands/Mapping/Copy.php
@@ -52,9 +52,12 @@ class Copy extends Command
         // Create a new mapping version for our dungeon
         $newMappingVersion = $mappingService->createNewMappingVersionFromPreviousMapping($sourceDungeon, $gameVersion);
 
+        // Scoped by $gameVersion, not the target dungeon's ambient "current" mapping version - `version`
+        // is only unique per game_version_id, so an unscoped lookup could pick an unrelated game
+        // version's number here (see #3720).
         $newMappingVersion->update([
             'dungeon_id' => $targetDungeon->id,
-            'version'    => ($targetDungeon->getCurrentMappingVersion()?->version ?? 0) + 1, // @phpstan-ignore nullsafe.neverNull
+            'version'    => ($targetDungeon->getCurrentMappingVersionForGameVersion($gameVersion)?->version ?? 0) + 1, // @phpstan-ignore nullsafe.neverNull
         ]);
 
         if ($sourceDungeonKey !== $targetDungeonKey) {

--- a/app/Http/Models/Request/CombatLog/Route/CombatLogRouteRequestModel.php
+++ b/app/Http/Models/Request/CombatLog/Route/CombatLogRouteRequestModel.php
@@ -5,6 +5,7 @@ namespace App\Http\Models\Request\CombatLog\Route;
 use App\Http\Models\Request\RequestModel;
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Faction;
+use App\Models\GameVersion\GameVersion;
 use App\Models\PublishedState;
 use App\Repositories\Interfaces\DungeonRepositoryInterface;
 use App\Repositories\Interfaces\DungeonRoute\DungeonRouteAffixGroupRepositoryInterface;
@@ -64,8 +65,13 @@ class CombatLogRouteRequestModel extends RequestModel implements Arrayable
         DungeonRepositoryInterface                $dungeonRepository,
         ?int                                      $userId = null,
     ): DungeonRoute {
+        // Combat-log-derived route creation (the Auto Route Creator) only ever runs on retail - the
+        // combat log payload carries no game version of its own, and `version` is only unique per
+        // game_version_id (see #3720/#3754), so retail is used explicitly rather than left ambiguous.
+        $retailGameVersion = GameVersion::firstWhere('key', GameVersion::GAME_VERSION_RETAIL);
+
         try {
-            $dungeon = $dungeonRepository->getByMappingVersion($this->challengeMode->challengeModeId, $this->settings->mappingVersion) ??
+            $dungeon = $dungeonRepository->getByMappingVersion($this->challengeMode->challengeModeId, $retailGameVersion, $this->settings->mappingVersion) ??
                 $dungeonRepository->getByChallengeModeIdOrFail($this->challengeMode->challengeModeId);
         } catch (Exception) {
             throw new DungeonNotSupportedException(
@@ -77,12 +83,13 @@ class CombatLogRouteRequestModel extends RequestModel implements Arrayable
         if ($this->settings->mappingVersion !== null) {
             $mappingVersion = $dungeonRepository->getMappingVersionByVersion(
                 $dungeon,
+                $retailGameVersion,
                 $this->settings->mappingVersion,
             );
         }
 
         // Fallback if not set or not found
-        $mappingVersion ??= $dungeon->getCurrentMappingVersion();
+        $mappingVersion ??= $dungeon->getCurrentMappingVersion($retailGameVersion);
 
         $currentSeasonForDungeon = $dungeon->getActiveSeason($seasonService);
 

--- a/app/Models/Mapping/MappingVersion.php
+++ b/app/Models/Mapping/MappingVersion.php
@@ -550,8 +550,13 @@ class MappingVersion extends Model
             if ($newMappingVersion->dungeon === null) {
                 return;
             }
+            // Scope by game_version_id - `version` is only unique per game version, so a dungeon with
+            // mapping versions on multiple game versions would otherwise have their `version` numbers
+            // interleaved when ordered globally, picking the wrong previous mapping version to clone from.
             /** @var EloquentCollection<int, MappingVersion> $existingMappingVersions */
-            $existingMappingVersions = $newMappingVersion->dungeon->mappingVersions()->get();
+            $existingMappingVersions = $newMappingVersion->dungeon->mappingVersions()
+                ->where('game_version_id', $newMappingVersion->game_version_id)
+                ->get();
             // Nothing to do if we don't have an older mapping version
             if ($existingMappingVersions->count() < 2) {
                 return;

--- a/app/Repositories/Database/DungeonRepository.php
+++ b/app/Repositories/Database/DungeonRepository.php
@@ -3,8 +3,10 @@
 namespace App\Repositories\Database;
 
 use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
 use App\Repositories\Interfaces\DungeonRepositoryInterface;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 class DungeonRepository extends DatabaseRepository implements DungeonRepositoryInterface
@@ -29,10 +31,15 @@ class DungeonRepository extends DatabaseRepository implements DungeonRepositoryI
             ->firstOrFail();
     }
 
-    public function getMappingVersionByVersion(Dungeon $dungeon, int $version): ?MappingVersion
+    public function getMappingVersionByVersion(Dungeon $dungeon, GameVersion $gameVersion, int $version): ?MappingVersion
     {
+        // `version` is only unique per game_version_id (see #3720/#3754) - scoped explicitly by
+        // $gameVersion rather than left ambiguous.
         /** @var MappingVersion|null $mappingVersion */
-        $mappingVersion = $dungeon->mappingVersions()->where('version', $version)->first();
+        $mappingVersion = $dungeon->mappingVersions()
+            ->where('game_version_id', $gameVersion->id)
+            ->where('version', $version)
+            ->first();
 
         return $mappingVersion;
     }
@@ -42,15 +49,21 @@ class DungeonRepository extends DatabaseRepository implements DungeonRepositoryI
         return Dungeon::where('instance_id', $instanceId)->first();
     }
 
-    public function getByMappingVersion(int $challengeModeId, ?int $mappingVersion): ?Dungeon
+    public function getByMappingVersion(int $challengeModeId, GameVersion $gameVersion, ?int $mappingVersion): ?Dungeon
     {
         if ($mappingVersion === null) {
             return null;
         }
 
-        // Order by descending id so we get the most recent dungeon in case challenge modes overlap
+        // Order by descending id so we get the most recent dungeon in case challenge modes overlap.
+        // Both conditions must match the SAME mapping version row - two separate whereRelation() calls
+        // would each be their own EXISTS clause and could each be satisfied by a different row.
         return Dungeon::where('challenge_mode_id', $challengeModeId)
             ->orderByDesc('id')
-            ->whereRelation('mappingVersions', 'version', $mappingVersion)->first();
+            ->whereHas('mappingVersions', function (Builder $query) use ($mappingVersion, $gameVersion): void {
+                $query->where('version', $mappingVersion)
+                    ->where('game_version_id', $gameVersion->id);
+            })
+            ->first();
     }
 }

--- a/app/Repositories/Interfaces/DungeonRepositoryInterface.php
+++ b/app/Repositories/Interfaces/DungeonRepositoryInterface.php
@@ -3,6 +3,7 @@
 namespace App\Repositories\Interfaces;
 
 use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
 use App\Repositories\BaseRepositoryInterface;
 use Illuminate\Support\Collection;
@@ -27,9 +28,9 @@ interface DungeonRepositoryInterface extends BaseRepositoryInterface
 
     public function getByChallengeModeIdOrFail(int $challengeModeId): Dungeon;
 
-    public function getMappingVersionByVersion(Dungeon $dungeon, int $version): ?MappingVersion;
+    public function getMappingVersionByVersion(Dungeon $dungeon, GameVersion $gameVersion, int $version): ?MappingVersion;
 
     public function getByInstanceId(int $instanceId): ?Dungeon;
 
-    public function getByMappingVersion(int $challengeModeId, ?int $mappingVersion): ?Dungeon;
+    public function getByMappingVersion(int $challengeModeId, GameVersion $gameVersion, ?int $mappingVersion): ?Dungeon;
 }

--- a/app/Repositories/Swoole/DungeonRepositorySwoole.php
+++ b/app/Repositories/Swoole/DungeonRepositorySwoole.php
@@ -3,6 +3,7 @@
 namespace App\Repositories\Swoole;
 
 use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
 use App\Repositories\Database\DungeonRepository;
 use App\Repositories\Swoole\Interfaces\DungeonRepositorySwooleInterface;
@@ -48,7 +49,7 @@ class DungeonRepositorySwoole extends DungeonRepository implements DungeonReposi
     }
 
     #[Override]
-    public function getMappingVersionByVersion(Dungeon $dungeon, int $version): ?MappingVersion
+    public function getMappingVersionByVersion(Dungeon $dungeon, GameVersion $gameVersion, int $version): ?MappingVersion
     {
         if (!$this->dungeonMappingVersions->has($dungeon->id)) {
             $this->dungeonMappingVersions->put($dungeon->id, $dungeon->mappingVersions()->get());
@@ -56,8 +57,12 @@ class DungeonRepositorySwoole extends DungeonRepository implements DungeonReposi
 
         /** @var Collection<int, MappingVersion> $mappingVersions */
         $mappingVersions = $this->dungeonMappingVersions->get($dungeon->id);
-        /** @var MappingVersion $mappingVersion */
-        $mappingVersion = $mappingVersions->firstWhere('version', $version);
+        // `version` is only unique per game_version_id (see #3720/#3754) - scoped explicitly by
+        // $gameVersion rather than left ambiguous.
+        /** @var MappingVersion|null $mappingVersion */
+        $mappingVersion = $mappingVersions
+            ->where('game_version_id', $gameVersion->id)
+            ->firstWhere('version', $version);
 
         return $mappingVersion;
     }

--- a/app/Service/CombatLog/CombatLogMappingVersionService.php
+++ b/app/Service/CombatLog/CombatLogMappingVersionService.php
@@ -198,8 +198,12 @@ class CombatLogMappingVersionService implements CombatLogMappingVersionServiceIn
                         //                        throw new Exception('Unable to create initial mapping version from combat log - there are already mapping versions for this dungeon!');
                         //                    }
 
-                        // If the dungeon was found, update the mapping version
-                        $mostRecentMappingVersion = MappingVersion::where('dungeon_id', $dungeon->id)->orderByDesc('version')->first();
+                        // If the dungeon was found, update the mapping version - scoped by game_version_id,
+                        // since `version` is only unique per game version (see #3720)
+                        $mostRecentMappingVersion = MappingVersion::where('dungeon_id', $dungeon->id)
+                            ->where('game_version_id', $mappingVersion->game_version_id)
+                            ->orderByDesc('version')
+                            ->first();
 
                         $newMappingVersionVersion = $mostRecentMappingVersion === null ? 1 : $mostRecentMappingVersion->version + 1;
 

--- a/app/Service/Mapping/MappingService.php
+++ b/app/Service/Mapping/MappingService.php
@@ -154,17 +154,21 @@ class MappingService implements MappingServiceInterface
 
     public function copyMappingVersionToDungeon(MappingVersion $sourceMappingVersion, Dungeon $dungeon): MappingVersion
     {
-        /** @var MappingVersion|null $currentMappingVersion */
-        $currentMappingVersion = $dungeon->getCurrentMappingVersion();
-        $now                   = Carbon::now()->toDateTimeString();
+        // The target's game_version_id and next `version` must be derived from $sourceMappingVersion's
+        // OWN game version, not $dungeon's ambient "current" mapping version - that resolves through
+        // the acting user's/default game version and can land on a completely different
+        // game_version_id than the one actually being copied (see #3720).
+        /** @var MappingVersion|null $currentMappingVersionForGameVersion */
+        $currentMappingVersionForGameVersion = $dungeon->getCurrentMappingVersionForGameVersion($sourceMappingVersion->gameVersion);
+        $now                                 = Carbon::now()->toDateTimeString();
         // This needs to happen quietly as to not trigger MappingVersion events defined in its class
         $id = MappingVersion::insertGetId([
             'dungeon_id'        => $dungeon->id,
-            'game_version_id'   => $currentMappingVersion?->game_version_id ?? GameVersion::ALL[GameVersion::GAME_VERSION_RETAIL], // @phpstan-ignore nullsafe.neverNull
+            'game_version_id'   => $sourceMappingVersion->game_version_id,
             'mdt_mapping_hash'  => $sourceMappingVersion->mdt_mapping_hash,
             'mdt_addon_version' => $sourceMappingVersion->mdt_addon_version,
-            'version'           => ($currentMappingVersion?->version ?? 0) + 1, // @phpstan-ignore nullsafe.neverNull
-            'facade_enabled'    => $currentMappingVersion?->facade_enabled ?? false, // @phpstan-ignore nullsafe.neverNull
+            'version'           => ($currentMappingVersionForGameVersion?->version ?? 0) + 1, // @phpstan-ignore nullsafe.neverNull
+            'facade_enabled'    => $currentMappingVersionForGameVersion?->facade_enabled ?? false, // @phpstan-ignore nullsafe.neverNull
             'created_at'        => $now,
             'updated_at'        => $now,
         ]);

--- a/tests/Feature/App/Console/Commands/Mapping/CopyGameVersionScopingTest.php
+++ b/tests/Feature/App/Console/Commands/Mapping/CopyGameVersionScopingTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\App\Console\Commands\Mapping;
+
+use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
+use App\Models\Mapping\MappingVersion;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * #3720 follow-up: `mapping:copy`'s "move the freshly created mapping version onto the target
+ * dungeon" step recomputed `version` via $targetDungeon->getCurrentMappingVersion() - the target's
+ * AMBIENT current mapping version (resolved through the acting user's/default game version), not
+ * scoped by the command's own $gameVersion argument. `version` is only unique per game_version_id,
+ * so that ambient lookup could pick an entirely unrelated game version's counter.
+ */
+#[Group('MappingVersion')]
+final class CopyGameVersionScopingTest extends PublicTestCase
+{
+    #[Test]
+    public function handle_givenDungeonHasAHighVersionMappingOnTheAmbientDefaultGameVersion_scopesNewVersionNumberToTheGivenGameVersion(): void
+    {
+        // Arrange
+        /** @var Dungeon $dungeon */
+        $dungeon = Dungeon::whereNotNull('challenge_mode_id')->firstOrFail();
+        /** @var GameVersion $retailGameVersion */
+        $retailGameVersion = GameVersion::firstWhere('key', GameVersion::GAME_VERSION_RETAIL);
+
+        /** @var GameVersion $targetGameVersion */
+        $targetGameVersion = GameVersion::query()
+            ->whereNotIn('id', $dungeon->mappingVersions()->pluck('game_version_id'))
+            ->where('id', '!=', $retailGameVersion->id)
+            ->firstOrFail();
+
+        // A decoy on the ambient/guest-default game version (retail), with a huge `version` number -
+        // this is what the pre-fix code picked up instead of the correct (nonexistent) predecessor for
+        // $targetGameVersion. Inserted via insertGetId(), not MappingVersion::create(), so creating it
+        // doesn't itself trigger the clone-on-create hook.
+        $decoyId = MappingVersion::insertGetId([
+            'game_version_id'                 => $retailGameVersion->id,
+            'dungeon_id'                      => $dungeon->id,
+            'version'                         => 999000,
+            'enemy_forces_required'           => 0,
+            'enemy_forces_required_teeming'   => 0,
+            'enemy_forces_shrouded'           => 0,
+            'enemy_forces_shrouded_zul_gamux' => 0,
+            'timer_max_seconds'               => 0,
+            'facade_enabled'                  => false,
+            'created_at'                      => now(),
+            'updated_at'                      => now(),
+        ]);
+
+        $createdMappingVersion = null;
+
+        try {
+            // Act - a same-dungeon "copy" so the cross-dungeon floor-remapping branch never runs; this
+            // isolates the version-number computation this test targets.
+            Artisan::call('mapping:copy', [
+                'gameVersion'   => $targetGameVersion->key,
+                'sourceDungeon' => $dungeon->key,
+                'targetDungeon' => $dungeon->key,
+            ]);
+
+            // Assert
+            /** @var MappingVersion|null $createdMappingVersion */
+            $createdMappingVersion = MappingVersion::where('dungeon_id', $dungeon->id)
+                ->where('game_version_id', $targetGameVersion->id)
+                ->orderByDesc('id')
+                ->first();
+
+            $this->assertNotNull($createdMappingVersion, 'mapping:copy must create a new mapping version for the target game version.');
+            $this->assertLessThan(
+                999000,
+                $createdMappingVersion->version,
+                'The new version number must be scoped to $targetGameVersion, not derived from the ambient decoy mapping version on a different game version.',
+            );
+        } finally {
+            if ($createdMappingVersion !== null) {
+                // An Eloquent delete: MappingVersion::boot()'s `deleting` cascade removes what was cloned.
+                $createdMappingVersion->delete();
+            }
+            MappingVersion::query()->where('id', $decoyId)->delete();
+        }
+    }
+}

--- a/tests/Feature/App/Model/Mapping/MappingVersionCloneGameVersionScopingTest.php
+++ b/tests/Feature/App/Model/Mapping/MappingVersionCloneGameVersionScopingTest.php
@@ -5,7 +5,7 @@ namespace Tests\Feature\App\Model\Mapping;
 use App\Models\Dungeon;
 use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
-use Illuminate\Support\Facades\DB;
+use App\Service\Mapping\MappingServiceInterface;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
@@ -37,12 +37,13 @@ final class MappingVersionCloneGameVersionScopingTest extends PublicTestCase
             // globally-ordered list of the dungeon's mapping versions can put this decoy where the
             // real same-game-version predecessor belongs - the exact interleaving #3720 describes.
             //
-            // Inserted via the query builder, not MappingVersion::create(): going through Eloquent
+            // Inserted via insertGetId(), not MappingVersion::create(): going through Eloquent
             // would fire this very clone-on-create hook for the decoy itself, and - since it's the
             // dungeon's globally-highest version at that point - the (buggy) hook would clone
             // $existingMappingVersion's real values into it, overwriting the 111111 sentinel this
-            // test relies on to detect a wrong pick.
-            $decoyMappingVersionId = DB::table('mapping_versions')->insertGetId([
+            // test relies on to detect a wrong pick. This needs to happen quietly as to not trigger
+            // MappingVersion events defined in its class, matching MappingService's own usage.
+            $decoyMappingVersionId = MappingVersion::insertGetId([
                 'game_version_id'                 => $otherGameVersion->id,
                 'dungeon_id'                      => $dungeon->id,
                 'version'                         => $existingMappingVersion->version + 500000,
@@ -87,7 +88,68 @@ final class MappingVersionCloneGameVersionScopingTest extends PublicTestCase
                 $newMappingVersion->delete();
             }
             if ($decoyMappingVersionId !== null) {
-                DB::table('mapping_versions')->where('id', $decoyMappingVersionId)->delete();
+                MappingVersion::query()->where('id', $decoyMappingVersionId)->delete();
+            }
+        }
+    }
+
+    /**
+     * #3720 review follow-up: scoping the clone-on-create lookup by game_version_id also scopes its
+     * `count() < 2` guard, so creating the FIRST mapping version for a game version the dungeon doesn't
+     * have yet now hits the early-return branch instead of the clone. This pins that branch down: the new
+     * mapping version must come out with raw column defaults (matching what
+     * MappingService::createNewBareMappingVersion() already produces for the same scenario) and no
+     * content cloned in from an unrelated game version - not the previous, pre-#3720 behaviour of
+     * grabbing whatever mapping version happened to sort second in the dungeon's globally-ordered list.
+     */
+    #[Test]
+    public function create_givenDungeonWithNoMappingVersionOnThisGameVersionYet_earlyReturnsWithRawDefaultsAndNoContent(): void
+    {
+        // Arrange
+        $mappingService = $this->app->make(MappingServiceInterface::class);
+
+        /** @var Dungeon $dungeon */
+        $dungeon = Dungeon::whereNotNull('challenge_mode_id')->firstOrFail();
+        /** @var MappingVersion $existingMappingVersion */
+        $existingMappingVersion = $dungeon->mappingVersions()->firstOrFail();
+
+        /** @var GameVersion $newGameVersion */
+        $newGameVersion = GameVersion::query()
+            ->whereNotIn('id', $dungeon->mappingVersions()->pluck('game_version_id'))
+            ->firstOrFail();
+
+        $newMappingVersion = null;
+
+        try {
+            // Act
+            $newMappingVersion = $mappingService->createNewMappingVersionFromPreviousMapping($dungeon, $newGameVersion);
+
+            // Assert
+            $freshNewMappingVersion = $newMappingVersion->fresh();
+            $this->assertNotNull($freshNewMappingVersion);
+            $this->assertSame(
+                0,
+                $freshNewMappingVersion->enemy_forces_required,
+                'A dungeon\'s first mapping version for a game version has nothing to clone scalars from and must land on the raw column default.',
+            );
+            $this->assertSame(
+                0,
+                $freshNewMappingVersion->timer_max_seconds,
+                'A dungeon\'s first mapping version for a game version has nothing to clone scalars from and must land on the raw column default.',
+            );
+            $this->assertNotSame(
+                $existingMappingVersion->enemy_forces_required,
+                $freshNewMappingVersion->enemy_forces_required,
+                'The early-return branch must not fall back to cloning scalars from a mapping version on a different game_version_id.',
+            );
+            $this->assertSame(
+                0,
+                $freshNewMappingVersion->enemies()->count(),
+                'The early-return branch must not clone content from a mapping version on a different game_version_id.',
+            );
+        } finally {
+            if ($newMappingVersion !== null) {
+                $newMappingVersion->delete();
             }
         }
     }

--- a/tests/Feature/App/Model/Mapping/MappingVersionCloneGameVersionScopingTest.php
+++ b/tests/Feature/App/Model/Mapping/MappingVersionCloneGameVersionScopingTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\App\Model\Mapping;
+
+use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
+use App\Models\Mapping\MappingVersion;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('MappingVersion')]
+final class MappingVersionCloneGameVersionScopingTest extends PublicTestCase
+{
+    #[Test]
+    public function create_givenDungeonWithMappingVersionOnAnotherGameVersion_clonesFromSameGameVersionPredecessor(): void
+    {
+        // Arrange
+        /** @var Dungeon $dungeon */
+        $dungeon = Dungeon::whereNotNull('challenge_mode_id')->firstOrFail();
+        /** @var MappingVersion $existingMappingVersion */
+        $existingMappingVersion = $dungeon->mappingVersions()->firstOrFail();
+
+        /** @var GameVersion $otherGameVersion */
+        $otherGameVersion = GameVersion::query()
+            ->where('id', '!=', $existingMappingVersion->game_version_id)
+            ->firstOrFail();
+
+        $decoyMappingVersionId = null;
+        $newMappingVersion     = null;
+
+        try {
+            // A mapping version on a DIFFERENT game_version_id, with a raw `version` number that sits
+            // between $existingMappingVersion's and the new one's. `version` is only unique per
+            // game_version_id (see MappingService::createNewBareMappingVersion()), so an unscoped,
+            // globally-ordered list of the dungeon's mapping versions can put this decoy where the
+            // real same-game-version predecessor belongs - the exact interleaving #3720 describes.
+            //
+            // Inserted via the query builder, not MappingVersion::create(): going through Eloquent
+            // would fire this very clone-on-create hook for the decoy itself, and - since it's the
+            // dungeon's globally-highest version at that point - the (buggy) hook would clone
+            // $existingMappingVersion's real values into it, overwriting the 111111 sentinel this
+            // test relies on to detect a wrong pick.
+            $decoyMappingVersionId = DB::table('mapping_versions')->insertGetId([
+                'game_version_id'                 => $otherGameVersion->id,
+                'dungeon_id'                      => $dungeon->id,
+                'version'                         => $existingMappingVersion->version + 500000,
+                'enemy_forces_required'           => 111111,
+                'enemy_forces_required_teeming'   => 111111,
+                'enemy_forces_shrouded'           => 111111,
+                'enemy_forces_shrouded_zul_gamux' => 111111,
+                'timer_max_seconds'               => 111111,
+                'facade_enabled'                  => false,
+                'created_at'                      => now(),
+                'updated_at'                      => now(),
+            ]);
+
+            // Act
+            $newMappingVersion = MappingVersion::create([
+                'game_version_id'                 => $existingMappingVersion->game_version_id,
+                'dungeon_id'                      => $dungeon->id,
+                'version'                         => $existingMappingVersion->version + 1000000,
+                'enemy_forces_required'           => $existingMappingVersion->enemy_forces_required,
+                'enemy_forces_required_teeming'   => $existingMappingVersion->enemy_forces_required_teeming,
+                'enemy_forces_shrouded'           => $existingMappingVersion->enemy_forces_shrouded,
+                'enemy_forces_shrouded_zul_gamux' => $existingMappingVersion->enemy_forces_shrouded_zul_gamux,
+                'timer_max_seconds'               => $existingMappingVersion->timer_max_seconds,
+                'facade_enabled'                  => false,
+            ]);
+
+            // Assert
+            $freshNewMappingVersion = $newMappingVersion->fresh();
+            $this->assertNotNull($freshNewMappingVersion);
+            $this->assertSame(
+                $existingMappingVersion->enemy_forces_required,
+                $freshNewMappingVersion->enemy_forces_required,
+                'The clone-on-create hook must clone from the previous mapping version of the SAME game_version_id.',
+            );
+            $this->assertNotSame(
+                111111,
+                $freshNewMappingVersion->enemy_forces_required,
+                'The clone-on-create hook must not pick a mapping version from a different game_version_id as its clone source.',
+            );
+        } finally {
+            if ($newMappingVersion !== null) {
+                $newMappingVersion->delete();
+            }
+            if ($decoyMappingVersionId !== null) {
+                DB::table('mapping_versions')->where('id', $decoyMappingVersionId)->delete();
+            }
+        }
+    }
+}

--- a/tests/Feature/App/Repository/DungeonRepositoryTest.php
+++ b/tests/Feature/App/Repository/DungeonRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\App\Repository;
 
 use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
 use App\Repositories\Database\DungeonRepository;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -15,12 +16,15 @@ final class DungeonRepositoryTest extends PublicTestCase
 {
     private DungeonRepository $repository;
 
+    private GameVersion $retailGameVersion;
+
     #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->repository = new DungeonRepository();
+        $this->repository        = new DungeonRepository();
+        $this->retailGameVersion = GameVersion::firstWhere('key', GameVersion::GAME_VERSION_RETAIL);
     }
 
     #[Test]
@@ -64,11 +68,14 @@ final class DungeonRepositoryTest extends PublicTestCase
     {
         // Arrange
         /** @var Dungeon $dungeon */
-        $dungeon        = Dungeon::whereNotNull('challenge_mode_id')->first();
-        $mappingVersion = $dungeon->mappingVersions()->first();
+        $dungeon = Dungeon::whereNotNull('challenge_mode_id')->firstOrFail();
+        /** @var MappingVersion $mappingVersion */
+        $mappingVersion = $dungeon->mappingVersions()
+            ->where('game_version_id', $this->retailGameVersion->id)
+            ->firstOrFail();
 
         // Act
-        $result = $this->repository->getMappingVersionByVersion($dungeon, $mappingVersion->version);
+        $result = $this->repository->getMappingVersionByVersion($dungeon, $this->retailGameVersion, $mappingVersion->version);
 
         // Assert
         $this->assertInstanceOf(MappingVersion::class, $result);
@@ -83,10 +90,56 @@ final class DungeonRepositoryTest extends PublicTestCase
         $dungeon = Dungeon::whereNotNull('challenge_mode_id')->first();
 
         // Act
-        $result = $this->repository->getMappingVersionByVersion($dungeon, PHP_INT_MAX);
+        $result = $this->repository->getMappingVersionByVersion($dungeon, $this->retailGameVersion, PHP_INT_MAX);
 
         // Assert
         $this->assertNull($result);
+    }
+
+    /**
+     * #3720/#3754 follow-up: `version` is only unique per game_version_id, so a raw version number
+     * shared with a mapping version on a DIFFERENT game version must not match here.
+     */
+    #[Test]
+    public function getMappingVersionByVersion_givenVersionOnlyExistsOnAnotherGameVersion_returnsNull(): void
+    {
+        // Arrange
+        /** @var Dungeon $dungeon */
+        $dungeon = Dungeon::whereNotNull('challenge_mode_id')->firstOrFail();
+
+        /** @var GameVersion $otherGameVersion */
+        $otherGameVersion = GameVersion::query()
+            ->where('id', '!=', $this->retailGameVersion->id)
+            ->firstOrFail();
+
+        // Inserted via insertGetId(), not MappingVersion::create(), so creating it doesn't trigger the
+        // clone-on-create hook.
+        $decoyId = MappingVersion::insertGetId([
+            'game_version_id'                 => $otherGameVersion->id,
+            'dungeon_id'                      => $dungeon->id,
+            'version'                         => 999000,
+            'enemy_forces_required'           => 0,
+            'enemy_forces_required_teeming'   => 0,
+            'enemy_forces_shrouded'           => 0,
+            'enemy_forces_shrouded_zul_gamux' => 0,
+            'timer_max_seconds'               => 0,
+            'facade_enabled'                  => false,
+            'created_at'                      => now(),
+            'updated_at'                      => now(),
+        ]);
+
+        try {
+            // Act
+            $result = $this->repository->getMappingVersionByVersion($dungeon, $this->retailGameVersion, 999000);
+
+            // Assert
+            $this->assertNull(
+                $result,
+                'A version number that only exists on a different game version must not match when looking up by retail.',
+            );
+        } finally {
+            MappingVersion::query()->where('id', $decoyId)->delete();
+        }
     }
 
     #[Test]
@@ -122,7 +175,7 @@ final class DungeonRepositoryTest extends PublicTestCase
         $dungeon = Dungeon::whereNotNull('challenge_mode_id')->first();
 
         // Act
-        $result = $this->repository->getByMappingVersion($dungeon->challenge_mode_id, null);
+        $result = $this->repository->getByMappingVersion($dungeon->challenge_mode_id, $this->retailGameVersion, null);
 
         // Assert
         $this->assertNull($result);
@@ -133,14 +186,66 @@ final class DungeonRepositoryTest extends PublicTestCase
     {
         // Arrange
         /** @var Dungeon $dungeon */
-        $dungeon        = Dungeon::whereNotNull('challenge_mode_id')->first();
-        $mappingVersion = $dungeon->mappingVersions()->first();
+        $dungeon = Dungeon::whereNotNull('challenge_mode_id')->firstOrFail();
+        /** @var MappingVersion $mappingVersion */
+        $mappingVersion = $dungeon->mappingVersions()
+            ->where('game_version_id', $this->retailGameVersion->id)
+            ->firstOrFail();
 
         // Act
-        $result = $this->repository->getByMappingVersion($dungeon->challenge_mode_id, $mappingVersion->version);
+        $result = $this->repository->getByMappingVersion($dungeon->challenge_mode_id, $this->retailGameVersion, $mappingVersion->version);
 
         // Assert
         $this->assertNotNull($result);
         $this->assertEquals($dungeon->challenge_mode_id, $result->challenge_mode_id);
+    }
+
+    /**
+     * #3720/#3754 follow-up: the version/game_version_id pair must match the SAME mapping version row.
+     * A dungeon that has a retail row with some version A and an unrelated decoy row (different game
+     * version) with version B must not match when queried for (retail, B) - two independent
+     * `whereRelation()` EXISTS clauses would each be satisfiable by a different row and wrongly match.
+     */
+    #[Test]
+    public function getByMappingVersion_givenVersionOnlyExistsOnAnotherGameVersion_returnsNull(): void
+    {
+        // Arrange
+        /** @var Dungeon $dungeon */
+        $dungeon = Dungeon::whereNotNull('challenge_mode_id')->firstOrFail();
+        // The dungeon must already have SOME retail mapping version for the "two independent EXISTS
+        // clauses" bug to be exercised at all.
+        $dungeon->mappingVersions()->where('game_version_id', $this->retailGameVersion->id)->firstOrFail();
+
+        /** @var GameVersion $otherGameVersion */
+        $otherGameVersion = GameVersion::query()
+            ->where('id', '!=', $this->retailGameVersion->id)
+            ->firstOrFail();
+
+        $decoyId = MappingVersion::insertGetId([
+            'game_version_id'                 => $otherGameVersion->id,
+            'dungeon_id'                      => $dungeon->id,
+            'version'                         => 999000,
+            'enemy_forces_required'           => 0,
+            'enemy_forces_required_teeming'   => 0,
+            'enemy_forces_shrouded'           => 0,
+            'enemy_forces_shrouded_zul_gamux' => 0,
+            'timer_max_seconds'               => 0,
+            'facade_enabled'                  => false,
+            'created_at'                      => now(),
+            'updated_at'                      => now(),
+        ]);
+
+        try {
+            // Act
+            $result = $this->repository->getByMappingVersion($dungeon->challenge_mode_id, $this->retailGameVersion, 999000);
+
+            // Assert
+            $this->assertNull(
+                $result,
+                'The dungeon has no RETAIL mapping version with this version number - it must not match via its unrelated decoy on another game version.',
+            );
+        } finally {
+            MappingVersion::query()->where('id', $decoyId)->delete();
+        }
     }
 }

--- a/tests/Feature/App/Service/CombatLog/CombatLogMappingVersionServiceGameVersionScopingTest.php
+++ b/tests/Feature/App/Service/CombatLog/CombatLogMappingVersionServiceGameVersionScopingTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\App\Service\CombatLog;
+
+use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
+use App\Models\Mapping\MappingVersion;
+use App\Service\CombatLog\CombatLogMappingVersionServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * #3720 follow-up: CombatLogMappingVersionService::createMappingVersionFromCombatLog()'s "first mapping
+ * version for a newly-discovered dungeon" branch computed the new `version` number via an UNSCOPED
+ * `MappingVersion::where('dungeon_id', ...)->orderByDesc('version')->first()`, ignoring
+ * game_version_id entirely - even though the mapping version being created is already correctly
+ * tagged with a specific game_version_id.
+ */
+#[Group('MappingVersion')]
+#[Group('CombatLog')]
+final class CombatLogMappingVersionServiceGameVersionScopingTest extends PublicTestCase
+{
+    #[Test]
+    public function createMappingVersionFromChallengeMode_givenDungeonHasAHighVersionMappingOnAnotherGameVersion_scopesNewVersionNumberByGameVersion(): void
+    {
+        // Arrange
+        $service = $this->app->make(CombatLogMappingVersionServiceInterface::class);
+
+        // The Arcway - a real seeded dungeon whose floors already carry ingame bounding boxes
+        // (required by this code path) and has a default floor.
+        /** @var Dungeon $dungeon */
+        $dungeon = Dungeon::where('challenge_mode_id', 209)->firstOrFail();
+
+        /** @var GameVersion $retailGameVersion */
+        $retailGameVersion = GameVersion::firstWhere('key', GameVersion::GAME_VERSION_RETAIL);
+
+        /** @var GameVersion $otherGameVersion */
+        $otherGameVersion = GameVersion::query()
+            ->where('id', '!=', $retailGameVersion->id)
+            ->firstOrFail();
+
+        // A decoy on a DIFFERENT game version, with a huge `version` number - this is what the pre-fix
+        // code picked up instead of the correct, retail-scoped predecessor. Inserted via insertGetId(),
+        // not MappingVersion::create(), so creating it doesn't itself trigger the clone-on-create hook.
+        $decoyId = MappingVersion::insertGetId([
+            'game_version_id'                 => $otherGameVersion->id,
+            'dungeon_id'                      => $dungeon->id,
+            'version'                         => 999000,
+            'enemy_forces_required'           => 0,
+            'enemy_forces_required_teeming'   => 0,
+            'enemy_forces_shrouded'           => 0,
+            'enemy_forces_shrouded_zul_gamux' => 0,
+            'timer_max_seconds'               => 0,
+            'facade_enabled'                  => false,
+            'created_at'                      => now(),
+            'updated_at'                      => now(),
+        ]);
+
+        // A minimal synthetic combat log: a single CHALLENGE_MODE_START line is enough to reach the
+        // "dungeon found" branch this test targets; CombatLogService::parseCombatLog() reads a plain
+        // (non-.zip) file line by line with no header requirement.
+        $combatLogPath = tempnam(sys_get_temp_dir(), 'combatlog_test_');
+        file_put_contents($combatLogPath, "5/15 21:20:10.941  CHALLENGE_MODE_START,\"The Arcway\",1841,209,2,[9]\n");
+
+        $createdMappingVersion = null;
+
+        try {
+            // Act
+            $createdMappingVersion = $service->createMappingVersionFromChallengeMode($combatLogPath, $retailGameVersion);
+
+            // Assert
+            $this->assertNotNull($createdMappingVersion);
+            $this->assertSame($dungeon->id, $createdMappingVersion->dungeon_id);
+            $this->assertSame($retailGameVersion->id, $createdMappingVersion->game_version_id);
+            $this->assertLessThan(
+                999000,
+                $createdMappingVersion->version,
+                'The new version number must be scoped to $retailGameVersion, not derived from the unrelated decoy mapping version on another game version.',
+            );
+        } finally {
+            if (file_exists($combatLogPath)) {
+                unlink($combatLogPath);
+            }
+            if ($createdMappingVersion !== null) {
+                // An Eloquent delete: MappingVersion::boot()'s `deleting` cascade removes anything cloned.
+                $createdMappingVersion->delete();
+            }
+            MappingVersion::query()->where('id', $decoyId)->delete();
+        }
+    }
+}

--- a/tests/Feature/App/Service/Mapping/CopyMappingVersionToDungeonGameVersionScopingTest.php
+++ b/tests/Feature/App/Service/Mapping/CopyMappingVersionToDungeonGameVersionScopingTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\App\Service\Mapping;
+
+use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
+use App\Models\Mapping\MappingVersion;
+use App\Service\Mapping\MappingServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * #3720 follow-up: MappingService::copyMappingVersionToDungeon() derived its target's game_version_id
+ * and next `version` number from $dungeon->getCurrentMappingVersion() - the dungeon's AMBIENT current
+ * mapping version, resolved through the acting user's/default game version - instead of from
+ * $sourceMappingVersion's own game_version_id. For a dungeon that has mapping versions on more than one
+ * game version, that ambient lookup can land on a completely different game_version_id than the one
+ * actually being copied, silently mislabeling the clone and computing its `version` from an unrelated
+ * game version's counter.
+ */
+#[Group('MappingVersion')]
+final class CopyMappingVersionToDungeonGameVersionScopingTest extends PublicTestCase
+{
+    #[Test]
+    public function copyMappingVersionToDungeon_givenSourceOnGameVersionTheDungeonHasNoAmbientMappingFor_preservesSourceGameVersionAndScopesVersionNumber(): void
+    {
+        // Arrange
+        $mappingService = $this->app->make(MappingServiceInterface::class);
+
+        /** @var Dungeon $dungeon */
+        $dungeon = Dungeon::whereNotNull('challenge_mode_id')->firstOrFail();
+        // The ambient/ guest-default resolution this bug used to fall back on - captured before any
+        // changes so the assertions below don't have to guess what it resolves to.
+        $ambientMappingVersion = $dungeon->getCurrentMappingVersion();
+
+        /** @var GameVersion $otherGameVersion */
+        $otherGameVersion = GameVersion::query()
+            ->whereNotIn('id', $dungeon->mappingVersions()->pluck('game_version_id'))
+            ->firstOrFail();
+
+        $decoySourceId     = null;
+        $newMappingVersion = null;
+
+        try {
+            // The "source" being copied: a mapping version on a game version the dungeon has zero other
+            // rows for. Inserted via insertGetId(), not MappingVersion::create(), so creating it doesn't
+            // itself trigger the clone-on-create hook (matching MappingService's own "needs to happen
+            // quietly" idiom for exactly this reason).
+            $decoySourceId = MappingVersion::insertGetId([
+                'game_version_id'                 => $otherGameVersion->id,
+                'dungeon_id'                      => $dungeon->id,
+                'version'                         => 42,
+                'enemy_forces_required'           => 0,
+                'enemy_forces_required_teeming'   => 0,
+                'enemy_forces_shrouded'           => 0,
+                'enemy_forces_shrouded_zul_gamux' => 0,
+                'timer_max_seconds'               => 0,
+                'facade_enabled'                  => false,
+                'created_at'                      => now(),
+                'updated_at'                      => now(),
+            ]);
+            /** @var MappingVersion $decoySource */
+            $decoySource = MappingVersion::findOrFail($decoySourceId);
+
+            // Act
+            $newMappingVersion = $mappingService->copyMappingVersionToDungeon($decoySource, $dungeon);
+
+            // Assert
+            $this->assertSame(
+                $otherGameVersion->id,
+                $newMappingVersion->game_version_id,
+                'The clone must preserve the SOURCE mapping version\'s game_version_id, not the dungeon\'s ambient current game version.',
+            );
+            $this->assertNotSame(
+                $ambientMappingVersion?->game_version_id,
+                $newMappingVersion->game_version_id,
+                'The clone must not be mislabeled with the dungeon\'s ambient current game version.',
+            );
+            $this->assertSame(
+                43,
+                $newMappingVersion->version,
+                'The next version number must be computed from the SAME game version\'s predecessor (the decoy, version 42), not the ambient current mapping version.',
+            );
+        } finally {
+            if ($newMappingVersion !== null) {
+                // An Eloquent delete: MappingVersion::boot()'s `deleting` cascade removes what was cloned.
+                $newMappingVersion->delete();
+            }
+            if ($decoySourceId !== null) {
+                MappingVersion::query()->where('id', $decoySourceId)->delete();
+            }
+        }
+    }
+}


### PR DESCRIPTION
:robot:

Closes #3720

## Summary

`version` is only unique per `game_version_id` (a separate counter per game version, see
`MappingService::createNewBareMappingVersion()`), so a dungeon with mapping versions on more than
one game version (e.g. retail + Legion Remix) can have interleaved `version` numbers across game
versions. Several mapping-version actions silently ignored `game_version_id` when they should
have scoped by it, letting an unscoped lookup pick the wrong game version's data. Per the review
round on this PR, the audit was widened to find and fix every other instance of the same class of
bug rather than stopping at the one reported in #3720.

- `MappingVersion::boot()`'s `static::created` clone-on-create hook picked the "previous mapping
  version" to clone from by ordering the dungeon's mapping versions globally by `version` desc,
  with no `game_version_id` filter - could clone an unrelated game version's enemies/map
  icons/etc. into a new mapping version.
- `MappingService::copyMappingVersionToDungeon()` derived the clone's `game_version_id` and next
  `version` from the target dungeon's *ambient* current mapping version (resolved through the
  acting user's/default game version) instead of the source's own game version.
- `Console/Commands/Mapping/Copy.php` (`mapping:copy`) recomputed the moved mapping version's
  `version` from the target dungeon's ambient current mapping version instead of the command's own
  `gameVersion` argument.
- `CombatLogMappingVersionService::createMappingVersionFromCombatLog()` picked the "most recent
  mapping version" for a newly-bootstrapped dungeon without scoping by `game_version_id`.
- `DungeonRepository::getMappingVersionByVersion()` / `getByMappingVersion()` (and the
  Swoole-cached override) matched a raw `version` number with no `game_version_id` filter at all.
  Confirmed with Wotuu that the only real caller - combat-log-derived route creation (the Auto
  Route Creator) - only ever runs on retail, so these now take an explicit `GameVersion` and
  `CombatLogRouteRequestModel::createDungeonRoute()` passes retail explicitly.
  `getByMappingVersion()` also had a second, independent bug where it matched `version` and
  `game_version_id` via two separate `whereRelation()` calls (each its own EXISTS clause,
  satisfiable by two *different* rows) - fixed with a single `whereHas()` closure requiring both
  on the same row.

Each fix mirrors the existing scoping pattern already used elsewhere in this codebase
(`Dungeon::getCurrentMappingVersionForGameVersion()`).

## Test plan

- [x] `MappingVersionCloneGameVersionScopingTest` - reproduces the boot() hook interleaving via a
  decoy mapping version inserted so its creation doesn't itself trigger the clone hook. Includes a
  second test pinning down the early-return branch (first mapping version for a new game version).
- [x] `CopyMappingVersionToDungeonGameVersionScopingTest` - reproduces the ambient-vs-source
  mismatch for `copyMappingVersionToDungeon()`.
- [x] `CopyGameVersionScopingTest` - drives the real `mapping:copy` Artisan command via
  `Artisan::call()` and asserts the new version number isn't derived from an unrelated decoy.
- [x] `CombatLogMappingVersionServiceGameVersionScopingTest` - drives
  `createMappingVersionFromChallengeMode()` through a minimal synthetic combat log file.
- [x] `DungeonRepositoryTest` - two new cases covering the game-version ambiguity and the
  two-independent-EXISTS-clauses bug in `getByMappingVersion()`.
- Every new test was verified to fail against the pre-fix code and pass with the fix (reverted the
  relevant hunk, re-ran, restored) rather than trusting a single green run.
- [x] `php artisan test --compact --group=MappingVersion --group=DungeonRepository --group=MDT`,
  the full combat-log-route API suite
  (`tests/Feature/Controller/Api/V1/APICombatLogController/CombatLogRoute`), and a full
  `php artisan test --compact --exclude-group=MapTiles` run - all green except one pre-existing,
  environment-specific failure (`NpcCompendiumControllerActivityTest`) confirmed to reproduce
  identically with every change in this PR reverted (local dev-DB drift, not a regression - this
  branch's CI already passed all 9 checks before this failure was investigated).
- [x] `composer run fix` (no drift) and `composer run analyse` (no errors).

## Follow-ups filed

- #3754 originally tracked the `DungeonRepository` gap separately, since fixing it seemed to need a
  protocol-level decision (no game version signal exists in the combat log payload). Wotuu
  confirmed the Auto Route Creator is retail-only, which resolved the ambiguity - #3754 is fixed
  here and closed.
- #3757 tracks a related but larger gap found during independent review of this PR:
  `MappingService::createNewMappingVersionFromMDTMapping()` has the same unscoped-fallback bug, but
  its root cause is one level up in `MDTMappingImportService::importMappingVersionFromMDT()` - the
  SAME `$currentMappingVersion` also feeds checkpoint/enemy/patrol/POI cloning, so a real fix means
  touching ~5 method signatures in the primary, scheduled MDT import pipeline (`mdt:importmapping`)
  to make a null predecessor (genuinely first import for a new game version) a handled case rather
  than an unscoped fallback. That's materially more invasive than anything else in this PR (mostly
  rarely-used admin/dev tools) and higher-traffic/higher-risk to rush, so it's tracked separately
  rather than folded in here.
