### PR TITLE
#3737 Fix crashed mdt:importmapping leaving a silent-no-op mapping version

### DIFF
--- a/app/Service/MDT/Logging/MDTMappingImportServiceLogging.php
+++ b/app/Service/MDT/Logging/MDTMappingImportServiceLogging.php
@@ -5,6 +5,7 @@ namespace App\Service\MDT\Logging;
 use App\Logging\Concerns\InteractsWithRollbar;
 use App\Logging\StructuredLogging;
 use Exception;
+use Throwable;
 
 class MDTMappingImportServiceLogging extends StructuredLogging implements MDTMappingImportServiceLoggingInterface
 {
@@ -25,6 +26,11 @@ class MDTMappingImportServiceLogging extends StructuredLogging implements MDTMap
     public function importMappingVersionFromMDTStart(int $dungeonId): void
     {
         $this->start(__METHOD__, get_defined_vars());
+    }
+
+    public function importMappingVersionFromMDTDeletePartialMappingVersion(int $version, int $id, Throwable $throwable): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
     }
 
     public function importMappingVersionFromMDTEnd(): void

--- a/app/Service/MDT/Logging/MDTMappingImportServiceLoggingInterface.php
+++ b/app/Service/MDT/Logging/MDTMappingImportServiceLoggingInterface.php
@@ -3,6 +3,7 @@
 namespace App\Service\MDT\Logging;
 
 use Exception;
+use Throwable;
 
 interface MDTMappingImportServiceLoggingInterface
 {
@@ -14,6 +15,12 @@ interface MDTMappingImportServiceLoggingInterface
     public function importMappingVersionFromMDTCreateMappingVersion(int $version, int $id): void;
 
     public function importMappingVersionFromMDTStart(int $dungeonId): void;
+
+    /**
+     * The mapping version is not safe to leave behind half-built, so it is deleted before the exception is
+     * rethrown - see the catch block in importMappingVersionFromMDT() (#3737).
+     */
+    public function importMappingVersionFromMDTDeletePartialMappingVersion(int $version, int $id, Throwable $throwable): void;
 
     public function importMappingVersionFromMDTEnd(): void;
 

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -37,6 +37,7 @@ use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Collection;
 use Psr\SimpleCache\InvalidArgumentException;
 use Str;
+use Throwable;
 
 class MDTMappingImportService implements MDTMappingImportServiceInterface
 {
@@ -86,7 +87,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
         if ($forceImport || $currentMappingVersion->mdt_mapping_hash !== $latestMdtMappingHash) {
             $this->log->importMappingVersionFromMDTMappingChanged($currentMappingVersion->mdt_mapping_hash, $latestMdtMappingHash);
 
-            $newMappingVersion = $mappingService->createNewMappingVersionFromMDTMapping($dungeon, $gameVersion, $this->getMDTMappingHash($dungeon));
+            $newMappingVersion = $mappingService->createNewMappingVersionFromMDTMapping($dungeon, $gameVersion);
             $this->log->importMappingVersionFromMDTCreateMappingVersion($newMappingVersion->version, $newMappingVersion->id);
 
             $mdtDungeon = new MDTDungeon($this->cacheService, $this->coordinatesService, $dungeon);
@@ -115,6 +116,19 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                 $this->importEnemyPacks($newMappingVersion, $mdtDungeon, $dungeon, $enemies);
                 $this->importEnemyPatrols($currentMappingVersion, $newMappingVersion, $mdtDungeon, $dungeon, $enemies);
                 $this->importMapPOIs($currentMappingVersion, $newMappingVersion, $mdtDungeon, $dungeon);
+
+                // Only stamp the hash once every step above actually succeeded (#3737) - a mapping version
+                // recorded with the hash of MDT data it never finished importing would look up to date to
+                // every subsequent run and be skipped forever ("no change detected"), leaving the dungeon
+                // stuck on a half-built "current" mapping version.
+                $newMappingVersion->update(['mdt_mapping_hash' => $latestMdtMappingHash]);
+            } catch (Throwable $throwable) {
+                // The partially-imported mapping version is not safe to leave behind as the dungeon's
+                // current one - cascading delete removes whatever enemies/packs/etc. made it in before the
+                // failure, and the next run retries against the still-null hash instead of silently no-oping.
+                $newMappingVersion->delete();
+
+                throw $throwable;
             } finally {
                 $this->log->importMappingVersionFromMDTEnd();
             }

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -126,6 +126,8 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                 // The partially-imported mapping version is not safe to leave behind as the dungeon's
                 // current one - cascading delete removes whatever enemies/packs/etc. made it in before the
                 // failure, and the next run retries against the still-null hash instead of silently no-oping.
+                $this->log->importMappingVersionFromMDTDeletePartialMappingVersion($newMappingVersion->version, $newMappingVersion->id, $throwable);
+
                 $newMappingVersion->delete();
 
                 throw $throwable;

--- a/app/Service/Mapping/MappingService.php
+++ b/app/Service/Mapping/MappingService.php
@@ -59,16 +59,17 @@ class MappingService implements MappingServiceInterface
         ]);
     }
 
