### PR TITLE
#3755 Fail the whole MDT mapping import when a per-item save is swallowed

### DIFF
--- a/app/Service/MDT/Exceptions/MDTMappingImportPartialFailureException.php
+++ b/app/Service/MDT/Exceptions/MDTMappingImportPartialFailureException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Service\MDT\Exceptions;
+
+use Exception;
+
+/**
+ * Thrown by {@see \App\Service\MDT\MDTMappingImportService::importMappingVersionFromMDT()} when one or more
+ * per-item saves (NPCs, enemies) inside the import failed. Those failures are individually caught and
+ * logged where they occur - so the loop keeps going and the rest of the items still get imported - but the
+ * run as a whole must still be treated as failed: stamping the new mapping version's mdt_mapping_hash despite
+ * the losses would make every subsequent run compare hashes, see no change, and silently skip retrying
+ * forever while the dungeon stays missing whatever failed to import (#3755).
+ */
+class MDTMappingImportPartialFailureException extends Exception
+{
+    /**
+     * @param list<Exception> $failures
+     */
+    public function __construct(private readonly array $failures)
+    {
+        parent::__construct(sprintf(
+            '%d item(s) failed to import: %s',
+            count($failures),
+            implode('; ', array_map(static fn(Exception $failure) => $failure->getMessage(), $failures)),
+        ));
+    }
+
+    /**
+     * @return list<Exception>
+     */
+    public function getFailures(): array
+    {
+        return $this->failures;
+    }
+}

--- a/app/Service/MDT/Exceptions/MDTMappingImportPartialFailureException.php
+++ b/app/Service/MDT/Exceptions/MDTMappingImportPartialFailureException.php
@@ -19,11 +19,17 @@ class MDTMappingImportPartialFailureException extends Exception
      */
     public function __construct(private readonly array $failures)
     {
-        parent::__construct(sprintf(
-            '%d item(s) failed to import: %s',
-            count($failures),
-            implode('; ', array_map(static fn(Exception $failure) => $failure->getMessage(), $failures)),
-        ));
+        $messages = array_map(static fn(Exception $failure) => $failure->getMessage(), $failures);
+        $shown    = array_slice($messages, 0, 10);
+        if (count($messages) > 10) {
+            $shown[] = sprintf('and %d more', count($messages) - 10);
+        }
+
+        parent::__construct(
+            sprintf('%d item(s) failed to import: %s', count($failures), implode('; ', $shown)),
+            0,
+            $failures[0] ?? null,
+        );
     }
 
     /**

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -31,6 +31,7 @@ use App\Models\Spell\SpellDungeon;
 use App\Service\Cache\CacheServiceInterface;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use App\Service\Mapping\MappingServiceInterface;
+use App\Service\MDT\Exceptions\MDTMappingImportPartialFailureException;
 use App\Service\MDT\Logging\MDTMappingImportServiceLoggingInterface;
 use Exception;
 use Illuminate\Database\UniqueConstraintViolationException;
@@ -92,6 +93,10 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
 
             $mdtDungeon = new MDTDungeon($this->cacheService, $this->coordinatesService, $dungeon);
 
+            /** @var array<int, Exception> $importFailures NPC/enemy saves that were individually caught and
+             *  logged rather than propagated, so the loop kept going for the remaining items (#3755) */
+            $importFailures = [];
+
             try {
                 $this->log->importMappingVersionFromMDTStart($dungeon->id);
 
@@ -104,7 +109,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                 );
 
                 $this->importDungeon($mdtDungeon, $dungeon, $newMappingVersion);
-                $this->importNpcs($newMappingVersion, $mdtDungeon, $dungeon, $gameVersion);
+                $this->importNpcs($newMappingVersion, $mdtDungeon, $dungeon, $gameVersion, $importFailures);
                 $enemies = $this->importEnemies(
                     $currentMappingVersion,
                     $newMappingVersion,
@@ -112,10 +117,18 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                     $dungeon,
                     $enemyForcesCheckpointIdMapping,
                     $forceImport,
+                    $importFailures,
                 );
                 $this->importEnemyPacks($newMappingVersion, $mdtDungeon, $dungeon, $enemies);
                 $this->importEnemyPatrols($currentMappingVersion, $newMappingVersion, $mdtDungeon, $dungeon, $enemies);
                 $this->importMapPOIs($currentMappingVersion, $newMappingVersion, $mdtDungeon, $dungeon);
