### PR TITLE
Handle a Patreon member missing the email attribute entirely

### DIFF
--- a/app/Service/Patreon/PatreonService.php
+++ b/app/Service/Patreon/PatreonService.php
@@ -149,7 +149,9 @@ class PatreonService implements PatreonServiceInterface
         try {
             $this->log->applyPaidBenefitsForMemberStart($member['id']);
 
-            $memberEmail = $member['attributes']['email'];
+            // The email attribute can be entirely absent for a member instead of present-but-null, so this can't
+            // rely on the key always being set (#3767) - a missing key is handled the same as an empty value below
+            $memberEmail = $member['attributes']['email'] ?? null;
 
             if (empty($memberEmail)) {
                 $this->log->applyPaidBenefitsForMemberEmptyMemberEmail();

--- a/tests/Feature/App/Service/Patreon/PatreonServiceTest.php
+++ b/tests/Feature/App/Service/Patreon/PatreonServiceTest.php
@@ -113,6 +113,27 @@ final class PatreonServiceTest extends PublicTestCase
         $this->assertDatabaseHas('patreon_user_benefits', ['id' => $patreonUserBenefit->id]);
     }
 
+    #[Test]
+    public function applyPaidBenefitsForMember_givenMemberAttributesWithoutEmailKey_returnsMemberNotLinked(): void
+    {
+        // Arrange
+        $member = [
+            'id'            => 'member-1',
+            'type'          => 'member',
+            'attributes'    => [],
+            'relationships' => ['currently_entitled_tiers' => ['data' => []]],
+        ];
+
+        /** @var PatreonServiceInterface $patreonService */
+        $patreonService = $this->app->make(PatreonServiceInterface::class);
+
+        // Act
+        $result = $patreonService->applyPaidBenefitsForMember([], [], $member);
+
+        // Assert
+        $this->assertSame(ApplyPaidBenefitsForMemberResult::MemberNotLinked, $result);
+    }
+
     private function createPatron(): void
     {
         $this->user = User::factory()->create();


### PR DESCRIPTION
:robot: Closes #3767

## Summary
- `patreon:refreshmembers` crashed on `Undefined array key "email"` at `PatreonService.php:152` for
  one member. `RefreshMembershipStatus::handle()` already wraps each member in its own
  `try { applyPaidBenefitsForMember(...) } catch (Throwable)` (from #3750), so the run itself kept
  going for every other member — the affected member's failure was reported (per #3750's exception
  reporting) and the command exited FAILURE with that member named, rather than the whole run
  aborting.
- `applyPaidBenefitsForMember()` already handles an *empty* email (`empty($memberEmail)` →
  `MemberNotLinked`), but read `$member['attributes']['email']` unguarded, so a member whose
  `attributes` array had no `email` key at all (rather than a null value) threw instead of
  falling into that existing handling.
- Fix: `$member['attributes']['email'] ?? null`. Confirmed a missing key is still logged with the
  member's id attached - `applyPaidBenefitsForMemberStart($member['id'])` registers it in the
  structured-logging grouped context, which stays attached to every log line (including the
  empty-email log) until `end()` is called - so this doesn't repeat the #3748 trap of turning a
  loud failure into a silent, unidentifiable one.

## Test plan
- [x] Added `applyPaidBenefitsForMember_givenMemberAttributesWithoutEmailKey_returnsMemberNotLinked`,
      verified it reproduces the exact production error before the fix and passes after
- [x] `php artisan test --compact --filter=PatreonServiceTest` (4 passed)
- [x] `composer run analyse` - no new PHPStan errors (pre-existing CBOR/vendor-lock skew noise only)
- [x] `composer run fix` - no changes needed