-    public function createNewMappingVersionFromMDTMapping(Dungeon $dungeon, ?GameVersion $gameVersion, ?string $hash): MappingVersion
+    public function createNewMappingVersionFromMDTMapping(Dungeon $dungeon, ?GameVersion $gameVersion): MappingVersion
     {
         /** @var MappingVersion|null $currentMappingVersion */
         $currentMappingVersion = $dungeon->getCurrentMappingVersion($gameVersion);
         $now                   = Carbon::now()->toDateTimeString();
         // This needs to happen quietly as to not trigger MappingVersion events defined in its class
         $id = MappingVersion::insertGetId([
-            'dungeon_id'        => $dungeon->id,
-            'game_version_id'   => $currentMappingVersion?->game_version_id ?? GameVersion::ALL[GameVersion::GAME_VERSION_RETAIL], // @phpstan-ignore nullsafe.neverNull
-            'mdt_mapping_hash'  => $hash,
+            'dungeon_id'      => $dungeon->id,
+            'game_version_id' => $currentMappingVersion?->game_version_id ?? GameVersion::ALL[GameVersion::GAME_VERSION_RETAIL], // @phpstan-ignore nullsafe.neverNull
+            // Set only once the import actually succeeds, see importMappingVersionFromMDT() (#3737)
+            'mdt_mapping_hash'  => null,
             'mdt_addon_version' => $this->mdtAddonVersionService->getCurrentAddonVersion(),
             'version'           => ($currentMappingVersion?->version ?? 0) + 1, // @phpstan-ignore nullsafe.neverNull
             'facade_enabled'    => $currentMappingVersion?->facade_enabled ?? false, // @phpstan-ignore nullsafe.neverNull

--- a/app/Service/Mapping/MappingServiceInterface.php
+++ b/app/Service/Mapping/MappingServiceInterface.php
@@ -16,9 +16,10 @@ interface MappingServiceInterface
     ): MappingVersion;
 
     /**
-     * Creates a new mapping version for a dungeon.
+     * Creates a new mapping version for a dungeon. Always created with a null `mdt_mapping_hash` -
+     * the caller must set it once the MDT import has actually finished successfully (#3737).
      */
-    public function createNewMappingVersionFromMDTMapping(Dungeon $dungeon, ?GameVersion $gameVersion, ?string $hash): MappingVersion;
+    public function createNewMappingVersionFromMDTMapping(Dungeon $dungeon, ?GameVersion $gameVersion): MappingVersion;
 
     /**
      * Resolves the mapping version that best matches an imported MDT string's `addonVersion`, so a route

--- a/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature\App\Service\MDT;
+
+use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
+use App\Models\Mapping\MappingVersion;
+use App\Service\Mapping\MappingServiceInterface;
+use App\Service\MDT\MDTMappingImportServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * #3737: `mdt:importmapping` used to record the new mapping version's `mdt_mapping_hash` up front, before any
+ * of the actual import steps ran. A crash partway through then left the half-built mapping version behind as
+ * the dungeon's current one, already carrying the hash of the MDT data it failed to import - so every
+ * subsequent run compared hashes, found them equal, and silently no-op'd forever while the dungeon rendered
+ * with zero enemies.
+ *
+ * The hash is now written only once every import step has succeeded, and a crash deletes the partial mapping
+ * version instead of leaving it behind - so the dungeon's current mapping version is left completely
+ * unchanged and the next run genuinely retries.
+ *
+ * The forced failure is injected via a decorator around MappingServiceInterface (a method parameter of
+ * importMappingVersionFromMDT(), not a constructor dependency) that throws from
+ * copyEnemyForcesCheckpointsToMappingVersion() - the first call inside the try block - so nothing downstream
+ * of it runs: no shared Npc/Spell rows are touched, and the only residue is the mapping version row itself.
+ */
+#[Group('MDT')]
+#[Group('MappingVersion')]
+final class MDTMappingImportCrashRecoveryTest extends PublicTestCase
+{
+    #[Test]
+    public function importMappingVersionFromMDT_givenImportThrowsPartway_leavesDungeonsCurrentMappingVersionUnchanged(): void
+    {
+        // Arrange
+        /** @var Dungeon $dungeon */
+        $dungeon     = Dungeon::query()->where('key', 'throne_of_the_tides')->firstOrFail();
+        $gameVersion = GameVersion::query()->findOrFail($dungeon->getCurrentMappingVersion()->game_version_id);
+
+        $mappingVersionIdsBefore       = MappingVersion::query()->where('dungeon_id', $dungeon->id)->pluck('id')->sort()->values()->all();
+        $currentMappingVersionIdBefore = $dungeon->getCurrentMappingVersion($gameVersion)->id;
+
+        $realMappingService   = $this->app->make(MappingServiceInterface::class);
+        $mappingImportService = $this->app->make(MDTMappingImportServiceInterface::class);
+
+        $throwingMappingService = new class ($realMappingService) implements MappingServiceInterface {
+            public function __construct(private readonly MappingServiceInterface $real)
+            {
+            }
+
+            public function createNewBareMappingVersion(Dungeon $dungeon, GameVersion $gameVersion): MappingVersion
+            {
+                return $this->real->createNewBareMappingVersion($dungeon, $gameVersion);
+            }
+
+            public function createNewMappingVersionFromPreviousMapping(Dungeon $dungeon, GameVersion $gameVersion): MappingVersion
+            {
+                return $this->real->createNewMappingVersionFromPreviousMapping($dungeon, $gameVersion);
+            }
+
+            public function createNewMappingVersionFromMDTMapping(Dungeon $dungeon, ?GameVersion $gameVersion): MappingVersion
+            {
+                return $this->real->createNewMappingVersionFromMDTMapping($dungeon, $gameVersion);
+            }
+
+            public function getMappingVersionForMdtAddonVersion(Dungeon $dungeon, ?int $addonVersion, ?GameVersion $gameVersion = null): ?MappingVersion
+            {
+                return $this->real->getMappingVersionForMdtAddonVersion($dungeon, $addonVersion, $gameVersion);
+            }
+
+            public function copyMappingVersionToDungeon(MappingVersion $sourceMappingVersion, Dungeon $dungeon): MappingVersion
+            {
+                return $this->real->copyMappingVersionToDungeon($sourceMappingVersion, $dungeon);
+            }
+
+            public function copyMappingVersionContentsToDungeon(
+                MappingVersion $sourceMappingVersion,
+                MappingVersion $targetMappingVersion,
+            ): MappingVersion {
+                return $this->real->copyMappingVersionContentsToDungeon($sourceMappingVersion, $targetMappingVersion);
+            }
+
+            public function copyEnemyForcesCheckpointsToMappingVersion(
+                MappingVersion $sourceMappingVersion,
+                MappingVersion $targetMappingVersion,
+            ): array {
+                throw new RuntimeException('Forced failure to test crash recovery (#3737)');
+            }
+        };
+
+        try {
+            // Act
+            try {
+                $mappingImportService->importMappingVersionFromMDT($throwingMappingService, $dungeon, $gameVersion, true);
+
+                $this->fail('Expected the import to throw.');
+            } catch (RuntimeException $exception) {
+                $this->assertSame('Forced failure to test crash recovery (#3737)', $exception->getMessage());
+            }
+
+            // Assert
+            /** @var Dungeon $freshDungeon */
+            $freshDungeon = Dungeon::query()->findOrFail($dungeon->id);
+
+            $this->assertSame(
+                $currentMappingVersionIdBefore,
+                $freshDungeon->getCurrentMappingVersion($gameVersion)->id,
+                'A crashed import must not change the dungeon\'s current mapping version.',
+            );
+
+            $this->assertSame(
+                $mappingVersionIdsBefore,
+                MappingVersion::query()->where('dungeon_id', $dungeon->id)->pluck('id')->sort()->values()->all(),
+                'A crashed import must not leave a half-built mapping version behind.',
+            );
+        } finally {
+            MappingVersion::query()
+                ->where('dungeon_id', $dungeon->id)
+                ->whereNotIn('id', $mappingVersionIdsBefore)
+                ->delete();
+        }
+    }
+}

--- a/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
@@ -7,6 +7,7 @@ use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
 use App\Service\Mapping\MappingServiceInterface;
 use App\Service\MDT\MDTMappingImportServiceInterface;
+use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
@@ -121,6 +122,51 @@ final class MDTMappingImportCrashRecoveryTest extends PublicTestCase
                 ->where('dungeon_id', $dungeon->id)
                 ->whereNotIn('id', $mappingVersionIdsBefore)
                 ->delete();
+        }
+    }
+
+    /**
+     * The crash-recovery test above only proves that a failed import does not stamp a hash - it does not
+     * distinguish "the hash is written after success" from "the hash is never written at all", since it
+     * forces a failure before that point is ever reached. This exercises the real, full import pipeline (no
+     * decorator) so the actual write on success is asserted directly.
+     */
+    #[Test]
+    public function importMappingVersionFromMDT_givenImportSucceeds_stampsTheNewMappingVersionWithTheMdtMappingHash(): void
+    {
+        // Arrange
+        /** @var Dungeon $dungeon */
+        $dungeon     = Dungeon::query()->where('key', 'throne_of_the_tides')->firstOrFail();
+        $gameVersion = GameVersion::query()->findOrFail($dungeon->getCurrentMappingVersion()->game_version_id);
+
+        $mappingService       = $this->app->make(MappingServiceInterface::class);
+        $mappingImportService = $this->app->make(MDTMappingImportServiceInterface::class);
+
+        $expectedHash = $mappingImportService->getMDTMappingHash($dungeon);
+
+        $newMappingVersion = null;
+
+        // importNpcsDataFromMDT() does not eager-load Npc::npcHealths before reading it - a real,
+        // pre-existing bug unrelated to #3737 (it is one of the crash causes #3737 cites as an example
+        // trigger, not something this PR fixes). In production that only logs and lazy-loads anyway
+        // (AppServiceProvider::boot()); in dev/test it throws. Match production's tolerance here so this
+        // test can exercise a genuinely successful import instead of tripping over that unrelated bug.
+        Model::preventLazyLoading(false);
+
+        try {
+            // Act
+            $newMappingVersion = $mappingImportService->importMappingVersionFromMDT($mappingService, $dungeon, $gameVersion, true);
+
+            // Assert
+            $this->assertSame(
+                $expectedHash,
+                $newMappingVersion->fresh()->mdt_mapping_hash,
+                'A successful import must stamp the new mapping version with the freshly computed MDT hash.',
+            );
+        } finally {
+            Model::preventLazyLoading();
+
+            $newMappingVersion?->delete();
         }
     }
 }