+
+                if (!empty($importFailures)) {
+                    // Every step above ran, but one or more individual NPCs/enemies were silently dropped
+                    // along the way - the mapping version is incomplete even though nothing propagated to
+                    // this try block on its own, so it must not be treated as a success (#3755).
+                    throw new MDTMappingImportPartialFailureException($importFailures);
+                }
 
                 // Only stamp the hash once every step above actually succeeded (#3737) - a mapping version
                 // recorded with the hash of MDT data it never finished importing would look up to date to
@@ -161,7 +174,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
         );
     }
 
-    public function importNpcsDataFromMDT(MDTDungeon $mdtDungeon, Dungeon $dungeon, GameVersion $gameVersion): void
+    public function importNpcsDataFromMDT(MDTDungeon $mdtDungeon, Dungeon $dungeon, GameVersion $gameVersion, array &$failures = []): void
     {
         try {
             $this->log->importNpcsDataFromMDTStart($dungeon->key);
@@ -270,9 +283,12 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                         $npc->createNpcEnemyForcesForExistingMappingVersions($mdtNpc->getCount());
                     }
                 } catch (UniqueConstraintViolationException) {
+                    // Expected and recoverable: another dungeon's import already inserted this NPC (or its
+                    // historical NpcEnemyForces rows) between our lookup and our write - not a real failure.
                     $this->log->importNpcsDataFromMDTNpcNotMarkedForAllDungeons($npc->id);
                 } catch (Exception $exception) {
                     $this->log->importNpcsDataFromMDTSaveNpcException($exception);
+                    $failures[] = $exception;
                 }
             }
 
