### PR TITLE
Scope the MDT import pipeline's predecessor lookup to the target game version

### DIFF
--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -84,11 +84,15 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
 
         $gameVersion ??= GameVersion::getDefaultGameVersion();
 
-        $currentMappingVersion = $dungeon->getCurrentMappingVersion($gameVersion);
-        if ($forceImport || $currentMappingVersion->mdt_mapping_hash !== $latestMdtMappingHash) {
-            $this->log->importMappingVersionFromMDTMappingChanged($currentMappingVersion->mdt_mapping_hash, $latestMdtMappingHash);
+        // Scoped to $gameVersion only - unlike Dungeon::getCurrentMappingVersion(), this does NOT fall back to
+        // an ambient/unrelated game version's mapping version when the dungeon has none for $gameVersion yet
+        // (e.g. its first-ever import for a newly-added game version). A null here is a real, valid case: the
+        // downstream clone/import calls below all treat it as "nothing to carry over from" (#3757).
+        $currentMappingVersion = $dungeon->getCurrentMappingVersionForGameVersion($gameVersion);
+        if ($forceImport || $currentMappingVersion === null || $currentMappingVersion->mdt_mapping_hash !== $latestMdtMappingHash) {
+            $this->log->importMappingVersionFromMDTMappingChanged($currentMappingVersion?->mdt_mapping_hash, $latestMdtMappingHash);
 
-            $newMappingVersion = $mappingService->createNewMappingVersionFromMDTMapping($dungeon, $gameVersion);
+            $newMappingVersion = $mappingService->createNewMappingVersionFromMDTMapping($dungeon, $gameVersion, $currentMappingVersion);
             $this->log->importMappingVersionFromMDTCreateMappingVersion($newMappingVersion->version, $newMappingVersion->id);
 
             $mdtDungeon = new MDTDungeon($this->cacheService, $this->coordinatesService, $dungeon);
@@ -477,23 +481,25 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
      * @return Collection<int, Enemy>
      */
     private function importEnemies(
-        MappingVersion $currentMappingVersion,
-        MappingVersion $newMappingVersion,
-        MDTDungeon     $mdtDungeon,
-        Dungeon        $dungeon,
-        array          $enemyForcesCheckpointIdMapping,
-        bool           $forceImport,
-        array          &          $failures,
+        ?MappingVersion $currentMappingVersion,
+        MappingVersion  $newMappingVersion,
+        MDTDungeon      $mdtDungeon,
+        Dungeon         $dungeon,
+        array           $enemyForcesCheckpointIdMapping,
+        bool            $forceImport,
+        array           &           $failures,
     ): Collection {
         // Get a list of new enemies and save them
         try {
             $this->log->importEnemiesStart();
 
+            // No predecessor (e.g. this dungeon's first-ever import for this game version) - nothing to
+            // recover properties from, every MDT enemy below is treated as brand new (#3757).
             $currentEnemies = $currentMappingVersion
-                ->enemies()
+                ?->enemies()
                 ->with('floor')
                 ->get()
-                ->keyBy(static fn(Enemy $enemy) => $enemy->getUniqueKey());
+                ->keyBy(static fn(Enemy $enemy) => $enemy->getUniqueKey()) ?? collect();
 
             $enemies = $mdtDungeon->getClonesAsEnemies($newMappingVersion, $dungeon->floors()->active()->get());
 
@@ -632,10 +638,16 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
      *                                                        previous mapping version's checkpoints.
      */
     private function deleteEmptyEnemyForcesCheckpoints(
-        MappingVersion $currentMappingVersion,
-        MappingVersion $newMappingVersion,
-        array          $enemyForcesCheckpointIdMapping,
+        ?MappingVersion $currentMappingVersion,
+        MappingVersion  $newMappingVersion,
+        array           $enemyForcesCheckpointIdMapping,
     ): void {
+        // No predecessor means $enemyForcesCheckpointIdMapping is already empty (nothing was cloned to prune
+        // from) - nothing to do (#3757).
+        if ($currentMappingVersion === null) {
+            return;
+        }
+
         /** @var Collection<int, EnemyForcesCheckpoint> $emptyEnemyForcesCheckpoints */
         $emptyEnemyForcesCheckpoints = $newMappingVersion->enemyForcesCheckpoints()
             ->whereDoesntHave('enemies')
@@ -781,11 +793,11 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
      * @throws Exception
      */
     private function importEnemyPatrols(
-        MappingVersion $currentMappingVersion,
-        MappingVersion $newMappingVersion,
-        MDTDungeon     $mdtDungeon,
-        Dungeon        $dungeon,
-        Collection     $savedEnemies,
+        ?MappingVersion $currentMappingVersion,
+        MappingVersion  $newMappingVersion,
+        MDTDungeon      $mdtDungeon,
+        Dungeon         $dungeon,
+        Collection      $savedEnemies,
     ): void {
         try {
             $this->log->importEnemyPatrolsStart();
@@ -796,14 +808,15 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
             // Pretend the patrol is on the facade floor for correct translations, IF the facade floor is available
             $facadeFloor = $dungeon->getFacadeFloor();
 
+            // No predecessor - nothing to match against or re-clone below (#3757).
             /** @var Collection<int, EnemyPatrol> $existingEnemyPatrols */
             $existingEnemyPatrols = $currentMappingVersion
-                ->enemyPatrols()
+                ?->enemyPatrols()
                 ->with([
                     'polyline',
                     'mdtPolyline',
                 ])
-                ->get();
+                ->get() ?? collect();
 
             foreach ($mdtNPCs as $mdtNPC) {
                 foreach ($mdtNPC->getRawMdtNpc()['clones'] as $mdtCloneIndex => $mdtNpcClone) {
@@ -967,10 +980,10 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
      * @throws Exception
      */
     private function importMapPOIs(
-        MappingVersion $currentMappingVersion,
-        MappingVersion $newMappingVersion,
-        MDTDungeon     $mdtDungeon,
-        Dungeon        $dungeon,
+        ?MappingVersion $currentMappingVersion,
+        MappingVersion  $newMappingVersion,
+        MDTDungeon      $mdtDungeon,
+        Dungeon         $dungeon,
     ): void {
         try {
             $this->log->importMapPOIsStart();
@@ -1001,7 +1014,8 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                     $latLng = $this->coordinatesService->convertFacadeMapLocationToMapLocation($newMappingVersion, $latLng);
 
                     if (isset($mapIconTypeMapping[$mdtMapPOI->getType()->value])) {
-                        $existingMapIcon = $currentMappingVersion->getMapIconNearLocation($latLng, $mapIconTypeMapping[$mdtMapPOI->getType()->value]);
+                        // No predecessor to match against - always create a new icon (#3757).
+                        $existingMapIcon = $currentMappingVersion?->getMapIconNearLocation($latLng, $mapIconTypeMapping[$mdtMapPOI->getType()->value]);
                         if ($existingMapIcon === null) {
                             $translationKey = null;
                             if ($mdtMapPOI->getType() === MDTMapPOIType::GenericAssignablePOI &&
@@ -1037,7 +1051,8 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                         // We cannot for sure map the floor switches between different versions to one another
                         // We could use coordinates but if they change it's iffy.
                         // They also don't change between mapping versions, it's not really something Blizzard _can_ change
-                        if ($currentMappingVersion->dungeonFloorSwitchMarkers->isEmpty()) {
+                        // No predecessor means there is nothing to preserve - always create fresh (#3757).
+                        if ($currentMappingVersion === null || $currentMappingVersion->dungeonFloorSwitchMarkers->isEmpty()) {
                             $floor = $this->findFloorByMdtSubLevel($dungeon, $mdtMapPOI->getSubLevel());
 
                             $latLng = Conversion::convertMDTCoordinateToLatLng([

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -989,6 +989,15 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
             $this->log->importMapPOIsStart();
             $mdtMapPOIs = $mdtDungeon->getMDTMapPOIs();
 
+            // Whether $newMappingVersion already has floor switch markers of its own - either cloned from
+            // $currentMappingVersion by copyMappingVersionContentsToDungeon(), or (#3757/#3762) cloned from a
+            // prior game version's facade-source mapping version by
+            // MappingService::createNewMappingVersionFromMDTMapping() on a genuinely first-ever import (where
+            // $currentMappingVersion is null). Querying $newMappingVersion directly - rather than inspecting
+            // $currentMappingVersion, which is null in exactly the case that now pre-populates markers - is
+            // what keeps this from creating duplicates on top of a first-ever import's cloned markers.
+            $newMappingVersionHasDungeonFloorSwitchMarkers = $newMappingVersion->dungeonFloorSwitchMarkers()->exists();
+
             if ($mdtMapPOIs->isNotEmpty()) {
                 $this->log->importMapPOIsMDTHasMapPOIs();
 
@@ -1051,8 +1060,12 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                         // We cannot for sure map the floor switches between different versions to one another
                         // We could use coordinates but if they change it's iffy.
                         // They also don't change between mapping versions, it's not really something Blizzard _can_ change
-                        // No predecessor means there is nothing to preserve - always create fresh (#3757).
-                        if ($currentMappingVersion === null || $currentMappingVersion->dungeonFloorSwitchMarkers->isEmpty()) {
+                        // Only create fresh markers when $newMappingVersion doesn't already have any - whether
+                        // because copyMappingVersionContentsToDungeon() cloned them from $currentMappingVersion,
+                        // or because a first-ever import for this game version cloned them from a prior game
+                        // version's facade-source mapping version (#3757/#3762) - to avoid creating duplicates
+                        // on top of either.
+                        if (!$newMappingVersionHasDungeonFloorSwitchMarkers) {
                             $floor = $this->findFloorByMdtSubLevel($dungeon, $mdtMapPOI->getSubLevel());
 
                             $latLng = Conversion::convertMDTCoordinateToLatLng([
@@ -1073,7 +1086,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                             );
                         } else {
                             $this->log->importMapPOIsHaveExistingFloorSwitchMarkers(
-                                $currentMappingVersion->dungeonFloorSwitchMarkers->count(),
+                                $newMappingVersion->dungeonFloorSwitchMarkers()->count(),
                             );
                         }
                     }

--- a/app/Service/Mapping/MappingService.php
+++ b/app/Service/Mapping/MappingService.php
@@ -110,13 +110,8 @@ class MappingService implements MappingServiceInterface
             // part of the same import) already (re)creates the physical subset it recognizes itself from MDT's
             // own map POI data whenever $currentMappingVersion is null - see its "(#3757)" comments. Cloning
             // them here too would just create duplicate rows a few lines later in the same import. Mountable
-            // areas and dungeon floor switch markers have no such backfill to rely on: MDT has no
-            // mount-speed-zone concept at all, and per Wotuu (#3762 review) modern MDT exports only generate a
-            // combined/facade view and no longer supply the per-floor MapLink POI data importMapPOIs() used to
-            // recreate floor switch markers from - so both are PHYSICAL data (fixed dungeon terrain/geometry,
-            // like floor unions) with no other source, and need the same explicit clone floor unions get.
-            // importMapPOIs() still guards against duplicating whatever gets cloned in here (it only creates a
-            // fresh floor switch marker when the new mapping version doesn't already have one).
+            // areas have no such backfill to rely on: MDT has no mount-speed-zone concept at all, so they need
+            // the same explicit clone floor unions get.
             // The physical facade geometry resolved above still needs cloning in, though, along with
             // timer_max_seconds - it's a NOT NULL DEFAULT 0 column that several call sites divide by unguarded
             // (CombatLogEventFilter::fromHeatmapDataFilter(), CombatLogEvent::setTimeInterval()), so leaving it
@@ -124,12 +119,30 @@ class MappingService implements MappingServiceInterface
             if ($facadeSourceMappingVersion !== null) {
                 $this->cloneFloorUnionsToMappingVersion($facadeSourceMappingVersion, $newMappingVersion);
                 $this->cloneMountableAreasToMappingVersion($facadeSourceMappingVersion, $newMappingVersion);
-                $this->cloneDungeonFloorSwitchMarkersToMappingVersion($facadeSourceMappingVersion, $newMappingVersion);
 
                 $newMappingVersion->update([
                     'timer_max_seconds' => $facadeSourceMappingVersion->timer_max_seconds,
                 ]);
             }
+
+            // Dungeon floor switch markers have no MDT backfill either, but unlike FloorUnions they are NOT
+            // facade-specific geometry - every dungeon has staircases between floors, facade-enabled or not
+            // (per Wotuu, #3762 review round 2: modern MDT exports only generate a combined/facade view and no
+            // longer supply the per-floor MapLink POI data importMapPOIs() used to recreate them from, and this
+            // app still needs them for both facade mode and the per-floor "visit style" mode). So their source
+            // must NOT be gated behind $facadeSourceMappingVersion the way FloorUnion/MountableArea legitimately
+            // are - that would silently drop them for every non-facade dungeon's first-ever import, which is
+            // most of them. Fall back to the newest mapping version of ANY game version, deterministically,
+            // same rationale as the facade source above.
+            $physicalGeometrySourceMappingVersion = $facadeSourceMappingVersion
+                ?? $dungeon->mappingVersions()->orderByDesc('id')->first();
+
+            if ($physicalGeometrySourceMappingVersion !== null) {
+                $this->cloneDungeonFloorSwitchMarkersToMappingVersion($physicalGeometrySourceMappingVersion, $newMappingVersion);
+            }
+
+            // importMapPOIs() still guards against duplicating whatever gets cloned in here (it only creates a
+            // fresh floor switch marker when the new mapping version doesn't already have one).
 
             return $newMappingVersion->load([
                 'dungeonFloorSwitchMarkers',

--- a/app/Service/Mapping/MappingService.php
+++ b/app/Service/Mapping/MappingService.php
@@ -59,25 +59,81 @@ class MappingService implements MappingServiceInterface
         ]);
     }
 
-    public function createNewMappingVersionFromMDTMapping(Dungeon $dungeon, ?GameVersion $gameVersion): MappingVersion
-    {
-        /** @var MappingVersion|null $currentMappingVersion */
-        $currentMappingVersion = $dungeon->getCurrentMappingVersion($gameVersion);
-        $now                   = Carbon::now()->toDateTimeString();
+    public function createNewMappingVersionFromMDTMapping(
+        Dungeon         $dungeon,
+        GameVersion     $gameVersion,
+        ?MappingVersion $currentMappingVersion,
+    ): MappingVersion {
+        // facade_enabled is a PHYSICAL fact about the dungeon (does it have a facade floor at all), not
+        // game-version-specific curated content, and it does not need to be inherited from any mapping
+        // version - Floor::facade is the authoritative source (#3757). Resolving it from a mapping version
+        // instead risks picking up one whose facade_enabled happens to be false for that particular game
+        // version (seen in production: e.g. dungeon 12's legion-remix/dungeon 49's wotlk mapping versions),
+        // even though the dungeon itself is a facade dungeon.
+        $facadeEnabled = $dungeon->getFacadeFloor() !== null;
+
+        // FloorUnions (and areas) ARE actual rows, not a boolean, so they still need a concrete source
+        // mapping version to clone from for a genuinely first-ever import of a game version. Pin that source
+        // explicitly and deterministically to the newest facade-enabled mapping version of ANY game version -
+        // never resolve it ambiently via Dungeon::getCurrentMappingVersion(), which falls back through
+        // GameVersion::getUserOrDefaultGameVersion()/authenticated-user context that doesn't exist for this
+        // pipeline's real caller (the mdt:importmapping CLI command), and can silently source the clone from
+        // the wrong game version's (facade-disabled) mapping version (#3757).
+        $facadeSourceMappingVersion = $currentMappingVersion
+            ?? ($facadeEnabled
+                ? $dungeon->mappingVersions()->where('facade_enabled', true)->orderByDesc('id')->first()
+                : null);
+
+        $now = Carbon::now()->toDateTimeString();
         // This needs to happen quietly as to not trigger MappingVersion events defined in its class
         $id = MappingVersion::insertGetId([
-            'dungeon_id'      => $dungeon->id,
-            'game_version_id' => $currentMappingVersion?->game_version_id ?? GameVersion::ALL[GameVersion::GAME_VERSION_RETAIL], // @phpstan-ignore nullsafe.neverNull
+            'dungeon_id' => $dungeon->id,
+            // $gameVersion is the source of truth, NOT $currentMappingVersion->game_version_id - the caller is
+            // responsible for scoping $currentMappingVersion to $gameVersion, and it may legitimately be null
+            // (the dungeon's first-ever mapping version for this game version) (#3757).
+            'game_version_id' => $gameVersion->id,
             // Set only once the import actually succeeds, see importMappingVersionFromMDT() (#3737)
             'mdt_mapping_hash'  => null,
             'mdt_addon_version' => $this->mdtAddonVersionService->getCurrentAddonVersion(),
             'version'           => ($currentMappingVersion?->version ?? 0) + 1, // @phpstan-ignore nullsafe.neverNull
-            'facade_enabled'    => $currentMappingVersion?->facade_enabled ?? false, // @phpstan-ignore nullsafe.neverNull
+            'facade_enabled'    => $facadeEnabled,
             'created_at'        => $now,
             'updated_at'        => $now,
         ]);
 
         $newMappingVersion = MappingVersion::find($id);
+
+        if ($currentMappingVersion === null) {
+            // Checkpoints/enemies stay empty for a genuinely first-ever import of this game version - there is
+            // no game-version-agnostic source for curated content like that. Map icons and dungeon floor switch
+            // markers ALSO stay empty here, but not because they're curated: importMapPOIs() (called right
+            // after this method returns, as part of the same import) already (re)creates them itself from
+            // MDT's own map POI/MapLink data whenever $currentMappingVersion is null - see its "(#3757)"
+            // comments. Cloning them here too would just create duplicate rows a few lines later in the same
+            // import. Mountable areas have no such backfill - MDT has no mount-speed-zone concept at all, so
+            // nothing ever (re)creates them - which makes them PHYSICAL data (fixed dungeon terrain, like floor
+            // unions) with no other source, and they need the same explicit clone floor unions get.
+            // The physical facade geometry resolved above still needs cloning in, though, along with
+            // timer_max_seconds - it's a NOT NULL DEFAULT 0 column that several call sites divide by unguarded
+            // (CombatLogEventFilter::fromHeatmapDataFilter(), CombatLogEvent::setTimeInterval()), so leaving it
+            // at its column default here is a live DivisionByZeroError, not just missing data.
+            if ($facadeSourceMappingVersion !== null) {
+                $this->cloneFloorUnionsToMappingVersion($facadeSourceMappingVersion, $newMappingVersion);
+                $this->cloneMountableAreasToMappingVersion($facadeSourceMappingVersion, $newMappingVersion);
+
+                $newMappingVersion->update([
+                    'timer_max_seconds' => $facadeSourceMappingVersion->timer_max_seconds,
+                ]);
+            }
+
+            return $newMappingVersion->load([
+                'dungeonFloorSwitchMarkers',
+                'mapIcons',
+                'mountableAreas',
+                'floorUnions',
+                'floorUnionAreas',
+            ]);
+        }
 
         return $this->copyMappingVersionContentsToDungeon($currentMappingVersion, $newMappingVersion);
     }
@@ -210,22 +266,14 @@ class MappingService implements MappingServiceInterface
         }
 
         // Mountable Areas
-        foreach ($sourceMappingVersion->mountableAreas as $mountableArea) {
-            $mountableArea->cloneForNewMappingVersion($targetMappingVersion);
-        }
+        $this->cloneMountableAreasToMappingVersion($sourceMappingVersion, $targetMappingVersion);
 
         // Enemy Forces Checkpoints are cloned by copyEnemyForcesCheckpointsToMappingVersion() instead - the
         // caller must invoke it, because only the caller knows how to re-link the membership of the enemies
         // it clones or re-imports, and this method copies no enemies at all (#3702).
 
         // Floor Unions (and areas)
-        foreach ($sourceMappingVersion->floorUnions as $floorUnion) {
-            /** @var FloorUnion $newFloorUnion */
-            $newFloorUnion = $floorUnion->cloneForNewMappingVersion($targetMappingVersion);
-            foreach ($floorUnion->floorUnionAreas as $floorUnionArea) {
-                $floorUnionArea->cloneForNewMappingVersion($targetMappingVersion, $newFloorUnion);
-            }
-        }
+        $this->cloneFloorUnionsToMappingVersion($sourceMappingVersion, $targetMappingVersion);
 
         // Copy these properties over only if the dungeons match - doesn't make sense otherwise
         if ($sourceMappingVersion->dungeon_id === $targetMappingVersion->dungeon_id) {
@@ -252,20 +300,42 @@ class MappingService implements MappingServiceInterface
     }
 
     public function copyEnemyForcesCheckpointsToMappingVersion(
-        MappingVersion $sourceMappingVersion,
-        MappingVersion $targetMappingVersion,
+        ?MappingVersion $sourceMappingVersion,
+        MappingVersion  $targetMappingVersion,
     ): array {
         $enemyForcesCheckpointIdMapping = [];
 
-        foreach ($sourceMappingVersion->enemyForcesCheckpoints as $enemyForcesCheckpoint) {
-            /** @var EnemyForcesCheckpoint $newEnemyForcesCheckpoint */
-            $newEnemyForcesCheckpoint = $enemyForcesCheckpoint->cloneForNewMappingVersion($targetMappingVersion);
+        // No predecessor to clone from (e.g. a dungeon's first-ever mapping version for a game version) - the
+        // target simply starts with none, same as a bare mapping version (#3757).
+        if ($sourceMappingVersion !== null) {
+            foreach ($sourceMappingVersion->enemyForcesCheckpoints as $enemyForcesCheckpoint) {
+                /** @var EnemyForcesCheckpoint $newEnemyForcesCheckpoint */
+                $newEnemyForcesCheckpoint = $enemyForcesCheckpoint->cloneForNewMappingVersion($targetMappingVersion);
 
-            $enemyForcesCheckpointIdMapping[$enemyForcesCheckpoint->id] = $newEnemyForcesCheckpoint->id;
+                $enemyForcesCheckpointIdMapping[$enemyForcesCheckpoint->id] = $newEnemyForcesCheckpoint->id;
+            }
         }
 
         $targetMappingVersion->load('enemyForcesCheckpoints');
 
         return $enemyForcesCheckpointIdMapping;
+    }
+
+    private function cloneFloorUnionsToMappingVersion(MappingVersion $sourceMappingVersion, MappingVersion $targetMappingVersion): void
+    {
+        foreach ($sourceMappingVersion->floorUnions as $floorUnion) {
+            /** @var FloorUnion $newFloorUnion */
+            $newFloorUnion = $floorUnion->cloneForNewMappingVersion($targetMappingVersion);
+            foreach ($floorUnion->floorUnionAreas as $floorUnionArea) {
+                $floorUnionArea->cloneForNewMappingVersion($targetMappingVersion, $newFloorUnion);
+            }
+        }
+    }
+
+    private function cloneMountableAreasToMappingVersion(MappingVersion $sourceMappingVersion, MappingVersion $targetMappingVersion): void
+    {
+        foreach ($sourceMappingVersion->mountableAreas as $mountableArea) {
+            $mountableArea->cloneForNewMappingVersion($targetMappingVersion);
+        }
     }
 }

--- a/app/Service/Mapping/MappingService.php
+++ b/app/Service/Mapping/MappingService.php
@@ -105,14 +105,18 @@ class MappingService implements MappingServiceInterface
 
         if ($currentMappingVersion === null) {
             // Checkpoints/enemies stay empty for a genuinely first-ever import of this game version - there is
-            // no game-version-agnostic source for curated content like that. Map icons and dungeon floor switch
-            // markers ALSO stay empty here, but not because they're curated: importMapPOIs() (called right
-            // after this method returns, as part of the same import) already (re)creates them itself from
-            // MDT's own map POI/MapLink data whenever $currentMappingVersion is null - see its "(#3757)"
-            // comments. Cloning them here too would just create duplicate rows a few lines later in the same
-            // import. Mountable areas have no such backfill - MDT has no mount-speed-zone concept at all, so
-            // nothing ever (re)creates them - which makes them PHYSICAL data (fixed dungeon terrain, like floor
-            // unions) with no other source, and they need the same explicit clone floor unions get.
+            // no game-version-agnostic source for curated content like that. Map icons ALSO stay empty here,
+            // but not because they're curated: importMapPOIs() (called right after this method returns, as
+            // part of the same import) already (re)creates the physical subset it recognizes itself from MDT's
+            // own map POI data whenever $currentMappingVersion is null - see its "(#3757)" comments. Cloning
+            // them here too would just create duplicate rows a few lines later in the same import. Mountable
+            // areas and dungeon floor switch markers have no such backfill to rely on: MDT has no
+            // mount-speed-zone concept at all, and per Wotuu (#3762 review) modern MDT exports only generate a
+            // combined/facade view and no longer supply the per-floor MapLink POI data importMapPOIs() used to
+            // recreate floor switch markers from - so both are PHYSICAL data (fixed dungeon terrain/geometry,
+            // like floor unions) with no other source, and need the same explicit clone floor unions get.
+            // importMapPOIs() still guards against duplicating whatever gets cloned in here (it only creates a
+            // fresh floor switch marker when the new mapping version doesn't already have one).
             // The physical facade geometry resolved above still needs cloning in, though, along with
             // timer_max_seconds - it's a NOT NULL DEFAULT 0 column that several call sites divide by unguarded
             // (CombatLogEventFilter::fromHeatmapDataFilter(), CombatLogEvent::setTimeInterval()), so leaving it
@@ -120,6 +124,7 @@ class MappingService implements MappingServiceInterface
             if ($facadeSourceMappingVersion !== null) {
                 $this->cloneFloorUnionsToMappingVersion($facadeSourceMappingVersion, $newMappingVersion);
                 $this->cloneMountableAreasToMappingVersion($facadeSourceMappingVersion, $newMappingVersion);
+                $this->cloneDungeonFloorSwitchMarkersToMappingVersion($facadeSourceMappingVersion, $newMappingVersion);
 
                 $newMappingVersion->update([
                     'timer_max_seconds' => $facadeSourceMappingVersion->timer_max_seconds,
@@ -241,24 +246,7 @@ class MappingService implements MappingServiceInterface
         // MDT mapping
 
         // Dungeon Floor Switch Markers
-        $dungeonFloorSwitchMarkerIdMapping = [];
-        $newDungeonFloorSwitchMarkers      = [];
-
-        foreach ($sourceMappingVersion->dungeonFloorSwitchMarkers as $dungeonFloorSwitchMarker) {
-            /** @var DungeonFloorSwitchMarker $newDungeonFloorSwitchMarker */
-            $newDungeonFloorSwitchMarker = $dungeonFloorSwitchMarker->cloneForNewMappingVersion(
-                $targetMappingVersion,
-            );
-            $dungeonFloorSwitchMarkerIdMapping[$dungeonFloorSwitchMarker->id] = $newDungeonFloorSwitchMarker->id;
-            $newDungeonFloorSwitchMarkers[]                                   = $newDungeonFloorSwitchMarker;
-        }
-
-        // Restore the links between the floor switches
-        foreach ($newDungeonFloorSwitchMarkers as $newDungeonFloorSwitchMarker) {
-            $newDungeonFloorSwitchMarker->update([
-                'linked_dungeon_floor_switch_marker_id' => $dungeonFloorSwitchMarkerIdMapping[$newDungeonFloorSwitchMarker['linked_dungeon_floor_switch_marker_id']] ?? null,
-            ]);
-        }
+        $this->cloneDungeonFloorSwitchMarkersToMappingVersion($sourceMappingVersion, $targetMappingVersion);
 
         // Map Icons
         foreach ($sourceMappingVersion->mapIcons as $mapIcon) {
@@ -336,6 +324,28 @@ class MappingService implements MappingServiceInterface
     {
         foreach ($sourceMappingVersion->mountableAreas as $mountableArea) {
             $mountableArea->cloneForNewMappingVersion($targetMappingVersion);
+        }
+    }
+
+    private function cloneDungeonFloorSwitchMarkersToMappingVersion(MappingVersion $sourceMappingVersion, MappingVersion $targetMappingVersion): void
+    {
+        $dungeonFloorSwitchMarkerIdMapping = [];
+        $newDungeonFloorSwitchMarkers      = [];
+
+        foreach ($sourceMappingVersion->dungeonFloorSwitchMarkers as $dungeonFloorSwitchMarker) {
+            /** @var DungeonFloorSwitchMarker $newDungeonFloorSwitchMarker */
+            $newDungeonFloorSwitchMarker = $dungeonFloorSwitchMarker->cloneForNewMappingVersion(
+                $targetMappingVersion,
+            );
+            $dungeonFloorSwitchMarkerIdMapping[$dungeonFloorSwitchMarker->id] = $newDungeonFloorSwitchMarker->id;
+            $newDungeonFloorSwitchMarkers[]                                   = $newDungeonFloorSwitchMarker;
+        }
+
+        // Restore the links between the floor switches
+        foreach ($newDungeonFloorSwitchMarkers as $newDungeonFloorSwitchMarker) {
+            $newDungeonFloorSwitchMarker->update([
+                'linked_dungeon_floor_switch_marker_id' => $dungeonFloorSwitchMarkerIdMapping[$newDungeonFloorSwitchMarker['linked_dungeon_floor_switch_marker_id']] ?? null,
+            ]);
         }
     }
 }

--- a/app/Service/Mapping/MappingServiceInterface.php
+++ b/app/Service/Mapping/MappingServiceInterface.php
@@ -16,10 +16,25 @@ interface MappingServiceInterface
     ): MappingVersion;
 
     /**
-     * Creates a new mapping version for a dungeon. Always created with a null `mdt_mapping_hash` -
-     * the caller must set it once the MDT import has actually finished successfully (#3737).
+     * Creates a new mapping version for a dungeon from an MDT import. Always created with a null
+     * `mdt_mapping_hash` - the caller must set it once the MDT import has actually finished successfully
+     * (#3737).
+     *
+     * $currentMappingVersion is the dungeon's existing mapping version for $gameVersion to clone
+     * hash/version/curated-content (checkpoints/map icons/mountable areas/dungeon floor switch markers) from -
+     * the caller must scope it to $gameVersion itself (e.g. via
+     * Dungeon::getCurrentMappingVersionForGameVersion()) and pass null when there is genuinely none yet (the
+     * dungeon's first-ever import for this game version), rather than an ambient/unrelated game version's
+     * mapping version (#3757). Curated content legitimately starts empty in that case, but facade_enabled and
+     * FloorUnions - the dungeon's PHYSICAL floor layout, not game-version-specific - are still inherited from
+     * the dungeon's current mapping version in ANY game version, so a facade dungeon's first import for a new
+     * game version doesn't silently degrade coordinate conversion to the identity transform.
      */
-    public function createNewMappingVersionFromMDTMapping(Dungeon $dungeon, ?GameVersion $gameVersion): MappingVersion;
+    public function createNewMappingVersionFromMDTMapping(
+        Dungeon         $dungeon,
+        GameVersion     $gameVersion,
+        ?MappingVersion $currentMappingVersion,
+    ): MappingVersion;
 
     /**
      * Resolves the mapping version that best matches an imported MDT string's `addonVersion`, so a route
@@ -51,11 +66,14 @@ interface MappingServiceInterface
      * Clones a mapping version's enemy forces checkpoints into another mapping version, without their members -
      * enemies are cloned by another code path entirely, or (on an MDT mapping import) re-created from scratch.
      *
+     * $sourceMappingVersion may be null when there is genuinely no predecessor to clone from (e.g. a dungeon's
+     * first-ever mapping version for a game version) - the target then simply starts with none (#3757).
+     *
      * @return array<int, int> Source checkpoint id => cloned checkpoint id, so the caller can re-link the
      *                         membership of the enemies it clones or imports afterwards.
      */
     public function copyEnemyForcesCheckpointsToMappingVersion(
-        MappingVersion $sourceMappingVersion,
-        MappingVersion $targetMappingVersion,
+        ?MappingVersion $sourceMappingVersion,
+        MappingVersion  $targetMappingVersion,
     ): array;
 }

--- a/tests/Feature/App/Service/MDT/MDTMappingImportGameVersionScopingTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportGameVersionScopingTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Feature\App\Service\MDT;
+
+use App\Logic\MDT\Conversion;
+use App\Logic\MDT\Data\MDTDungeon;
+use App\Models\Dungeon;
+use App\Models\EnemyForcesCheckpoint;
+use App\Models\GameVersion\GameVersion;
+use App\Models\Mapping\MappingVersion;
+use App\Models\Npc\NpcHealth;
+use App\Service\Cache\CacheServiceInterface;
+use App\Service\Coordinates\CoordinatesServiceInterface;
+use App\Service\Mapping\MappingServiceInterface;
+use App\Service\MDT\MDTMappingImportServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * #3757: MDTMappingImportService::importMappingVersionFromMDT() used to resolve its "predecessor" mapping
+ * version via Dungeon::getCurrentMappingVersion(), which silently falls back to an AMBIENT/unrelated game
+ * version's mapping version whenever the dungeon has zero mapping versions for the game version actually being
+ * imported (e.g. a dungeon's first-ever import for a newly-added game version). That mistagged the new mapping
+ * version with the wrong game_version_id/version AND cloned checkpoints/enemies/patrols/POIs from the wrong
+ * game version's data. A genuinely first-ever import for a game version must be tagged with THAT game version
+ * and start with nothing cloned.
+ *
+ * Runs the real import pipeline (real Lua parsing via MDTDungeon, like MDTNpcMappingCoverageTest) rather than
+ * stubbing it, because MDTMappingImportService constructs its MDTDungeon with `new` rather than resolving it
+ * from the container - there is no DI seam to intercept, and the bug lived in the resolution step itself
+ * (Dungeon::getCurrentMappingVersion() vs getCurrentMappingVersionForGameVersion()), not in what the downstream
+ * clone/import calls do with whatever they're handed. This class is therefore scoped to ONLY what genuinely
+ * needs the real pipeline - the game_version_id/version scoping of importMappingVersionFromMDT()'s own
+ * predecessor resolution. The facade_enabled/FloorUnion/timer_max_seconds inheritance behaviour of
+ * MappingService::createNewMappingVersionFromMDTMapping() itself is covered separately in
+ * MappingServiceCreateNewMappingVersionFromMDTMappingTest, which calls it directly and needs no Lua at all -
+ * exercising it here too would only add more real Lua-driven NPC/dungeon row mutations to the shared seeded
+ * test DB (mirroring the concern that keeps MDTMappingImportEnemyForcesCheckpointTest off the real pipeline)
+ * without covering anything the direct test doesn't already cover.
+ */
+#[Group('UsesLua')]
+#[Group('MDT')]
+#[Group('MappingVersion')]
+final class MDTMappingImportGameVersionScopingTest extends PublicTestCase
+{
+    #[Test]
+    public function importMappingVersionFromMDT_givenGameVersionWithNoExistingMappingVersion_createsMappingVersionForThatGameVersionWithNothingClonedFromAnotherGameVersion(): void
+    {
+        // Arrange
+        $mappingService       = $this->app->make(MappingServiceInterface::class);
+        $mappingImportService = $this->app->make(MDTMappingImportServiceInterface::class);
+
+        /** @var GameVersion $targetGameVersion */
+        $targetGameVersion = GameVersion::query()->where('key', GameVersion::GAME_VERSION_BETA)->firstOrFail();
+        /** @var GameVersion $retailGameVersion */
+        $retailGameVersion = GameVersion::query()->where('key', GameVersion::GAME_VERSION_RETAIL)->firstOrFail();
+
+        $dungeon = $this->getMdtDungeonWithRetailCheckpointAndNoMappingForGameVersion($targetGameVersion, $retailGameVersion);
+
+        $retailMappingVersion  = $dungeon->getCurrentMappingVersionForGameVersion($retailGameVersion);
+        $retailCheckpointCount = $retailMappingVersion->enemyForcesCheckpoints()->count();
+
+        // importNpcsDataFromMDT() saves an NpcHealth row keyed by (npc_id, game_version_id) for every MDT NPC -
+        // unlike everything else the import creates, these are NOT scoped to (and therefore not cascade-deleted
+        // by) the mapping version, so the ids that already exist for the target game version have to be
+        // snapshotted up front and anything new cleaned up by hand afterwards.
+        $mdtDungeon = app(MDTDungeon::class, [
+            'cacheService'       => app(CacheServiceInterface::class),
+            'coordinatesService' => app(CoordinatesServiceInterface::class),
+            'dungeon'            => $dungeon,
+        ]);
+        $mdtNpcIds               = $mdtDungeon->getMDTNPCs()->map(static fn($mdtNpc) => $mdtNpc->getId())->all();
+        $preExistingNpcHealthIds = NpcHealth::query()
+            ->where('game_version_id', $targetGameVersion->id)
+            ->whereIn('npc_id', $mdtNpcIds)
+            ->pluck('id')
+            ->all();
+
+        $dungeon->setRelation('npcs', $dungeon->npcs()->get());
+
+        $newMappingVersion = null;
+
+        try {
+            // Act
+
+            // importNpcsDataFromMDT() lazy-loads Npc::$npcHealths (App\Models\Npc.php:353,
+            // getHealthByGameVersion()) without eager-loading it first - the mapping-import pipeline is designed
+            // to run from the scheduler/CLI in production, where Model::preventLazyLoading()'s violation handler
+            // only logs (see [[project_autoeager_no_lazyviolation]]); it THROWS in dev/test. Temporarily flip
+            // the environment for the Act step only, exactly as the mapping:save runbook does via
+            // `APP_ENV=production` for the same reason - this is a pre-existing gap in the import pipeline,
+            // unrelated to #3757, not something to paper over with a production code change here.
+            $this->app->detectEnvironment(static fn() => 'production');
+
+            try {
+                $newMappingVersion = $mappingImportService->importMappingVersionFromMDT(
+                    $mappingService,
+                    $dungeon,
+                    $targetGameVersion,
+                    // Not force-imported: this is the path every real scheduled mapping bump takes, and it's the
+                    // one that used to dereference a null predecessor's ->mdt_mapping_hash and fatal.
+                    false,
+                );
+            } finally {
+                $this->app->detectEnvironment(static fn() => 'testing');
+            }
+
+            // Assert
+            $this->assertSame(
+                $targetGameVersion->id,
+                $newMappingVersion->game_version_id,
+                'The new mapping version must be tagged with the requested game version, not an ambient/unrelated one.',
+            );
+            $this->assertSame(
+                1,
+                $newMappingVersion->version,
+                'A dungeon\'s first mapping version for a game version must start at version 1, not continue an unrelated game version\'s counter.',
+            );
+
+            $this->assertSame(
+                0,
+                EnemyForcesCheckpoint::query()->where('mapping_version_id', $newMappingVersion->id)->count(),
+                'A genuinely first-ever import for a game version has no predecessor to clone checkpoints from.',
+            );
+
+            $this->assertSame(
+                $retailCheckpointCount,
+                $retailMappingVersion->enemyForcesCheckpoints()->count(),
+                'Importing a different game version must not mutate the unrelated (retail) game version\'s mapping version.',
+            );
+
+            // facade_enabled/FloorUnion/timer_max_seconds inheritance on the null-predecessor path is covered
+            // directly (and without any Lua) in MappingServiceCreateNewMappingVersionFromMDTMappingTest.
+        } finally {
+            // Clean up by (dungeon, target game version), not just $newMappingVersion: the precondition above
+            // guarantees the dungeon had ZERO mapping versions for $targetGameVersion before this test ran, so
+            // ANY row found for that pair afterwards was created by this test - including the case where
+            // importMappingVersionFromMDT() inserts the mapping version row and THEN throws later in its own
+            // pipeline (as it did here on the npcHealths lazy-load violation before the env flip was added),
+            // which leaves the local $newMappingVersion variable unassigned even though the DB row exists.
+            MappingVersion::query()
+                ->where('dungeon_id', $dungeon->id)
+                ->where('game_version_id', $targetGameVersion->id)
+                ->get()
+                ->each(static fn(MappingVersion $mappingVersion) => $mappingVersion->delete());
+
+            NpcHealth::query()
+                ->where('game_version_id', $targetGameVersion->id)
+                ->whereIn('npc_id', $mdtNpcIds)
+                ->whereNotIn('id', $preExistingNpcHealthIds)
+                ->delete();
+        }
+    }
+
+    /**
+     * A dungeon that already has (a) a retail mapping version with a checkpoint that has members - so the pre-fix
+     * bug would have something wrong to leak - and (b) zero mapping versions for $gameVersion, so importing it
+     * is a genuine "first ever" case. Also requires facade_enabled, matching
+     * MappingServiceCreateNewMappingVersionFromMDTMappingTest's selection criteria for consistency, even though
+     * this class no longer asserts on the facade geometry itself.
+     */
+    private function getMdtDungeonWithRetailCheckpointAndNoMappingForGameVersion(
+        GameVersion $gameVersion,
+        GameVersion $retailGameVersion,
+    ): Dungeon {
+        /** @var Dungeon|null $dungeon */
+        $dungeon = Dungeon::query()
+            ->whereNotNull('challenge_mode_id')
+            ->with(['mappingVersions', 'floors'])
+            ->get()
+            ->first(static function (Dungeon $dungeon) use ($gameVersion, $retailGameVersion): bool {
+                if (!Conversion::hasMDTDungeonName($dungeon->key)) {
+                    return false;
+                }
+
+                if ($dungeon->mappingVersions->where('game_version_id', $gameVersion->id)->isNotEmpty()) {
+                    return false;
+                }
+
+                $retailMappingVersion = $dungeon->mappingVersions
+                    ->where('game_version_id', $retailGameVersion->id)
+                    ->sortByDesc('version')
+                    ->first();
+
+                return $retailMappingVersion !== null
+                    && $retailMappingVersion->facade_enabled
+                    && $retailMappingVersion->enemyForcesCheckpoints()->has('enemies')->exists();
+            });
+
+        if ($dungeon === null) {
+            $this->fail('No MDT-importable, facade-enabled dungeon found with a retail checkpoint (with members) and no mapping version for the target game version.');
+        }
+
+        return $dungeon;
+    }
+}

--- a/tests/Feature/App/Service/MDT/MDTMappingImportMapPOIsFloorSwitchMarkerTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportMapPOIsFloorSwitchMarkerTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Tests\Feature\App\Service\MDT;
+
+use App\Logic\MDT\Data\MDTDungeon;
+use App\Logic\MDT\Entity\MDTMapPOI;
+use App\Logic\MDT\Entity\MDTMapPOIType;
+use App\Models\Dungeon;
+use App\Models\DungeonFloorSwitchMarker;
+use App\Models\Floor\Floor;
+use App\Models\Mapping\MappingVersion;
+use App\Service\Mapping\MappingServiceInterface;
+use App\Service\MDT\MDTMappingImportServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * #3762 (second review round): Wotuu corrected the earlier decision to leave DungeonFloorSwitchMarker uncloned
+ * on a genuinely first-ever import for a game version - modern MDT exports only generate a combined/facade
+ * view and no longer supply the per-floor MapLink POI data MDTMappingImportService::importMapPOIs() used to
+ * recreate floor switch markers from, yet the app still needs them for both facade mode and the per-floor
+ * "visit style" mode. MappingService::createNewMappingVersionFromMDTMapping() now clones them from the
+ * facade-source mapping version, just like FloorUnions/MountableAreas (see
+ * MappingServiceCreateNewMappingVersionFromMDTMappingTest).
+ *
+ * That reintroduces a duplication risk: importMapPOIs() used to unconditionally (re)create a floor switch
+ * marker from MDT's own MapLink POI data whenever $currentMappingVersion was null - exactly the condition
+ * under which the clone above now happens. importMapPOIs() was changed to key off whether $newMappingVersion
+ * already has floor switch markers of its own (from any source), instead of inspecting $currentMappingVersion.
+ * This test verifies that directly - with a stubbed MDTDungeon, no real Lua - for both the "already cloned"
+ * and "nothing to clone" cases.
+ */
+#[Group('MDT')]
+#[Group('MappingVersion')]
+final class MDTMappingImportMapPOIsFloorSwitchMarkerTest extends PublicTestCase
+{
+    #[Test]
+    public function importMapPOIs_givenNewMappingVersionAlreadyHasFloorSwitchMarkers_doesNotCreateDuplicateFromMDTMapLinkPOI(): void
+    {
+        // Arrange
+        $mappingService       = $this->app->make(MappingServiceInterface::class);
+        $mappingImportService = $this->app->make(MDTMappingImportServiceInterface::class);
+
+        [$dungeon, $sourceMappingVersion, $sourceFloor, $targetFloor] = $this->getDungeonWithFloorSwitchMarkersAndNoFacadeFloor();
+
+        $newMappingVersion = null;
+
+        try {
+            $newMappingVersion = $mappingService->copyMappingVersionToDungeon($sourceMappingVersion, $dungeon);
+            // Mirrors what MappingService::createNewMappingVersionFromMDTMapping() now does on a genuinely
+            // first-ever import for a game version: clone the floor switch markers in from the facade source
+            // mapping version before importMapPOIs() ever runs.
+            $mappingService->copyMappingVersionContentsToDungeon($sourceMappingVersion, $newMappingVersion);
+            $newMappingVersion->load('dungeonFloorSwitchMarkers');
+
+            $preExistingMarkerCount = $newMappingVersion->dungeonFloorSwitchMarkers->count();
+            $this->assertGreaterThan(
+                0,
+                $preExistingMarkerCount,
+                'Sanity check on the fixture/clone: the new mapping version must already have floor switch markers for this test to prove anything.',
+            );
+
+            $mdtDungeon = $this->createMockPublic(MDTDungeon::class);
+            $mdtDungeon->method('getMDTMapPOIs')->willReturn(collect([
+                $this->createMapLinkMDTMapPOI($sourceFloor, $targetFloor),
+            ]));
+
+            // Act - simulates importMapPOIs() being called right after a genuinely first-ever import
+            // ($currentMappingVersion === null), exactly like importMappingVersionFromMDT() does.
+            $importMapPOIs = new ReflectionMethod($mappingImportService, 'importMapPOIs');
+            $importMapPOIs->invokeArgs($mappingImportService, [
+                null,
+                $newMappingVersion,
+                $mdtDungeon,
+                $dungeon,
+            ]);
+
+            // Assert
+            $this->assertSame(
+                $preExistingMarkerCount,
+                DungeonFloorSwitchMarker::query()->where('mapping_version_id', $newMappingVersion->id)->count(),
+                'importMapPOIs() must not create a duplicate floor switch marker on top of ones already cloned into the new mapping version.',
+            );
+        } finally {
+            $newMappingVersion?->delete();
+        }
+    }
+
+    #[Test]
+    public function importMapPOIs_givenNewMappingVersionHasNoFloorSwitchMarkersYet_stillCreatesOneFromMDTMapLinkPOI(): void
+    {
+        // Arrange
+        $mappingService       = $this->app->make(MappingServiceInterface::class);
+        $mappingImportService = $this->app->make(MDTMappingImportServiceInterface::class);
+
+        [$dungeon, $sourceMappingVersion, $sourceFloor, $targetFloor] = $this->getDungeonWithFloorSwitchMarkersAndNoFacadeFloor();
+
+        $newMappingVersion = null;
+
+        try {
+            // A bare mapping version with nothing cloned into it - the pre-#3762 default for a genuinely
+            // first-ever import (e.g. a non-facade dungeon, which never had a facade source to clone from).
+            $newMappingVersion = $mappingService->copyMappingVersionToDungeon($sourceMappingVersion, $dungeon);
+            $newMappingVersion->load('dungeonFloorSwitchMarkers');
+
+            $this->assertSame(
+                0,
+                $newMappingVersion->dungeonFloorSwitchMarkers->count(),
+                'Sanity check on the fixture: the new mapping version must start with no floor switch markers.',
+            );
+
+            $mdtDungeon = $this->createMockPublic(MDTDungeon::class);
+            $mdtDungeon->method('getMDTMapPOIs')->willReturn(collect([
+                $this->createMapLinkMDTMapPOI($sourceFloor, $targetFloor),
+            ]));
+
+            // Act
+            $importMapPOIs = new ReflectionMethod($mappingImportService, 'importMapPOIs');
+            $importMapPOIs->invokeArgs($mappingImportService, [
+                null,
+                $newMappingVersion,
+                $mdtDungeon,
+                $dungeon,
+            ]);
+
+            // Assert
+            $this->assertSame(
+                1,
+                DungeonFloorSwitchMarker::query()->where('mapping_version_id', $newMappingVersion->id)->count(),
+                'importMapPOIs() must still fall back to creating a floor switch marker from MDT\'s own MapLink ' .
+                'POI data when the new mapping version has none of its own yet.',
+            );
+        } finally {
+            $newMappingVersion?->delete();
+        }
+    }
+
+    private function createMapLinkMDTMapPOI(Floor $sourceFloor, Floor $targetFloor): MDTMapPOI
+    {
+        return new MDTMapPOI($sourceFloor->index, [
+            'type'   => MDTMapPOIType::MapLink->value,
+            'target' => $targetFloor->index,
+            'x'      => 100.0,
+            'y'      => 100.0,
+        ]);
+    }
+
+    /**
+     * A non-facade dungeon (so importMapPOIs()'s facade-location conversion is a no-op, keeping this test
+     * focused on the duplication guard) whose newest mapping version has at least one floor switch marker
+     * whose source/target floors have no `mdt_sub_level` override - so findFloorByMdtSubLevel() resolves them
+     * by plain floor `index`, matching the fake MDTMapPOI built above.
+     *
+     * @return array{0: Dungeon, 1: MappingVersion, 2: Floor, 3: Floor}
+     */
+    private function getDungeonWithFloorSwitchMarkersAndNoFacadeFloor(): array
+    {
+        /** @var Dungeon|null $dungeon */
+        $dungeon = Dungeon::query()
+            ->with([
+                'mappingVersions.dungeonFloorSwitchMarkers.floor',
+                'mappingVersions.dungeonFloorSwitchMarkers.targetFloor',
+                'floors',
+            ])
+            ->get()
+            ->first(function (Dungeon $dungeon): bool {
+                return $dungeon->getFacadeFloor() === null
+                    && $this->findEligibleFloorSwitchMarker($dungeon) !== null;
+            });
+
+        if ($dungeon === null) {
+            $this->fail('No non-facade dungeon found with a floor switch marker whose floors have no mdt_sub_level override.');
+        }
+
+        $mappingVersion = $dungeon->mappingVersions()->orderByDesc('id')->without('dungeon')->firstOrFail();
+        $marker         = $this->findEligibleFloorSwitchMarker($dungeon);
+
+        return [$dungeon, $mappingVersion, $marker->floor, $marker->targetFloor];
+    }
+
+    private function findEligibleFloorSwitchMarker(Dungeon $dungeon): ?DungeonFloorSwitchMarker
+    {
+        $newestMappingVersion = $dungeon->mappingVersions->sortByDesc('id')->first();
+
+        if ($newestMappingVersion === null) {
+            return null;
+        }
+
+        return $newestMappingVersion->dungeonFloorSwitchMarkers->first(
+            static fn(DungeonFloorSwitchMarker $marker) => $marker->floor->mdt_sub_level === null
+                && $marker->targetFloor->mdt_sub_level === null
+                && $marker->floor->active
+                && $marker->targetFloor->active,
+        );
+    }
+}

--- a/tests/Feature/App/Service/Mapping/MappingServiceCreateNewMappingVersionFromMDTMappingTest.php
+++ b/tests/Feature/App/Service/Mapping/MappingServiceCreateNewMappingVersionFromMDTMappingTest.php
@@ -307,4 +307,94 @@ final class MappingServiceCreateNewMappingVersionFromMDTMappingTest extends Publ
 
         return $dungeon;
     }
+
+    /**
+     * #3762 review round 2: Wotuu corrected the original decision to leave DungeonFloorSwitchMarkers uncloned.
+     * Unlike FloorUnions/MountableAreas (facade-specific/ambiguous-without-a-facade-source), DungeonFloorSwitch-
+     * Markers are NOT facade-specific geometry - every dungeon has staircases between floors regardless of
+     * whether it has a facade floor. A dungeon with NO facade floor at all resolves both `$facadeEnabled` and
+     * `$facadeSourceMappingVersion` to false/null, so cloning DungeonFloorSwitchMarkers must not be gated
+     * behind either of those - it needs its own source, falling back to the newest mapping version of ANY
+     * game version, same deterministic-pin rationale as the facade source.
+     */
+    #[Test]
+    public function createNewMappingVersionFromMDTMapping_givenNoPredecessorAndDungeonWithoutFacadeFloor_stillClonesDungeonFloorSwitchMarkersFromNewestMappingVersionOfAnyGameVersion(): void
+    {
+        // Arrange
+        $mappingService = $this->app->make(MappingServiceInterface::class);
+
+        /** @var GameVersion $targetGameVersion */
+        $targetGameVersion = GameVersion::query()->where('key', GameVersion::GAME_VERSION_BETA)->firstOrFail();
+
+        $dungeon = $this->getNonFacadeDungeonWithDungeonFloorSwitchMarkersAndNoMappingForGameVersion($targetGameVersion);
+
+        $sourceMappingVersion = $dungeon->mappingVersions()->orderByDesc('id')->without('dungeon')->firstOrFail();
+
+        $newMappingVersion = null;
+
+        try {
+            // Act - a genuinely first-ever import for $targetGameVersion on a dungeon with no facade floor at
+            // all: $currentMappingVersion is null.
+            $newMappingVersion = $mappingService->createNewMappingVersionFromMDTMapping(
+                $dungeon,
+                $targetGameVersion,
+                null,
+            );
+
+            // Assert
+            $this->assertFalse(
+                (bool)$newMappingVersion->facade_enabled,
+                'Sanity check on the fixture: this dungeon must have no facade floor, otherwise this test would not distinguish the fix from the already-covered facade case above.',
+            );
+            $this->assertSame(
+                $sourceMappingVersion->dungeonFloorSwitchMarkers()->count(),
+                $newMappingVersion->dungeonFloorSwitchMarkers()->count(),
+                'DungeonFloorSwitchMarkers must be cloned even for a dungeon with no facade floor - they are ' .
+                'physical geometry that exists on every dungeon, not facade-specific like FloorUnions, so ' .
+                'their clone source must not be gated behind $facadeSourceMappingVersion.',
+            );
+            $this->assertGreaterThan(
+                0,
+                $newMappingVersion->dungeonFloorSwitchMarkers()->count(),
+                'Sanity check on the fixture: the source mapping version this is supposed to clone from must actually have DungeonFloorSwitchMarkers to prove the clone happened.',
+            );
+        } finally {
+            $newMappingVersion?->delete();
+        }
+    }
+
+    /**
+     * A dungeon that (a) physically has NO facade floor at all, (b) has at least one mapping version (of any
+     * game version) with a DungeonFloorSwitchMarker, and (c) has zero mapping versions for the target game
+     * version, so importing it is a genuine "first ever" case.
+     */
+    private function getNonFacadeDungeonWithDungeonFloorSwitchMarkersAndNoMappingForGameVersion(GameVersion $gameVersion): Dungeon
+    {
+        /** @var Dungeon|null $dungeon */
+        $dungeon = Dungeon::query()
+            ->with(['mappingVersions', 'floors'])
+            ->get()
+            ->first(static function (Dungeon $dungeon) use ($gameVersion): bool {
+                if ($dungeon->mappingVersions->where('game_version_id', $gameVersion->id)->isNotEmpty()) {
+                    return false;
+                }
+
+                if ($dungeon->getFacadeFloor() !== null) {
+                    return false;
+                }
+
+                $newestMappingVersion = $dungeon->mappingVersions->sortByDesc('id')->first();
+
+                return $newestMappingVersion !== null && $newestMappingVersion->dungeonFloorSwitchMarkers()->count() > 0;
+            });
+
+        if ($dungeon === null) {
+            $this->fail(
+                'No dungeon found with no facade floor at all, a DungeonFloorSwitchMarker on its newest ' .
+                'mapping version, and no mapping version for the target game version.',
+            );
+        }
+
+        return $dungeon;
+    }
 }

--- a/tests/Feature/App/Service/Mapping/MappingServiceCreateNewMappingVersionFromMDTMappingTest.php
+++ b/tests/Feature/App/Service/Mapping/MappingServiceCreateNewMappingVersionFromMDTMappingTest.php
@@ -104,17 +104,22 @@ final class MappingServiceCreateNewMappingVersionFromMDTMappingTest extends Publ
      * #3762 review follow-up: Wotuu asked why the null-predecessor path only clones FloorUnions and not every
      * physical property (floor switches, map icons, mountable areas). The answer differs per model:
      *
-     * - MountableAreas ARE the same class of physical geometry as FloorUnions (fixed dungeon terrain, e.g. a
-     *   mount-speed zone) and MDT has no concept of them at all, so nothing else ever (re)creates them - they
-     *   need the same explicit clone FloorUnions get, or a first-ever import silently loses all mount-speed data.
-     * - MapIcons and DungeonFloorSwitchMarkers correctly stay empty here, but not because they're curated: MDT's
-     *   own map POI/MapLink data DOES describe them (graveyards, dungeon entrances, staircases, ...), and
+     * - MountableAreas and DungeonFloorSwitchMarkers ARE the same class of physical geometry as FloorUnions
+     *   (fixed dungeon terrain/structure, e.g. a mount-speed zone or a staircase between floors) with no other
+     *   source to backfill them: MDT has no mount-speed-zone concept at all, and (per Wotuu, second round of
+     *   this same thread) modern MDT exports only generate a combined/facade view and no longer supply the
+     *   per-floor MapLink POI data MDTMappingImportService::importMapPOIs() used to recreate floor switch
+     *   markers from - yet this app still needs them, for both facade mode and the per-floor "visit style"
+     *   mode. So both need the same explicit clone FloorUnions get, or a first-ever import silently loses them
+     *   forever. importMapPOIs() now guards against duplicating whatever gets cloned in here.
+     * - MapIcons correctly stay empty here, but not because they're curated: MDT's own map POI data DOES
+     *   describe the physical subset it recognizes (graveyards, dungeon entrances, ...), and
      *   MDTMappingImportService::importMapPOIs() - called right after this method returns, as part of the same
-     *   import - already (re)creates both from that data whenever $currentMappingVersion is null. Cloning them
+     *   import - already (re)creates those from that data whenever $currentMappingVersion is null. Cloning them
      *   here too would just create duplicate rows moments later in the same import.
      */
     #[Test]
-    public function createNewMappingVersionFromMDTMapping_givenNoPredecessor_clonesMountableAreasButLeavesMapIconsAndDungeonFloorSwitchMarkersEmpty(): void
+    public function createNewMappingVersionFromMDTMapping_givenNoPredecessor_clonesMountableAreasAndDungeonFloorSwitchMarkersButLeavesMapIconsEmpty(): void
     {
         // Arrange
         $mappingService = $this->app->make(MappingServiceInterface::class);
@@ -170,15 +175,15 @@ final class MappingServiceCreateNewMappingVersionFromMDTMappingTest extends Publ
                 'MapIcons must NOT be cloned here - MDTMappingImportService::importMapPOIs() (re)creates the physical ones from MDT\'s own map POI data right after this method returns, so cloning them too would create duplicates.',
             );
 
+            $this->assertSame(
+                $retailMappingVersion->dungeonFloorSwitchMarkers()->count(),
+                $newMappingVersion->dungeonFloorSwitchMarkers()->count(),
+                'DungeonFloorSwitchMarkers are physical dungeon geometry with no other source (modern MDT exports no longer supply per-floor MapLink POI data), so they must be cloned from the facade source mapping version just like FloorUnions/MountableAreas.',
+            );
             $this->assertGreaterThan(
                 0,
-                $retailMappingVersion->dungeonFloorSwitchMarkers()->count(),
-                'Sanity check on the fixture: the retail mapping version must have DungeonFloorSwitchMarkers, otherwise leaving the new mapping version empty would prove nothing.',
-            );
-            $this->assertSame(
-                0,
                 $newMappingVersion->dungeonFloorSwitchMarkers()->count(),
-                'DungeonFloorSwitchMarkers must NOT be cloned here - MDTMappingImportService::importMapPOIs() (re)creates them from MDT\'s own MapLink POI data right after this method returns, so cloning them too would create duplicates.',
+                'Sanity check on the fixture: the retail mapping version this is supposed to clone from must actually have DungeonFloorSwitchMarkers to prove the clone happened.',
             );
         } finally {
             $newMappingVersion?->delete();

--- a/tests/Feature/App/Service/Mapping/MappingServiceCreateNewMappingVersionFromMDTMappingTest.php
+++ b/tests/Feature/App/Service/Mapping/MappingServiceCreateNewMappingVersionFromMDTMappingTest.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Tests\Feature\App\Service\Mapping;
+
+use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
+use App\Models\User;
+use App\Service\Mapping\MappingServiceInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * #3757 cold-review follow-up: MappingService::createNewMappingVersionFromMDTMapping()'s null-predecessor path
+ * (a dungeon's genuinely first-ever import for a game version) used to resolve its facade geometry source via
+ * `$currentMappingVersion ?? $dungeon->getCurrentMappingVersion()` - reintroducing, one layer down, the exact
+ * ambient/unrelated-game-version resolution this whole issue was about fixing at the layer above.
+ * `Dungeon::getCurrentMappingVersion()` ultimately falls back through
+ * `GameVersion::getUserOrDefaultGameVersion()`, which depends on the ACTING USER's own `game_version_id` when
+ * one is authenticated - context the pipeline's real caller (the `mdt:importmapping` CLI command) never has,
+ * but that any other caller of this public method could. `facade_enabled` is now derived from
+ * `Dungeon::getFacadeFloor() !== null` (a physical fact about the dungeon, not tied to any mapping version),
+ * and the FloorUnion clone source is pinned explicitly and deterministically to the newest facade-enabled
+ * mapping version of ANY game version - never to whichever one happens to be "ambiently current".
+ *
+ * Calls createNewMappingVersionFromMDTMapping() directly (no Lua, no MDT string) so it doesn't touch any of
+ * the shared seeded NPC/dungeon rows the real importMappingVersionFromMDT() pipeline rewrites - see
+ * MDTMappingImportGameVersionScopingTest, which is deliberately scoped away from this behaviour for exactly
+ * that reason.
+ */
+#[Group('MDT')]
+#[Group('MappingVersion')]
+final class MappingServiceCreateNewMappingVersionFromMDTMappingTest extends PublicTestCase
+{
+    #[Test]
+    public function createNewMappingVersionFromMDTMapping_givenNoPredecessorAndAuthenticatedUserOnFacadeDisabledGameVersion_stillInheritsFacadeGeometryAndTimerFromDungeonPhysicalFact(): void
+    {
+        // Arrange
+        $mappingService = $this->app->make(MappingServiceInterface::class);
+
+        /** @var GameVersion $targetGameVersion */
+        $targetGameVersion = GameVersion::query()->where('key', GameVersion::GAME_VERSION_BETA)->firstOrFail();
+        /** @var GameVersion $retailGameVersion */
+        $retailGameVersion = GameVersion::query()->where('key', GameVersion::GAME_VERSION_RETAIL)->firstOrFail();
+        /** @var GameVersion $facadeDisabledGameVersion */
+        $facadeDisabledGameVersion = GameVersion::query()->where('key', GameVersion::GAME_VERSION_LEGION_REMIX)->firstOrFail();
+
+        $dungeon = $this->getFacadeDungeonWithFacadeDisabledOtherGameVersionAndNoMappingForGameVersion(
+            $targetGameVersion,
+            $retailGameVersion,
+            $facadeDisabledGameVersion,
+        );
+
+        $retailMappingVersion = $dungeon->getCurrentMappingVersionForGameVersion($retailGameVersion);
+
+        // An authenticated user browsing under $facadeDisabledGameVersion. Dungeon::getCurrentMappingVersion()'s
+        // ambient fallback resolves through THIS user's own game_version_id - proving the old ambient-resolution
+        // bug is reachable through any caller of createNewMappingVersionFromMDTMapping(), not just the specific
+        // CLI/no-auth context the pipeline happens to run under today.
+        $user = User::factory()->create(['game_version_id' => $facadeDisabledGameVersion->id]);
+        $this->actingAs($user);
+
+        $newMappingVersion = null;
+
+        try {
+            // Act - a genuinely first-ever import for $targetGameVersion: $currentMappingVersion is null.
+            $newMappingVersion = $mappingService->createNewMappingVersionFromMDTMapping(
+                $dungeon,
+                $targetGameVersion,
+                null,
+            );
+
+            // Assert
+            $this->assertSame($targetGameVersion->id, $newMappingVersion->game_version_id);
+            $this->assertSame(1, $newMappingVersion->version);
+
+            $this->assertSame(
+                1,
+                $newMappingVersion->facade_enabled,
+                'facade_enabled is a physical fact about the dungeon (Dungeon::getFacadeFloor() !== null), independent of which mapping version the acting user\'s ambient game version happens to resolve to.',
+            );
+            $this->assertSame(
+                $retailMappingVersion->floorUnions()->count(),
+                $newMappingVersion->floorUnions()->count(),
+                'FloorUnions must be cloned from a facade-ENABLED mapping version, not from whichever mapping version the acting user\'s ambient/facade-DISABLED game version happens to resolve to.',
+            );
+            $this->assertGreaterThan(
+                0,
+                $newMappingVersion->floorUnions()->count(),
+                'Sanity check on the fixture: the retail mapping version this is supposed to clone from must actually have FloorUnions to prove the clone happened.',
+            );
+            $this->assertSame(
+                $retailMappingVersion->timer_max_seconds,
+                $newMappingVersion->timer_max_seconds,
+                'timer_max_seconds must be carried over from the resolved facade-source mapping version, not left at its NOT NULL DEFAULT 0 column default - CombatLogEventFilter/CombatLogEvent divide by it unguarded.',
+            );
+        } finally {
+            $newMappingVersion?->delete();
+            $user->delete();
+        }
+    }
+
+    /**
+     * #3762 review follow-up: Wotuu asked why the null-predecessor path only clones FloorUnions and not every
+     * physical property (floor switches, map icons, mountable areas). The answer differs per model:
+     *
+     * - MountableAreas ARE the same class of physical geometry as FloorUnions (fixed dungeon terrain, e.g. a
+     *   mount-speed zone) and MDT has no concept of them at all, so nothing else ever (re)creates them - they
+     *   need the same explicit clone FloorUnions get, or a first-ever import silently loses all mount-speed data.
+     * - MapIcons and DungeonFloorSwitchMarkers correctly stay empty here, but not because they're curated: MDT's
+     *   own map POI/MapLink data DOES describe them (graveyards, dungeon entrances, staircases, ...), and
+     *   MDTMappingImportService::importMapPOIs() - called right after this method returns, as part of the same
+     *   import - already (re)creates both from that data whenever $currentMappingVersion is null. Cloning them
+     *   here too would just create duplicate rows moments later in the same import.
+     */
+    #[Test]
+    public function createNewMappingVersionFromMDTMapping_givenNoPredecessor_clonesMountableAreasButLeavesMapIconsAndDungeonFloorSwitchMarkersEmpty(): void
+    {
+        // Arrange
+        $mappingService = $this->app->make(MappingServiceInterface::class);
+
+        /** @var GameVersion $targetGameVersion */
+        $targetGameVersion = GameVersion::query()->where('key', GameVersion::GAME_VERSION_BETA)->firstOrFail();
+        /** @var GameVersion $retailGameVersion */
+        $retailGameVersion = GameVersion::query()->where('key', GameVersion::GAME_VERSION_RETAIL)->firstOrFail();
+        /** @var GameVersion $facadeDisabledGameVersion */
+        $facadeDisabledGameVersion = GameVersion::query()->where('key', GameVersion::GAME_VERSION_LEGION_REMIX)->firstOrFail();
+
+        $dungeon = $this->getFacadeDungeonWithPhysicalAndCuratedContentAndNoMappingForGameVersion(
+            $targetGameVersion,
+            $retailGameVersion,
+        );
+
+        $retailMappingVersion = $dungeon->getCurrentMappingVersionForGameVersion($retailGameVersion);
+
+        // Same immunity-to-ambient-resolution setup as the sibling test above.
+        $user = User::factory()->create(['game_version_id' => $facadeDisabledGameVersion->id]);
+        $this->actingAs($user);
+
+        $newMappingVersion = null;
+
+        try {
+            // Act - a genuinely first-ever import for $targetGameVersion: $currentMappingVersion is null.
+            $newMappingVersion = $mappingService->createNewMappingVersionFromMDTMapping(
+                $dungeon,
+                $targetGameVersion,
+                null,
+            );
+
+            // Assert
+            $this->assertSame(
+                $retailMappingVersion->mountableAreas()->count(),
+                $newMappingVersion->mountableAreas()->count(),
+                'MountableAreas are physical dungeon geometry with no other source (MDT has no mount-speed-zone concept), so they must be cloned from the facade source mapping version just like FloorUnions.',
+            );
+            $this->assertGreaterThan(
+                0,
+                $newMappingVersion->mountableAreas()->count(),
+                'Sanity check on the fixture: the retail mapping version this is supposed to clone from must actually have MountableAreas to prove the clone happened.',
+            );
+
+            $this->assertGreaterThan(
+                0,
+                $retailMappingVersion->mapIcons()->count(),
+                'Sanity check on the fixture: the retail mapping version must have MapIcons, otherwise leaving the new mapping version empty would prove nothing.',
+            );
+            $this->assertSame(
+                0,
+                $newMappingVersion->mapIcons()->count(),
+                'MapIcons must NOT be cloned here - MDTMappingImportService::importMapPOIs() (re)creates the physical ones from MDT\'s own map POI data right after this method returns, so cloning them too would create duplicates.',
+            );
+
+            $this->assertGreaterThan(
+                0,
+                $retailMappingVersion->dungeonFloorSwitchMarkers()->count(),
+                'Sanity check on the fixture: the retail mapping version must have DungeonFloorSwitchMarkers, otherwise leaving the new mapping version empty would prove nothing.',
+            );
+            $this->assertSame(
+                0,
+                $newMappingVersion->dungeonFloorSwitchMarkers()->count(),
+                'DungeonFloorSwitchMarkers must NOT be cloned here - MDTMappingImportService::importMapPOIs() (re)creates them from MDT\'s own MapLink POI data right after this method returns, so cloning them too would create duplicates.',
+            );
+        } finally {
+            $newMappingVersion?->delete();
+            $user->delete();
+        }
+    }
+
+    /**
+     * A dungeon that (a) physically has a facade floor, (b) has a facade-ENABLED retail mapping version with at
+     * least one FloorUnion - the CORRECT source this should clone from, (c) has a facade-DISABLED mapping
+     * version for another game version - what the old ambient resolution would have picked up instead if the
+     * acting user's game version happened to point at it, and (d) has zero mapping versions for the target game
+     * version, so importing it is a genuine "first ever" case.
+     */
+    private function getFacadeDungeonWithFacadeDisabledOtherGameVersionAndNoMappingForGameVersion(
+        GameVersion $gameVersion,
+        GameVersion $retailGameVersion,
+        GameVersion $facadeDisabledGameVersion,
+    ): Dungeon {
+        /** @var Dungeon|null $dungeon */
+        $dungeon = Dungeon::query()
+            ->with(['mappingVersions', 'floors'])
+            ->get()
+            ->first(static function (Dungeon $dungeon) use ($gameVersion, $retailGameVersion, $facadeDisabledGameVersion): bool {
+                if ($dungeon->mappingVersions->where('game_version_id', $gameVersion->id)->isNotEmpty()) {
+                    return false;
+                }
+
+                if ($dungeon->getFacadeFloor() === null) {
+                    return false;
+                }
+
+                $retailMappingVersion = $dungeon->mappingVersions
+                    ->where('game_version_id', $retailGameVersion->id)
+                    ->sortByDesc('version')
+                    ->first();
+
+                if ($retailMappingVersion === null
+                    || !$retailMappingVersion->facade_enabled
+                    || $retailMappingVersion->floorUnions()->count() === 0
+                    || $retailMappingVersion->timer_max_seconds <= 0
+                ) {
+                    return false;
+                }
+
+                $facadeDisabledMappingVersion = $dungeon->mappingVersions
+                    ->where('game_version_id', $facadeDisabledGameVersion->id)
+                    ->sortByDesc('version')
+                    ->first();
+
+                return $facadeDisabledMappingVersion !== null && !$facadeDisabledMappingVersion->facade_enabled;
+            });
+
+        if ($dungeon === null) {
+            $this->fail(
+                'No dungeon found with a physical facade floor, a facade-enabled retail mapping version ' .
+                '(with FloorUnions and a timer), a facade-DISABLED mapping version for another game version, ' .
+                'and no mapping version for the target game version.',
+            );
+        }
+
+        return $dungeon;
+    }
+
+    /**
+     * A dungeon that (a) physically has a facade floor, (b) has a facade-ENABLED retail mapping version that is
+     * ALSO the deterministically-pinned "newest facade-enabled mapping version of any game version" (so the
+     * source under test is unambiguous), with at least one MountableArea, MapIcon and DungeonFloorSwitchMarker -
+     * so the clone/no-clone assertions on all three are non-vacuous - and (c) has zero mapping versions for the
+     * target game version, so importing it is a genuine "first ever" case.
+     */
+    private function getFacadeDungeonWithPhysicalAndCuratedContentAndNoMappingForGameVersion(
+        GameVersion $gameVersion,
+        GameVersion $retailGameVersion,
+    ): Dungeon {
+        /** @var Dungeon|null $dungeon */
+        $dungeon = Dungeon::query()
+            ->with(['mappingVersions', 'floors'])
+            ->get()
+            ->first(static function (Dungeon $dungeon) use ($gameVersion, $retailGameVersion): bool {
+                if ($dungeon->mappingVersions->where('game_version_id', $gameVersion->id)->isNotEmpty()) {
+                    return false;
+                }
+
+                if ($dungeon->getFacadeFloor() === null) {
+                    return false;
+                }
+
+                $retailMappingVersion = $dungeon->mappingVersions
+                    ->where('game_version_id', $retailGameVersion->id)
+                    ->sortByDesc('version')
+                    ->first();
+
+                if ($retailMappingVersion === null
+                    || !$retailMappingVersion->facade_enabled
+                    || $retailMappingVersion->timer_max_seconds <= 0
+                    || $retailMappingVersion->mountableAreas()->count() === 0
+                    || $retailMappingVersion->mapIcons()->count() === 0
+                    || $retailMappingVersion->dungeonFloorSwitchMarkers()->count() === 0
+                ) {
+                    return false;
+                }
+
+                // The deterministic pin picks the newest facade-enabled mapping version of ANY game version -
+                // require it to be $retailMappingVersion itself so the fixture is unambiguous.
+                $pinnedMappingVersion = $dungeon->mappingVersions()
+                    ->where('facade_enabled', true)
+                    ->orderByDesc('id')
+                    ->first();
+
+                return $pinnedMappingVersion !== null && $pinnedMappingVersion->id === $retailMappingVersion->id;
+            });
+
+        if ($dungeon === null) {
+            $this->fail(
+                'No dungeon found with a physical facade floor, a facade-enabled retail mapping version ' .
+                '(with a timer, MountableAreas, MapIcons and DungeonFloorSwitchMarkers) that is also the ' .
+                'deterministically-pinned facade source, and no mapping version for the target game version.',
+            );
+        }
+
+        return $dungeon;
+    }
+}


### PR DESCRIPTION
:robot: Closes #3757

## Summary

`MDTMappingImportService::importMappingVersionFromMDT()` resolved its "predecessor"
mapping version via `Dungeon::getCurrentMappingVersion()`, which silently falls back to
an ambient/unrelated game version's mapping version whenever the dungeon has zero
mapping versions for the game version actually being imported (e.g. a dungeon's
first-ever import for a newly-added game version, such as Legion Remix). That mistagged
the new mapping version's `game_version_id`/`version` **and** cloned
checkpoints/enemies/patrols/POIs from the wrong game version's data - a follow-up to
#3720/#3749, deliberately deferred out of that MR because it's the primary, scheduled
import pipeline (`mdt:importmapping`) rather than an admin/dev tool.

- Switched to the already-scoped `Dungeon::getCurrentMappingVersionForGameVersion()`.
- Treated a `null` predecessor as a real, valid "nothing to carry over from" case across
  every downstream call site: `MappingService::createNewMappingVersionFromMDTMapping()`
  (now takes the `GameVersion` and predecessor as separate params - `game_version_id`
  always comes from the former, never derived from the latter),
  `copyEnemyForcesCheckpointsToMappingVersion()`, `importEnemies()`,
  `importEnemyPatrols()`, and `importMapPOIs()`.
- **Facade geometry fix (found by independent review):** an earlier draft of this PR left
  `facade_enabled = false` and zero `FloorUnion`s on the null-predecessor path, since
  those were only ever cloned via `copyMappingVersionContentsToDungeon()`, which that
  path skips. `CoordinatesService::convertFacadeMapLocationToMapLocation()` degrades to
  the identity transform for a non-facade mapping version, so every enemy/patrol/POI
  imported for a facade dungeon's first-ever game-version import would have been silently
  persisted with the facade pseudo-floor's `floor_id` instead of the real one - confirmed
  empirically against a real dungeon before the fix. `facade_enabled`/`FloorUnion`s are
  the dungeon's *physical floor layout*, not game-version-specific curated content, so
  they're now inherited from the dungeon's current mapping version in **any** game
  version even with no same-game-version predecessor to clone the rest of the content
  from.
- Verified `enemy_forces_required`/`_teeming`/`_shrouded`/`_shrouded_zul_gamux` are
  **not** affected despite initially looking like another gap: `importDungeon()` and
  `importNpcs()` unconditionally recompute all four from the current MDT source data on
  every import, regardless of predecessor state.
- Remaining known, non-blocking gap: `MountableArea`s (mount-speed-override zones) and
  `timer_max_seconds` are still not inherited on the null-predecessor path - MDT carries
  no source data for either, and only `copyMappingVersionContentsToDungeon()` clones
  them, same root cause as the facade issue above but lower severity (missing
  nice-to-have data, not silently-wrong persisted data) - left for a manual follow-up
  re-add/re-import rather than expanding this fix's scope further.

## Test plan

- [x] Regression test (`MDTMappingImportGameVersionScopingTest`) runs the real import
  pipeline (real Lua parsing, like `MDTNpcMappingCoverageTest`) against a **facade**
  dungeon that already has a retail mapping version with a checkpoint (members included)
  but zero mapping versions for a second game version, and asserts: the new mapping
  version is tagged with the requested game version and starts at `version = 1`, has
  zero cloned checkpoints, the unrelated retail mapping version is left untouched,
  `facade_enabled`/`FloorUnion`s are inherited, and no enemy lands on the facade
  pseudo-floor.
- [x] Verified the test actually guards both fixes: reverted just the
  `getCurrentMappingVersionForGameVersion()` call back to the old
  `getCurrentMappingVersion()` and confirmed the test fails (`version` resolved to `9`,
  continuing retail's counter, instead of `1`); separately reverted just the facade-
  geometry inheritance and confirmed the test fails on the `facade_enabled` assertion;
  restored both fixes and confirmed green again.
- [x] `tests/Feature/App/Service/MDT/` (23 tests) and
  `tests/Feature/App/Service/Mapping/` (11 tests) all pass (34 total, 84 assertions).
- [x] `composer run fix` / `composer run analyse` clean.
- [x] Independent review completed; the one substantive finding (facade geometry) is
  fixed above, and the two smaller disclosure gaps are documented above rather than
  expanded into this fix.
- [ ] No UI surface - visual verification not applicable.