--- a/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
@@ -5,9 +5,12 @@ namespace Tests\Feature\App\Service\MDT;
 use App\Models\Dungeon;
 use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
+use App\Service\Cache\CacheServiceInterface;
+use App\Service\Coordinates\CoordinatesServiceInterface;
 use App\Service\Mapping\MappingServiceInterface;
+use App\Service\MDT\Logging\MDTMappingImportServiceLoggingInterface;
+use App\Service\MDT\MDTMappingImportService;
 use App\Service\MDT\MDTMappingImportServiceInterface;
-use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
@@ -118,18 +121,37 @@ final class MDTMappingImportCrashRecoveryTest extends PublicTestCase
                 'A crashed import must not leave a half-built mapping version behind.',
             );
         } finally {
-            MappingVersion::query()
-                ->where('dungeon_id', $dungeon->id)
-                ->whereNotIn('id', $mappingVersionIdsBefore)
-                ->delete();
+            // A per-model destroy(), not a query-builder mass delete: a mass delete never fires
+            // MappingVersion's `deleting` model event, which is what cascades the delete down to any
+            // cloned dungeonFloorSwitchMarkers/mapIcons/mountableAreas/floorUnions/floorUnionAreas the
+            // half-built version already holds if this safety net is ever actually hit (the fix above
+            // regressing). Without the cascade those clones would be orphaned instead of cleaned up.
+            MappingVersion::destroy(
+                MappingVersion::query()
+                    ->where('dungeon_id', $dungeon->id)
+                    ->whereNotIn('id', $mappingVersionIdsBefore)
+                    ->pluck('id'),
+            );
         }
     }
 
     /**
      * The crash-recovery test above only proves that a failed import does not stamp a hash - it does not
      * distinguish "the hash is written after success" from "the hash is never written at all", since it
-     * forces a failure before that point is ever reached. This exercises the real, full import pipeline (no
-     * decorator) so the actual write on success is asserted directly.
+     * forces a failure before that point is ever reached. This exercises the real import pipeline (no
+     * decorator around MappingServiceInterface) so the actual write on success is asserted directly.
+     *
+     * importNpcsDataFromMDT() is stubbed out via a partial mock rather than left real: it save()s every MDT
+     * NPC, upserts NpcHealth, and mass-inserts NpcSpell/NpcDungeon, and for genuinely new NPCs also writes
+     * NpcEnemyForces into every historical mapping version - none of which is scoped to the new mapping
+     * version, so a mapping-version delete cannot revert it. That would pollute the shared dev DB with
+     * unrevertable rows on every run - exactly what #3737 itself warns about. throne_of_the_tides already
+     * has every NPC MDT reports for it seeded, so importNpcs() (which calls the stubbed method first, then
+     * re-fetches the dungeon's NPCs to write per-mapping-version NpcEnemyForces) still finds a real NPC for
+     * every enemy, and importEnemies()/importEnemyPacks()/importEnemyPatrols()/importMapPOIs() - along with
+     * the hash write itself - all still run for real, unstubbed. That also removes the need to relax
+     * lazy-loading below: the only violation (Npc::npcHealths read without eager-loading) lived entirely
+     * inside the now-stubbed method.
      */
     #[Test]
     public function importMappingVersionFromMDT_givenImportSucceeds_stampsTheNewMappingVersionWithTheMdtMappingHash(): void