@@ -388,6 +404,8 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
     }
 
     /**
+     * @param  array<int, Exception> $failures Appended with NPC saves that failed - see
+     *                                         importNpcsDataFromMDT()'s $failures parameter.
      * @throws Exception
      */
     private function importNpcs(
@@ -395,11 +413,12 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
         MDTDungeon     $mdtDungeon,
         Dungeon        $dungeon,
         GameVersion    $gameVersion,
+        array          &          $failures,
     ): void {
         try {
             $this->log->importNpcsStart();
 
-            $this->importNpcsDataFromMDT($mdtDungeon, $dungeon, $gameVersion);
+            $this->importNpcsDataFromMDT($mdtDungeon, $dungeon, $gameVersion, $failures);
 
             // Get a list of NPCs and update/save them (re-fetch the list to include any new NPCs)
             $npcs = $dungeon->npcs()->get()->keyBy('id');
@@ -439,6 +458,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                     }
                 } catch (Exception $exception) {
                     $this->log->importNpcsDataFromMDTSaveNpcException($exception);
+                    $failures[] = $exception;
                 }
             }
         } finally {
@@ -450,6 +470,8 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
      * @param  array<int, int>        $enemyForcesCheckpointIdMapping Source checkpoint id => cloned checkpoint id, as
      *                                                                built by MappingService when it cloned the
      *                                                                previous mapping version's checkpoints.
+     * @param  array<int, Exception>  $failures                       Appended with enemy saves that failed - see
+     *                                                                importNpcsDataFromMDT()'s $failures parameter.
      * @return Collection<int, Enemy>
      */
     private function importEnemies(
@@ -458,7 +480,8 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
         MDTDungeon     $mdtDungeon,
         Dungeon        $dungeon,
         array          $enemyForcesCheckpointIdMapping,
-        bool           $forceImport = false,
+        bool           $forceImport,
+        array          &          $failures,
     ): Collection {
         // Get a list of new enemies and save them
         try {
@@ -577,6 +600,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                     }
                 } catch (Exception $exception) {
                     $this->log->importEnemiesSaveNewEnemyException($exception);
+                    $failures[] = $exception;
                 }
             }
 

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -283,8 +283,10 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                         $npc->createNpcEnemyForcesForExistingMappingVersions($mdtNpc->getCount());
                     }
                 } catch (UniqueConstraintViolationException) {
-                    // Expected and recoverable: another dungeon's import already inserted this NPC (or its
-                    // historical NpcEnemyForces rows) between our lookup and our write - not a real failure.
+                    // Expected and recoverable, not a real failure: the NPC row already exists globally but
+                    // is not linked to this dungeon yet, so the dungeon-scoped lookup above missed it and we
+                    // attempted an insert on an existing primary key - the npc_dungeons link is written below,
+                    // so the next run takes the update path.
                     $this->log->importNpcsDataFromMDTNpcNotMarkedForAllDungeons($npc->id);
                 } catch (Exception $exception) {
                     $this->log->importNpcsDataFromMDTSaveNpcException($exception);

--- a/app/Service/MDT/MDTMappingImportServiceInterface.php
+++ b/app/Service/MDT/MDTMappingImportServiceInterface.php
@@ -7,6 +7,7 @@ use App\Models\Dungeon;
 use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
 use App\Service\Mapping\MappingServiceInterface;
+use Exception;
 
 interface MDTMappingImportServiceInterface
 {
@@ -19,7 +20,16 @@ interface MDTMappingImportServiceInterface
 
     public function getMDTMappingHash(Dungeon $dungeon): string;
 
-    public function importNpcsDataFromMDT(MDTDungeon $mdtDungeon, Dungeon $dungeon, GameVersion $gameVersion): void;
+    /**
+     * @param array<int, Exception> $failures Appended with any exception a per-NPC save legitimately failed
+     *                                        with - everything except the benign "already imported by
+     *                                        another dungeon" unique-constraint case. Only
+     *                                        importMappingVersionFromMDT() inspects this afterwards to
+     *                                        decide whether the whole import must fail (#3755); the
+     *                                        standalone mdt:importnpcs command leaves it at its default and
+     *                                        keeps behaving as before.
+     */
+    public function importNpcsDataFromMDT(MDTDungeon $mdtDungeon, Dungeon $dungeon, GameVersion $gameVersion, array &$failures = []): void;
 
     public function importSpellDataFromMDT(MDTDungeon $mdtDungeon, Dungeon $dungeon): void;
 }

--- a/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
@@ -9,12 +9,14 @@ use App\Service\Cache\CacheServiceInterface;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use App\Service\Mapping\MappingService;
 use App\Service\Mapping\MappingServiceInterface;
+use App\Service\MDT\Exceptions\MDTMappingImportPartialFailureException;
 use App\Service\MDT\Logging\MDTMappingImportServiceLoggingInterface;
 use App\Service\MDT\MDTAddonVersionServiceInterface;
 use App\Service\MDT\MDTMappingImportService;
 use App\Service\MDT\MDTMappingImportServiceInterface;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use RuntimeException;
 use Tests\TestCases\PublicTestCase;
 
@@ -166,5 +168,111 @@ final class MDTMappingImportCrashRecoveryTest extends PublicTestCase
 
             $dungeon->update(['mdt_id' => $originalDungeonMdtId]);
         }