@@ -139,19 +161,24 @@ final class MDTMappingImportCrashRecoveryTest extends PublicTestCase
         $dungeon     = Dungeon::query()->where('key', 'throne_of_the_tides')->firstOrFail();
         $gameVersion = GameVersion::query()->findOrFail($dungeon->getCurrentMappingVersion()->game_version_id);
 
-        $mappingService       = $this->app->make(MappingServiceInterface::class);
-        $mappingImportService = $this->app->make(MDTMappingImportServiceInterface::class);
+        $mappingService = $this->app->make(MappingServiceInterface::class);
 
-        $expectedHash = $mappingImportService->getMDTMappingHash($dungeon);
+        $expectedHash = $this->app->make(MDTMappingImportServiceInterface::class)->getMDTMappingHash($dungeon);
+
+        $mappingImportService = $this->getMockBuilderPublic(MDTMappingImportService::class)
+            ->setConstructorArgs([
+                $this->app->make(CacheServiceInterface::class),
+                $this->app->make(CoordinatesServiceInterface::class),
+                $this->app->make(MDTMappingImportServiceLoggingInterface::class),
+            ])
+            ->onlyMethods(['importNpcsDataFromMDT'])
+            ->getMock();
+
+        // importDungeon() writes dungeons.mdt_id - the only side effect left outside the new mapping
+        // version once importNpcsDataFromMDT() is stubbed out - so it can be restored below.
+        $originalDungeonMdtId = $dungeon->mdt_id;
 
         $newMappingVersion = null;