+    }
+
+    /**
+     * #3755: importNpcs() used to catch a per-NPC exception, log it, and move on to the next NPC - so a
+     * genuine save failure never reached importMappingVersionFromMDT()'s outer catch, the new mapping
+     * version still got stamped with the fresh mdt_mapping_hash, and the next run saw "no change detected"
+     * and skipped retrying forever, exactly like #3737's symptom but through a different door.
+     *
+     * The failure is forced via a mocked MDTMappingImportServiceLoggingInterface that throws from
+     * importNpcsUpdateExistingNpc() - a log call inside importNpcs()'s per-NPC try block, right after the
+     * new mapping version's NpcEnemyForces row is created for it. That exercises the real per-item catch at
+     * the exact point #3755 describes, without needing to fabricate a genuine NPC-save failure.
+     *
+     * importNpcsDataFromMDT() is stubbed out for the same reason the success-path test above stubs it: it
+     * writes to shared Npc/NpcHealth/NpcSpell/NpcDungeon rows that are not scoped to the new mapping version,
+     * so a mapping-version delete cannot revert them. throne_of_the_tides already has every NPC MDT reports
+     * for it seeded, so importNpcs()'s re-fetch of the dungeon's NPCs still finds a real NPC - with count > 0
+     * - to reach the per-NPC try block that is being forced to fail.
+     */
+    #[Test]
+    public function importMappingVersionFromMDT_givenPerNpcSaveThrows_failsTheWholeImportInsteadOfSilentlyStampingTheHash(): void
+    {
+        // Arrange
+        /** @var Dungeon $dungeon */
+        $dungeon     = Dungeon::query()->where('key', 'throne_of_the_tides')->firstOrFail();
+        $gameVersion = GameVersion::query()->findOrFail($dungeon->getCurrentMappingVersion()->game_version_id);
+
+        $mappingVersionIdsBefore       = MappingVersion::query()->where('dungeon_id', $dungeon->id)->pluck('id')->sort()->values()->all();
+        $currentMappingVersionIdBefore = $this->highestVersionMappingVersionId($dungeon, $gameVersion);
+
+        $mappingService = $this->app->make(MappingServiceInterface::class);
+
+        $forcedFailureMessage = 'Forced failure to test partial-failure accumulation (#3755)';
+
+        /** @var MDTMappingImportServiceLoggingInterface&MockObject $mockLog */
+        $mockLog = $this->createMockPublic(MDTMappingImportServiceLoggingInterface::class);
+        $mockLog->method('importNpcsUpdateExistingNpc')
+            ->willThrowException(new RuntimeException($forcedFailureMessage));
+
+        $mappingImportService = $this->getMockBuilderPublic(MDTMappingImportService::class)
+            ->setConstructorArgs([
+                $this->app->make(CacheServiceInterface::class),
+                $this->app->make(CoordinatesServiceInterface::class),
+                $mockLog,
+            ])
+            ->onlyMethods(['importNpcsDataFromMDT'])
+            ->getMock();
+
+        // importDungeon() writes dungeons.mdt_id - the only side effect left outside the new mapping version
+        // once importNpcsDataFromMDT() is stubbed out - so it can be restored below.
+        $originalDungeonMdtId = $dungeon->mdt_id;
+
+        try {
+            // Act
+            try {
+                $mappingImportService->importMappingVersionFromMDT($mappingService, $dungeon, $gameVersion, true);
+
+                $this->fail('Expected the import to throw.');
+            } catch (MDTMappingImportPartialFailureException $exception) {
+                $this->assertNotEmpty($exception->getFailures(), 'The partial-failure exception must carry the failures that caused it.');
+                $this->assertSame($forcedFailureMessage, $exception->getFailures()[0]->getMessage());
+            }
+
+            // Assert
+            /** @var Dungeon $freshDungeon */
+            $freshDungeon = Dungeon::query()->findOrFail($dungeon->id);
+
+            $this->assertSame(
+                $currentMappingVersionIdBefore,
+                $this->highestVersionMappingVersionId($freshDungeon, $gameVersion),
+                'A partially-failed import must not change the dungeon\'s current mapping version.',
+            );
+
+            $this->assertSame(
+                $mappingVersionIdsBefore,
+                MappingVersion::query()->where('dungeon_id', $dungeon->id)->pluck('id')->sort()->values()->all(),
+                'A partially-failed import must not leave a half-built mapping version behind, even though ' .
+                'every import step ran to completion.',
+            );
+        } finally {
+            // Same cascade-safe cleanup as the crash-recovery test above, in case the fix regresses.
+            MappingVersion::destroy(
+                MappingVersion::query()
+                    ->where('dungeon_id', $dungeon->id)
+                    ->whereNotIn('id', $mappingVersionIdsBefore)
+                    ->pluck('id'),
+            );
+
+            $dungeon->update(['mdt_id' => $originalDungeonMdtId]);
+        }
+    }
+
+    /**
+     * A direct, game-version-scoped query, deliberately not Dungeon::getCurrentMappingVersion() - that
+     * method falls back through the caller's own game version, then the default game version, then (if
+     * still unmatched) the highest mapping version ID across ALL game versions. Comparing "before" and
+     * "after" through that fallback chain risks silently comparing two different game versions if either
+     * side happens to miss the scoped lookup.
+     */
+    private function highestVersionMappingVersionId(Dungeon $dungeon, GameVersion $gameVersion): ?int
+    {
+        return MappingVersion::query()
+            ->where('dungeon_id', $dungeon->id)
+            ->where('game_version_id', $gameVersion->id)
+            ->orderByDesc('version')
+            ->value('id');
     }
 }