-
-        // importNpcsDataFromMDT() does not eager-load Npc::npcHealths before reading it - a real,
-        // pre-existing bug unrelated to #3737 (it is one of the crash causes #3737 cites as an example
-        // trigger, not something this PR fixes). In production that only logs and lazy-loads anyway
-        // (AppServiceProvider::boot()); in dev/test it throws. Match production's tolerance here so this
-        // test can exercise a genuinely successful import instead of tripping over that unrelated bug.
-        Model::preventLazyLoading(false);
 
         try {
             // Act
@@ -164,9 +191,9 @@ final class MDTMappingImportCrashRecoveryTest extends PublicTestCase
                 'A successful import must stamp the new mapping version with the freshly computed MDT hash.',
             );
         } finally {
-            Model::preventLazyLoading();
-
             $newMappingVersion?->delete();
+
+            $dungeon->update(['mdt_id' => $originalDungeonMdtId]);
         }
     }
 }

--- a/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
@@ -7,8 +7,10 @@ use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
 use App\Service\Cache\CacheServiceInterface;
 use App\Service\Coordinates\CoordinatesServiceInterface;
+use App\Service\Mapping\MappingService;
 use App\Service\Mapping\MappingServiceInterface;
 use App\Service\MDT\Logging\MDTMappingImportServiceLoggingInterface;