--- a/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportCrashRecoveryTest.php
@@ -229,6 +229,11 @@ final class MDTMappingImportCrashRecoveryTest extends PublicTestCase
             } catch (MDTMappingImportPartialFailureException $exception) {
                 $this->assertNotEmpty($exception->getFailures(), 'The partial-failure exception must carry the failures that caused it.');
                 $this->assertSame($forcedFailureMessage, $exception->getFailures()[0]->getMessage());
+                $this->assertSame(
+                    $exception->getFailures()[0],
+                    $exception->getPrevious(),
+                    'The first accumulated failure must be preserved as the previous exception so its original stack trace is not lost.',
+                );
             }
 
             // Assert

--- a/tests/Feature/App/Service/MDT/MDTMappingImportEnemyForcesCheckpointTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportEnemyForcesCheckpointTest.php
@@ -71,14 +71,18 @@ final class MDTMappingImportEnemyForcesCheckpointTest extends PublicTestCase
                 $this->app->make(MDTMappingImportServiceInterface::class),
                 'importEnemies',
             );
-            $importEnemies->invoke(
+            $failures = [];
+            $importEnemies->invokeArgs(
                 $this->app->make(MDTMappingImportServiceInterface::class),
-                $sourceMappingVersion,
-                $newMappingVersion,
-                $mdtDungeon,
-                $dungeon,
-                $enemyForcesCheckpointIdMapping,
-                $forceImport,
+                [
+                    $sourceMappingVersion,
+                    $newMappingVersion,
+                    $mdtDungeon,
+                    $dungeon,
+                    $enemyForcesCheckpointIdMapping,
+                    $forceImport,
+                    &$failures,
+                ],
             );
 
             // Assert
@@ -183,14 +187,18 @@ final class MDTMappingImportEnemyForcesCheckpointTest extends PublicTestCase
                 $this->app->make(MDTMappingImportServiceInterface::class),
                 'importEnemies',
             );
-            $importEnemies->invoke(
+            $failures = [];
+            $importEnemies->invokeArgs(
                 $this->app->make(MDTMappingImportServiceInterface::class),
-                $sourceMappingVersion,
-                $newMappingVersion,
-                $mdtDungeon,
-                $dungeon,
-                $enemyForcesCheckpointIdMapping,
-                false,
+                [
+                    $sourceMappingVersion,
+                    $newMappingVersion,
+                    $mdtDungeon,
+                    $dungeon,
+                    $enemyForcesCheckpointIdMapping,
+                    false,
+                    &$failures,
+                ],
             );
 
             // Assert


### PR DESCRIPTION
:robot:

Closes #3755

## Summary

Follow-up to #3737/#3751. `importNpcsDataFromMDT()`, `importNpcs()`, and `importEnemies()` each
catch a genuine per-NPC/per-enemy save exception, log it, and move on to the next item - which is
good for letting the rest of the import proceed, but it also meant that exception never reached
`importMappingVersionFromMDT()`'s outer catch (added by #3751). The new mapping version still got
stamped with the fresh `mdt_mapping_hash` even though data was silently dropped, so the next run
saw "no change detected" and skipped retrying forever - #3737's exact symptom, through a different
door.

Each of the three swallowing catches now also appends the exception to a `$failures` accumulator
threaded through the call chain by reference. Once every import step in
`importMappingVersionFromMDT()` has run, it checks the accumulator and, if anything failed, throws
`MDTMappingImportPartialFailureException` instead of stamping the hash - which lets #3751's
existing outer catch delete the partial mapping version and retry cleanly next run.

**#3751 has since merged** - `importMappingVersionFromMDT()`'s "throw before stamping" behavior this
PR relies on comes from that merge. This branch was rebased onto current master after #3751/#3753
landed; the diff now shows only this PR's own changes.

## Audit: which catches changed, which didn't

- `importNpcsDataFromMDT()`'s `UniqueConstraintViolationException` case (another dungeon's import
  already inserted this NPC) is left alone, unchanged - the issue itself flagged this as expected
  and recoverable, not a real failure.
- `importNpcsDataFromMDT()`'s and `importNpcs()`'s generic `catch (Exception)`, and
  `importEnemies()`'s per-enemy `catch (Exception)`, now accumulate.
- `importEnemyPatrols()`'s existing `catch (Exception)` (unable to find the attached enemy) was
  already rethrowing - no change needed there.
- `importNpcs()`'s "NPC not found" `continue` (no matching NPC after `importNpcsDataFromMDT()`) is
  deliberately **not** wired into the failure set - NPCs in `IGNORE_NPC_DATA_NPC_IDS` legitimately
  skip that lookup by design, so treating it as a failure would misclassify an intentional skip.

## Known trade-off

This does change behavior for a genuinely non-recoverable per-item exception (e.g. a malformed DB
write on one specific NPC/enemy): instead of losing just that one item, the **whole dungeon's**
import now fails every run until the underlying data problem is fixed, rather than quietly limping
along missing that one item forever. That matches the issue's recommended shape - a dungeon stuck
on its previous, still-working mapping version is preferable to one silently missing enemies while
looking up to date - but it is a real behavior change worth flagging explicitly.

The partial-mapping-version-delete log (`importMappingVersionFromMDTDeletePartialMappingVersion`,
reused from #3751) is already logged at `error`, so this reaches the same visibility channel as
before.

## Test plan

- [x] New regression test: `MDTMappingImportCrashRecoveryTest::importMappingVersionFromMDT_givenPerNpcSaveThrows_failsTheWholeImportInsteadOfSilentlyStampingTheHash`
      - forces a per-NPC exception via a mocked logger (throws from `importNpcsUpdateExistingNpc()`,
        a log call inside `importNpcs()`'s per-NPC try block) and asserts the import throws
        `MDTMappingImportPartialFailureException`, the dungeon's current mapping version is
        unchanged, and no half-built mapping version is left behind.
- [x] `MDTMappingImportEnemyForcesCheckpointTest` updated for `importEnemies()`'s new `$failures`
      parameter (it invokes the private method via Reflection).
- [x] `--group=MDT --group=MappingVersion --group=EnemyForcesCheckpoint` green, run repeatedly to
      rule out flakiness.
- [x] `composer run fix` / `composer run analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Cold-review follow-up

Addressed the three inline findings from the cold review:
- `MDTMappingImportPartialFailureException` now passes the first accumulated failure as `$previous`
  (so its stack trace/class survive the rethrow) and caps the concatenated message to the first 10
  failures; covered by a new assertion in `MDTMappingImportCrashRecoveryTest`.
- Corrected the `UniqueConstraintViolationException` comment: the collision is deterministic (an
  NPC that exists globally but isn't yet linked to this dungeon), not a race - behavior unchanged.
- Left the `array &$failures` parameter spacing in `importNpcs()`/`importEnemies()` as-is: it's what
  `php-cs-fixer`'s `ErickSkrauch/align_multiline_parameters` fixer produces for this multi-line
  parameter list (`--dry-run` is clean on the current form; hand-editing it to single-sided padding
  gets reverted by `composer run fix` and would fail the `php-cs-fixer` CI job).