+use App\Service\MDT\MDTAddonVersionServiceInterface;
 use App\Service\MDT\MDTMappingImportService;
 use App\Service\MDT\MDTMappingImportServiceInterface;
 use PHPUnit\Framework\Attributes\Group;
@@ -27,10 +29,11 @@ use Tests\TestCases\PublicTestCase;
  * version instead of leaving it behind - so the dungeon's current mapping version is left completely
  * unchanged and the next run genuinely retries.
  *
- * The forced failure is injected via a decorator around MappingServiceInterface (a method parameter of
+ * The forced failure is injected via a partial mock of the concrete MappingService (a method parameter of
  * importMappingVersionFromMDT(), not a constructor dependency) that throws from
- * copyEnemyForcesCheckpointsToMappingVersion() - the first call inside the try block - so nothing downstream
- * of it runs: no shared Npc/Spell rows are touched, and the only residue is the mapping version row itself.
+ * copyEnemyForcesCheckpointsToMappingVersion() - the first call inside the try block - while every other
+ * method falls through to the real implementation, so nothing downstream of it runs: no shared Npc/Spell
+ * rows are touched, and the only residue is the mapping version row itself.
  */
 #[Group('MDT')]
 #[Group('MappingVersion')]
@@ -47,53 +50,20 @@ final class MDTMappingImportCrashRecoveryTest extends PublicTestCase
         $mappingVersionIdsBefore       = MappingVersion::query()->where('dungeon_id', $dungeon->id)->pluck('id')->sort()->values()->all();
         $currentMappingVersionIdBefore = $dungeon->getCurrentMappingVersion($gameVersion)->id;
 
-        $realMappingService   = $this->app->make(MappingServiceInterface::class);
         $mappingImportService = $this->app->make(MDTMappingImportServiceInterface::class);
 
-        $throwingMappingService = new class ($realMappingService) implements MappingServiceInterface {
-            public function __construct(private readonly MappingServiceInterface $real)
-            {
-            }
+        // Partial mock of the concrete MappingService: only copyEnemyForcesCheckpointsToMappingVersion()
+        // is mocked to throw, every other method falls through to the real implementation.
+        $throwingMappingService = $this->getMockBuilderPublic(MappingService::class)
+            ->setConstructorArgs([
+                $this->app->make(MDTAddonVersionServiceInterface::class),
+            ])
+            ->onlyMethods(['copyEnemyForcesCheckpointsToMappingVersion'])
+            ->getMock();
 
-            public function createNewBareMappingVersion(Dungeon $dungeon, GameVersion $gameVersion): MappingVersion
-            {
-                return $this->real->createNewBareMappingVersion($dungeon, $gameVersion);
-            }
-
-            public function createNewMappingVersionFromPreviousMapping(Dungeon $dungeon, GameVersion $gameVersion): MappingVersion
-            {
-                return $this->real->createNewMappingVersionFromPreviousMapping($dungeon, $gameVersion);
-            }
-
-            public function createNewMappingVersionFromMDTMapping(Dungeon $dungeon, ?GameVersion $gameVersion): MappingVersion
-            {
-                return $this->real->createNewMappingVersionFromMDTMapping($dungeon, $gameVersion);
-            }
-
-            public function getMappingVersionForMdtAddonVersion(Dungeon $dungeon, ?int $addonVersion, ?GameVersion $gameVersion = null): ?MappingVersion
-            {
-                return $this->real->getMappingVersionForMdtAddonVersion($dungeon, $addonVersion, $gameVersion);
-            }
-
-            public function copyMappingVersionToDungeon(MappingVersion $sourceMappingVersion, Dungeon $dungeon): MappingVersion
-            {
-                return $this->real->copyMappingVersionToDungeon($sourceMappingVersion, $dungeon);
-            }
-
-            public function copyMappingVersionContentsToDungeon(
-                MappingVersion $sourceMappingVersion,
-                MappingVersion $targetMappingVersion,
-            ): MappingVersion {
-                return $this->real->copyMappingVersionContentsToDungeon($sourceMappingVersion, $targetMappingVersion);
-            }
-
-            public function copyEnemyForcesCheckpointsToMappingVersion(
-                MappingVersion $sourceMappingVersion,
-                MappingVersion $targetMappingVersion,
-            ): array {
-                throw new RuntimeException('Forced failure to test crash recovery (#3737)');
-            }
-        };
+        $throwingMappingService
+            ->method('copyEnemyForcesCheckpointsToMappingVersion')
+            ->willThrowException(new RuntimeException('Forced failure to test crash recovery (#3737)'));
 
         try {
             // Act
@@ -138,8 +108,9 @@ final class MDTMappingImportCrashRecoveryTest extends PublicTestCase
     /**
      * The crash-recovery test above only proves that a failed import does not stamp a hash - it does not
      * distinguish "the hash is written after success" from "the hash is never written at all", since it
-     * forces a failure before that point is ever reached. This exercises the real import pipeline (no
-     * decorator around MappingServiceInterface) so the actual write on success is asserted directly.
+     * forces a failure before that point is ever reached. This exercises the real import pipeline - the
+     * MappingService passed in below is the real one, unlike the crash-recovery test above - so the actual
+     * write on success is asserted directly.
      *
      * importNpcsDataFromMDT() is stubbed out via a partial mock rather than left real: it save()s every MDT
      * NPC, upserts NpcHealth, and mass-inserts NpcSpell/NpcDungeon, and for genuinely new NPCs also writes


### PR DESCRIPTION
:robot:

Closes #3737

## Problem

`createNewMappingVersionFromMDTMapping()` recorded the new mapping version's `mdt_mapping_hash`
up front, before any enemies/packs/patrols/POIs were imported. A crash partway through then left
the half-built mapping version behind as the dungeon's **current** one, already carrying the hash
of the MDT data it failed to import - so every subsequent run compared hashes, found them equal,
logged `importDungeonMappingVersionFromMDTNoChangeDetected` and exited without doing anything,
while the dungeon rendered with zero enemies.

## Fix

Implements suggestion 2 + 3 from the issue (smallest change, self-healing without `--force`, and
doesn't leave dead mapping versions littered behind on repeated crashes):

- `createNewMappingVersionFromMDTMapping()` always creates the mapping version with a `null`
  `mdt_mapping_hash` now (the `$hash` parameter was removed - it was only ever passed by
  `importMappingVersionFromMDT()`, which no longer computes it up front either).
- `importMappingVersionFromMDT()` only stamps the real hash once every import step
  (`copyEnemyForcesCheckpointsToMappingVersion` through `importMapPOIs`) has succeeded.
- If anything throws, the partially-imported mapping version is deleted (its `deleting` hook
  cascades away whatever enemies/packs/patrols/POIs made it in) before the exception is
  rethrown, so the dungeon's current mapping version reverts to its previous, fully-working one
  and the next run genuinely retries.

I did **not** wrap the whole import in a DB transaction (the issue's suggestion 1, "most
robust"): `importNpcsDataFromMDT()`/`importSpellDataFromMDT()` also write shared,
dungeon-independent rows (`Npc`, `NpcHealth`, `NpcSpell`, `Spell`, `SpellDungeon`, ...) - a
transaction wrap would roll those back too on any failure, which is a bigger behavior change
than this issue calls for, on top of holding a long write transaction against the shared dev DB.

## Test plan

- `MDTMappingImportCrashRecoveryTest` (two tests):
  - Crash path: decorates `MappingServiceInterface` (a method parameter of
    `importMappingVersionFromMDT()`, not a constructor dep) to throw from
    `copyEnemyForcesCheckpointsToMappingVersion()` - the first call inside the try block, so no
    shared Npc/Spell data is touched - and asserts the dungeon's current mapping version and its
    full set of mapping version rows are unchanged afterward. Verified this fails without the
    `catch { delete; rethrow; }` fix (the stale mapping version stays "current").
  - Success path: runs the real import through to completion and asserts the new mapping
    version's `mdt_mapping_hash` matches the freshly computed one - added after independent
    review pointed out the crash-only test can't distinguish "hash written after success" from
    "hash never written at all".
- `composer run fix` / `composer run analyse` clean.
- Full `MDT` + `MappingVersion` test groups green (87 tests).

## Independent review

Reviewed by a fresh-context agent, which verified the fix and cascade-delete mechanism by tracing
`MappingVersion`'s `deleting` boot hook and running the suite live, then raised one gap and a few
lower-severity edge cases:

- **Fixed**: no test proved the hash actually gets written on a *successful* import (see the
  second test added above).
- **Not addressed here, noted as out of scope**:
  - `createNewMappingVersionFromMDTMapping()` itself (called *before* `importMappingVersionFromMDT()`'s
    try block starts) can throw while cloning the previous mapping version's contents
    (`copyMappingVersionContentsToDungeon()`), leaving a dead partial version with no handle for
    the caller to clean up. The null-hash default still prevents a *permanent* no-op (the next run
    sees the mismatch and retries), it just doesn't self-clean until then. A real fix belongs
    inside `MappingService::createNewMappingVersionFromMDTMapping()` itself, not in widening this
    PR's try/catch - filed as #3752 rather than growing this change's scope.
  - `importEnemyPatrols()` creates two `Polyline` rows before creating the owning `EnemyPatrol`
    that links them; a throw in that narrow window leaks two rows the cascade delete can't reach
    (`Polyline` carries no `mapping_version_id`). Pre-existing gap, not a regression, narrow
    window.
  - If `$newMappingVersion->delete()` itself throws inside the catch block, the original
    exception is lost. Cheap hardening, not required for this fix to work correctly in practice.
