### PR TITLE
#3761 Keep the dungeon selector on the current season until the next one starts

### DIFF
--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -59,11 +59,13 @@ try {
 
 ### `SeederModel` models silently refuse `$model->delete()`
 
-Models using the `SeederModel` trait (`Season`, `SeasonDungeon`, `Dungeon`, `Expansion`, …) register a
-`deleting` hook that returns `false` unless the **authenticated** user is an admin. `$model->delete()`
-then does nothing and returns `false` — no exception — so a `finally` that looks correct leaves the row
-behind and poisons the shared DB for every later test (a leftover `Season` with no dungeons breaks any
-test doing `Season::orderByDesc('id')->first()->dungeons()`).
+~51 models use the `SeederModel` trait (`Season`, `SeasonDungeon`, `Expansion`, `EnemyPack`,
+`GameServerRegion`, … — check with `grep -rln "use SeederModel;" app/Models/`; `Dungeon` is **not** one of
+them). It registers a `deleting` hook that returns `false` unless the **authenticated** user is an admin.
+`$model->delete()` then does nothing and returns `false` — no exception — so a `finally` that looks
+correct leaves the row behind and poisons the shared DB for every later test (a leftover `Season` with no
+dungeons breaks any test doing `Season::orderByDesc('id')->first()->dungeons()`). The hook exempts
+`MappingVersion`, `Floor` and `Enemy`, which delete normally.
 
 Clean these up through the query builder, which does not fire model events:
 
@@ -80,7 +82,22 @@ Two caches make freshly created/deleted rows invisible in tests, and neither is 
 - **laravel-model-caching** (every `CacheModel`) — flush with `new Model()->flushCache()`.
 - **`RemembersToFile`** (`ViewService::cachedGlobal`, map context, …) writes to `Cache::store('tmp_file')`,
   a **file** store that survives between test runs. If your test touches `ViewService`, flush it:
-  `Cache::store('tmp_file')->flush()`.
+  `Cache::store('tmp_file')->flush()`. `phpunit.xml` points `CACHE_FILE_PATH` at `/tmp/phpunit_cache` so
+  that flush cannot reach the cache of the app running out of the same checkout.
+
+Create fixtures **inside** the `try`, not before it, so a failure halfway through setup still cleans up:
+
+```php
+$season = null;
+
+try {
+    $season = Season::create([...]);
+    SeasonDungeon::create([...]);   // this throwing must not leave $season behind
+    // Act + Assert
+} finally {
+    if ($season !== null) { /* delete */ }
+}
+```
 
 ## Creating users & roles (Laratrust)
 

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -57,6 +57,31 @@ try {
 
 `DungeonRoute` has no soft-deletes, so `delete()` truly removes the row.
 
+### `SeederModel` models silently refuse `$model->delete()`
+
+Models using the `SeederModel` trait (`Season`, `SeasonDungeon`, `Dungeon`, `Expansion`, …) register a
+`deleting` hook that returns `false` unless the **authenticated** user is an admin. `$model->delete()`
+then does nothing and returns `false` — no exception — so a `finally` that looks correct leaves the row
+behind and poisons the shared DB for every later test (a leftover `Season` with no dungeons breaks any
+test doing `Season::orderByDesc('id')->first()->dungeons()`).
+
+Clean these up through the query builder, which does not fire model events:
+
+```php
+} finally {
+    Season::query()->whereKey($season->id)->delete();
+    // No model events fired, so laravel-model-caching does not invalidate on its own
+    new Season()->flushCache();
+}
+```
+
+Two caches make freshly created/deleted rows invisible in tests, and neither is the `array` store
+`phpunit.xml` configures:
+- **laravel-model-caching** (every `CacheModel`) — flush with `new Model()->flushCache()`.
+- **`RemembersToFile`** (`ViewService::cachedGlobal`, map context, …) writes to `Cache::store('tmp_file')`,
+  a **file** store that survives between test runs. If your test touches `ViewService`, flush it:
+  `Cache::store('tmp_file')->flush()`.
+
 ## Creating users & roles (Laratrust)
 
 - **Admin**: `User::findOrFail(1)` — the seeded admin. Assert it defensively:

--- a/app/Http/View/Composers/DungeonGridTabsComposer.php
+++ b/app/Http/View/Composers/DungeonGridTabsComposer.php
@@ -4,6 +4,7 @@ namespace App\Http\View\Composers;
 
 use App\Service\View\RequestViewContextInterface;
 use App\Service\View\ViewServiceInterface;
+use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 readonly class DungeonGridTabsComposer implements ViewComposerInterface
@@ -11,6 +12,7 @@ readonly class DungeonGridTabsComposer implements ViewComposerInterface
     public function __construct(
         private ViewServiceInterface        $viewService,
         private RequestViewContextInterface $requestViewContext,
+        private Request                     $request,
     ) {
     }
 
@@ -20,5 +22,9 @@ readonly class DungeonGridTabsComposer implements ViewComposerInterface
         $view->with('activeExpansions', $this->viewService->getActiveExpansions());
         $view->with('currentSeason', $this->viewService->getCurrentSeasonForRegion($gameServerRegion));
         $view->with('nextSeason', $this->viewService->getNextSeasonForRegion($gameServerRegion));
+
+        // Which season's tab to open on - the current season unless another one was explicitly asked for,
+        // for example through the header's "next season" card (#3761). Garbage input casts to 0 = none.
+        $view->with('requestedSeasonId', $this->request->integer('season') ?: null);
     }
 }

--- a/app/Http/View/Composers/HeaderComposer.php
+++ b/app/Http/View/Composers/HeaderComposer.php
@@ -4,13 +4,16 @@ namespace App\Http\View\Composers;
 
 use App\Models\AffixGroup\AffixGroup;
 use App\Models\AffixGroup\AffixGroupEaseTier;
+use App\Models\GameServerRegion;
 use App\Models\GameVersion\GameVersion;
+use App\Models\Season;
 use App\Service\AffixGroup\AffixGroupEaseTierServiceInterface;
 use App\Service\Cache\CacheServiceInterface;
 use App\Service\Dungeon\DungeonServiceInterface;
 use App\Service\Season\SeasonAffixGroupServiceInterface;
 use App\Service\View\RequestViewContextInterface;
 use App\Service\View\ViewServiceInterface;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\View\View;
 
@@ -32,13 +35,25 @@ readonly class HeaderComposer implements ViewComposerInterface
 
         $currentSeason = $this->viewService->getCurrentSeasonForRegion($gameServerRegion);
 
+        $nextSeason = $this->viewService->getNextSeasonForRegion($gameServerRegion);
+
         $view->with('activeExpansions', $this->viewService->getActiveExpansions());
         $view->with('currentSeason', $currentSeason);
-        $view->with('nextSeason', $this->viewService->getNextSeasonForRegion($gameServerRegion));
+        $view->with('nextSeason', $nextSeason);
         $view->with('allGameVersions', $this->viewService->getAllGameVersions());
 
         $userOrDefaultGameVersion = GameVersion::getUserOrDefaultGameVersion();
         $view->with('gameVersionDungeons', $this->dungeonService->getDungeonsForGameVersion($userOrDefaultGameVersion));
+
+        // The dungeon context bar follows the current season only (#3761) - the upcoming season is
+        // advertised next to it as a card of its own, leading to a selection of just its dungeons.
+        $upcomingSeason = $this->getUpcomingSeason($nextSeason, $gameServerRegion);
+
+        $view->with('dungeonContextNextSeason', $upcomingSeason);
+        $view->with('dungeonContextNextSeasonLink', $upcomingSeason === null ? null : route('dungeon.explore.gameversion.select', [
+            'gameVersion' => $userOrDefaultGameVersion,
+            'season'      => $upcomingSeason->id,
+        ]));
 
         // Ease tiers for the dungeon-context strip ("what's easy this week", archon.gg data). The header
         // renders on every page, so the current affix group + tier lookup are resolved once and cached
@@ -47,6 +62,22 @@ readonly class HeaderComposer implements ViewComposerInterface
 
         $view->with('dungeonContextCurrentAffixGroup', $currentAffixGroup);
         $view->with('dungeonContextEaseTiers', $this->getEaseTiers($currentAffixGroup));
+    }
+
+    /**
+     * The next season, but only once it is close enough to its start to be worth advertising. A season is seeded
+     * weeks - sometimes months - before it starts so its mapping can be reviewed, and until then it should not be
+     * visible on the site at all.
+     */
+    private function getUpcomingSeason(?Season $nextSeason, GameServerRegion $gameServerRegion): ?Season
+    {
+        if ($nextSeason === null) {
+            return null;
+        }
+
+        $upcomingVisibleAt = Carbon::now()->addDays((int)config('keystoneguru.season.upcoming_visible_days'));
+
+        return $nextSeason->start($gameServerRegion)->isBefore($upcomingVisibleAt) ? $nextSeason : null;
     }
 
     /**

--- a/app/Http/View/Composers/HeaderComposer.php
+++ b/app/Http/View/Composers/HeaderComposer.php
@@ -47,7 +47,11 @@ readonly class HeaderComposer implements ViewComposerInterface
 
         // The dungeon context bar follows the current season only (#3761) - the upcoming season is
         // advertised next to it as a card of its own, leading to a selection of just its dungeons.
-        $upcomingSeason = $this->getUpcomingSeason($nextSeason, $gameServerRegion);
+        // Seasons are a retail concept: the dungeon selection hides every season for a game version
+        // without them, so advertising one there would lead to a page that cannot show it.
+        $upcomingSeason = $userOrDefaultGameVersion->has_seasons
+            ? $this->getUpcomingSeason($nextSeason, $gameServerRegion)
+            : null;
 
         $view->with('dungeonContextNextSeason', $upcomingSeason);
         $view->with('dungeonContextNextSeasonLink', $upcomingSeason === null ? null : route('dungeon.explore.gameversion.select', [

--- a/app/Service/Dungeon/DungeonService.php
+++ b/app/Service/Dungeon/DungeonService.php
@@ -117,19 +117,19 @@ class DungeonService implements DungeonServiceInterface
         // Resort to finding a default dungeon of sorts
         $gameVersion ??= GameVersion::getUserOrDefaultGameVersion();
 
+        // Only ever the current season - a season is seeded weeks ahead of its start for review and QA
+        // (#3739), and until it starts its dungeons are not playable, so they must not push the current
+        // season's dungeons out of the selector (#3761). The upcoming season gets its own entry point
+        // instead: the "next season" card that HeaderComposer adds to the dungeon context bar.
         $currentSeason = $this->seasonService->getCurrentSeason($gameVersion->expansion);
-        $nextSeason    = $currentSeason === null ? null : $this->seasonService->getNextSeason($currentSeason);
 
-        // Load the relation explicitly rather than reading it lazily. getNextSeason() returns a season out
-        // of a collection, so as soon as an upcoming season exists the lazy read trips preventLazyLoading
-        // and takes down every page that renders the header (HeaderComposer). This never fired before
-        // because getNextSeason() returned null while no future season was seeded, and the current season
-        // it fell back to is loaded as a single model, which the guard exempts.
+        // Load the relation explicitly rather than reading it lazily - a season read out of a collection
+        // trips preventLazyLoading, which takes down every page that renders the header (HeaderComposer).
         //
         // Deliberately dungeons()->get() and NOT loadMissing(): SeasonService keeps its season models in a
         // service-level cache, so memoising the relation onto them makes it outlive the request and leak a
         // stale dungeon list into later ones. That was measurable - loadMissing() turned the suite red with
         // a route being created against the wrong dungeon.
-        return ($nextSeason ?? $currentSeason)?->dungeons()->get() ?? $gameVersion->expansion->dungeons;
+        return $currentSeason?->dungeons()->get() ?? $gameVersion->expansion->dungeons;
     }
 }

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -258,6 +258,17 @@ return [
     ],
 
     /**
+     * Seasons of the game
+     */
+    'season' => [
+        /**
+         * The amount of days before a season starts that it is advertised on the site as the upcoming season. Seasons
+         * are seeded well before they start so that their mapping can be reviewed, which should not affect the site.
+         */
+        'upcoming_visible_days' => 14,
+    ],
+
+    /**
      * For the discover section of the site - this controls various variables
      */
     'discover' => [

--- a/lang/en_US/view_common.php
+++ b/lang/en_US/view_common.php
@@ -14,7 +14,8 @@ return [
             'new'     => 'New',
         ],
         'list' => [
-            'card' => [
+            'next_season' => 'Next season',
+            'card'        => [
                 'this_week_tier' => 'This week\'s difficulty tier (archon.gg)',
             ],
         ],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,10 @@
         <env name="PENNANT_STORE" value="array"/>
         <env name="LOG_CHANNEL" value="daily"/>
         <env name="APP_SERVICES_CACHE" value="/tmp/phpunit_services.php"/>
+        <!-- The 'tmp_file' store (RemembersToFile, used by ViewService among others) is a file cache that
+             CACHE_STORE does not cover. Without this the tests read, write and flush the cache of the
+             application running out of the same checkout. -->
+        <env name="CACHE_FILE_PATH" value="/tmp/phpunit_cache"/>
     </php>
     <source>
         <include>

--- a/resources/views/common/dungeon/gridtabs.blade.php
+++ b/resources/views/common/dungeon/gridtabs.blade.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
  * @var GameVersion|null           $gameVersion
  * @var Season|null                $nextSeason
  * @var Season                     $currentSeason
+ * @var int|null                   $requestedSeasonId
  * @var Collection<int, Expansion> $activeExpansions
  * @var string                     $id
  * @var string                     $tabsId
@@ -32,12 +33,17 @@ $filterFn              ??= fn(Dungeon $dungeon) => true;
 $nextSeasonDungeons    = $nextSeason?->dungeons->filter($filterFn)->values() ?? collect();
 $currentSeasonDungeons = $currentSeason->dungeons->filter($filterFn)->values();
 
+// Open on the current season - the next season is seeded well before it starts, and until then it should
+// not take over the selection (#3761). It is opened only when it was explicitly asked for, or when the
+// current season has nothing to show for this game version.
 $selectedSeasonId = null;
 if ($gameVersion->has_seasons) {
-    if ($nextSeason !== null && $nextSeasonDungeons->isNotEmpty()) {
+    if ($nextSeason !== null && $nextSeasonDungeons->isNotEmpty() && $requestedSeasonId === $nextSeason->id) {
         $selectedSeasonId = $nextSeason->id;
     } else if ($currentSeasonDungeons->isNotEmpty()) {
         $selectedSeasonId = $currentSeason->id;
+    } else if ($nextSeason !== null && $nextSeasonDungeons->isNotEmpty()) {
+        $selectedSeasonId = $nextSeason->id;
     }
 }
 
@@ -49,7 +55,7 @@ $showFullExpansionName = $nextSeason !== null && $nextSeason->expansion_id !== $
             @if($nextSeason !== null && $nextSeasonDungeons->isNotEmpty())
                 <li class="nav-item">
                     <a id="season-{{ $nextSeason->id }}-grid-tab"
-                       class="nav-link active"
+                       class="nav-link {{ $selectedSeasonId === $nextSeason->id ? 'active' : '' }}"
                        href="#season-{{ $nextSeason->id }}-grid-content"
                        role="tab"
                        aria-controls="season-{{ $nextSeason->id }}-grid-content"
@@ -62,7 +68,7 @@ $showFullExpansionName = $nextSeason !== null && $nextSeason->expansion_id !== $
             @if($currentSeasonDungeons->isNotEmpty())
                 <li class="nav-item">
                     <a id="season-{{ $currentSeason->id }}-grid-tab"
-                       class="nav-link {{ $nextSeason === null || $nextSeasonDungeons->isEmpty() ? 'active' : '' }}"
+                       class="nav-link {{ $selectedSeasonId === $currentSeason->id ? 'active' : '' }}"
                        href="#season-{{ $currentSeason->id }}-grid-content"
                        role="tab"
                        aria-controls="season-{{ $currentSeason->id }}-grid-content"

--- a/resources/views/common/dungeon/list.blade.php
+++ b/resources/views/common/dungeon/list.blade.php
@@ -67,6 +67,9 @@ $currentAffixGroup ??= null;
             'imageUrl' => $gameVersion->expansion->getWallpaperUrl(),
             'imageAlt' => __($gameVersion->expansion->name),
             'width' => $width,
+            // Explicitly null: an @include inherits the enclosing scope, so the last dungeon's tier would
+            // otherwise leak into this card - it is not a dungeon and has no difficulty tier
+            'thisWeekTier' => null,
         ])
     <?php
     }
@@ -80,6 +83,7 @@ $currentAffixGroup ??= null;
             'imageUrl' => $nextSeason->expansion->getWallpaperUrl(),
             'imageAlt' => __($nextSeason->expansion->name),
             'width' => $width,
+            'thisWeekTier' => null,
         ])
     <?php
     }

--- a/resources/views/common/dungeon/list.blade.php
+++ b/resources/views/common/dungeon/list.blade.php
@@ -3,6 +3,7 @@
 use App\Models\Dungeon;
 use App\Models\Expansion;
 use App\Models\GameVersion\GameVersion;
+use App\Models\Season;
 use App\Service\Expansion\ExpansionService;
 use Illuminate\Support\Collection;
 
@@ -11,6 +12,8 @@ use Illuminate\Support\Collection;
  * @var Expansion                $expansion
  * @var Collection<int, Dungeon> $dungeons
  * @var boolean                  $useAbbreviation
+ * @var Season|null              $nextSeason
+ * @var string|null              $nextSeasonLink
  */
 
 $dungeons        ??= $expansion->dungeonsAndRaids()->active()->get();
@@ -23,6 +26,11 @@ $subtextFn       ??= null;
 $width           ??= null;
 $showMore        ??= false;
 $maxColCount     ??= 8;
+// The upcoming season is shown as an extra card next to the dungeons, leading to a selection of just
+// its dungeons - it never takes the place of the current season's dungeons (#3761). Only set when the
+// season is close enough to its start to be advertised.
+$nextSeason     ??= null;
+$nextSeasonLink ??= null;
 // Ease tiers ("what's easy this week") - a Collection<affixGroupId, Collection<dungeonId, tier>>
 $easeTiers         ??= collect();
 $currentAffixGroup ??= null;
@@ -58,6 +66,19 @@ $currentAffixGroup ??= null;
             'isSelected' => !$hasSelectedDungeon,
             'imageUrl' => $gameVersion->expansion->getWallpaperUrl(),
             'imageAlt' => __($gameVersion->expansion->name),
+            'width' => $width,
+        ])
+    <?php
+    }
+
+    if($nextSeason !== null && $nextSeasonLink !== null) {
+        ?>
+        @include('common.dungeon.list.card', [
+            'link' => $nextSeasonLink,
+            'title' => __('view_common.dungeon.list.next_season'),
+            'isSelected' => false,
+            'imageUrl' => $nextSeason->expansion->getWallpaperUrl(),
+            'imageAlt' => __($nextSeason->expansion->name),
             'width' => $width,
         ])
     <?php

--- a/resources/views/common/layout/header.blade.php
+++ b/resources/views/common/layout/header.blade.php
@@ -18,6 +18,8 @@ use Illuminate\Support\Str;
  * @var Collection<int, Dungeon>     $gameVersionDungeons
  * @var Season                       $currentSeason
  * @var Season|null                  $nextSeason
+ * @var Season|null                  $dungeonContextNextSeason
+ * @var string|null                  $dungeonContextNextSeasonLink
  * @var bool                         $forceShrink
  * @var bool                         $showMore
  * @var bool                         $showDungeonContext
@@ -119,6 +121,9 @@ $isActiveRoute = function (string $route, bool $strict = false) {
                         'useAbbreviation' => true,
                         'selectable' => true,
                         'showMore' => $showMore,
+                        // Only set when the next season is close enough to be advertised (#3761)
+                        'nextSeason' => $dungeonContextNextSeason,
+                        'nextSeasonLink' => $dungeonContextNextSeasonLink,
                         'selected' => Dungeon::getUserOrDefaultDungeon()->key,
                         // "What's easy this week" ease tiers (archon.gg), resolved in HeaderComposer.
                         'easeTiers' => $dungeonContextEaseTiers ?? collect(),

--- a/tests/Feature/App/Service/Dungeon/DungeonService/GetDungeonsForGameVersionTest.php
+++ b/tests/Feature/App/Service/Dungeon/DungeonService/GetDungeonsForGameVersionTest.php
@@ -135,26 +135,29 @@ final class GetDungeonsForGameVersionTest extends PublicTestCase
         // A dungeon that is not part of the current season, so the assert below can tell the two apart
         $futureSeasonDungeon = Dungeon::firstWhere('key', Dungeon::DUNGEON_ARA_KARA_CITY_OF_ECHOES);
 
-        $futureSeason = Season::create([
-            'expansion_id'            => $expansion->id,
-            'seasonal_affix_id'       => null,
-            'index'                   => $currentSeason->index + 1,
-            'start'                   => Carbon::now()->addDays(60)->toDateTimeString(),
-            'presets'                 => 0,
-            'affix_group_count'       => 8,
-            'start_affix_group_index' => 0,
-            'key_level_min'           => 2,
-            'key_level_max'           => 25,
-            'item_level_min'          => 240,
-            'item_level_max'          => 300,
-        ]);
-
-        $futureSeasonDungeonRow = SeasonDungeon::create([
-            'season_id'  => $futureSeason->id,
-            'dungeon_id' => $futureSeasonDungeon->id,
-        ]);
+        // Created inside the try so a failure halfway through still cleans up
+        $futureSeason = null;
 
         try {
+            $futureSeason = Season::create([
+                'expansion_id'            => $expansion->id,
+                'seasonal_affix_id'       => null,
+                'index'                   => $currentSeason->index + 1,
+                'start'                   => Carbon::now()->addDays(60)->toDateTimeString(),
+                'presets'                 => 0,
+                'affix_group_count'       => 8,
+                'start_affix_group_index' => 0,
+                'key_level_min'           => 2,
+                'key_level_max'           => 25,
+                'item_level_min'          => 240,
+                'item_level_max'          => 300,
+            ]);
+
+            SeasonDungeon::create([
+                'season_id'  => $futureSeason->id,
+                'dungeon_id' => $futureSeasonDungeon->id,
+            ]);
+
             // Act - resolved after seeding the season so the season service starts with a cold cache
             $dungeons = app(DungeonServiceInterface::class)->getDungeonsForGameVersion($gameVersion);
 
@@ -168,11 +171,13 @@ final class GetDungeonsForGameVersionTest extends PublicTestCase
             // Through the query builder on purpose - SeederModel blocks deleting these models for anyone
             // who is not an admin, and it does so silently, so $model->delete() would leave the rows behind.
             // That skips the model events too, hence flushing the model cache by hand afterwards.
-            SeasonDungeon::query()->whereKey($futureSeasonDungeonRow->id)->delete();
-            Season::query()->whereKey($futureSeason->id)->delete();
+            if ($futureSeason !== null) {
+                SeasonDungeon::query()->where('season_id', $futureSeason->id)->delete();
+                Season::query()->whereKey($futureSeason->id)->delete();
 
-            new SeasonDungeon()->flushCache();
-            new Season()->flushCache();
+                new SeasonDungeon()->flushCache();
+                new Season()->flushCache();
+            }
         }
     }
 }

--- a/tests/Feature/App/Service/Dungeon/DungeonService/GetDungeonsForGameVersionTest.php
+++ b/tests/Feature/App/Service/Dungeon/DungeonService/GetDungeonsForGameVersionTest.php
@@ -2,13 +2,18 @@
 
 namespace Tests\Feature\App\Service\Dungeon\DungeonService;
 
+use App\Models\Dungeon;
+use App\Models\Expansion;
 use App\Models\GameVersion\GameVersion;
 use App\Models\Season;
+use App\Models\SeasonDungeon;
 use App\Service\Cookies\CookieServiceInterface;
 use App\Service\Dungeon\DungeonService;
+use App\Service\Dungeon\DungeonServiceInterface;
 use App\Service\Dungeon\Logging\DungeonServiceLoggingInterface;
 use App\Service\GameVersion\GameVersionServiceInterface;
 use App\Service\Season\SeasonServiceInterface;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
@@ -32,17 +37,16 @@ final class GetDungeonsForGameVersionTest extends PublicTestCase
     }
 
     /**
-     * Scenario: a season has been seeded before its start date, so getNextSeason() returns a season
-     * instead of null. Reading its dungeons lazily throws, and because HeaderComposer calls this for
-     * the site header that takes down every page rendering layouts/sitepage.blade.php (#3746).
+     * Scenario: a season has been seeded before its start date. Its dungeons are not playable yet, so the
+     * selector must keep showing the current season's dungeons instead of swapping over to them (#3761).
+     *
+     * The seasons are deliberately loaded as a collection: preventLazyLoading only enforces on models
+     * loaded as part of a multi-row result, which is how the site header used to be taken down (#3746).
      */
     #[Test]
-    public function getDungeonsForGameVersion_givenAnUpcomingSeason_returnsThatSeasonsDungeons(): void
+    public function getDungeonsForGameVersion_givenAnUpcomingSeason_returnsTheCurrentSeasonsDungeons(): void
     {
-        // Arrange - both seasons come out of a multi-row result on purpose. That is what
-        // SeasonService hands back, and preventLazyLoading only enforces on models loaded as part of
-        // a collection - a single-model load is exempt, which is why the current-season fallback
-        // never tripped this.
+        // Arrange
         $seasons = Season::query()->orderByDesc('id')->limit(2)->get();
 
         $this->assertCount(2, $seasons, 'Need at least two seeded seasons to load them as a collection');
@@ -61,16 +65,14 @@ final class GetDungeonsForGameVersionTest extends PublicTestCase
 
         // Assert
         $this->assertEqualsCanonicalizing(
-            $nextSeason->dungeons()->pluck('dungeons.id')->all(),
+            $currentSeason->dungeons()->pluck('dungeons.id')->all(),
             $dungeons->pluck('id')->all(),
         );
     }
 
     /**
-     * Scenario: no season has been seeded ahead of its start date, so the method falls back to the
-     * current season. In production that season is loaded as a single model and the guard exempts
-     * it, which is why this path never crashed - it is loaded as a collection here so the fallback
-     * is covered by the same guarantee as the branch above.
+     * Scenario: no season has been seeded ahead of its start date, so there is nothing that could take
+     * over the selector to begin with.
      */
     #[Test]
     public function getDungeonsForGameVersion_givenNoUpcomingSeason_returnsTheCurrentSeasonsDungeons(): void
@@ -93,5 +95,84 @@ final class GetDungeonsForGameVersionTest extends PublicTestCase
             $currentSeason->dungeons()->pluck('dungeons.id')->all(),
             $dungeons->pluck('id')->all(),
         );
+    }
+
+    /**
+     * Scenario: an expansion without an active season - the game version's expansion is all we can show.
+     */
+    #[Test]
+    public function getDungeonsForGameVersion_givenNoCurrentSeason_returnsTheExpansionsDungeons(): void
+    {
+        // Arrange
+        $seasonService = $this->createMockPublic(SeasonServiceInterface::class);
+        $seasonService->method('getCurrentSeason')->willReturn(null);
+        $seasonService->method('getNextSeason')->willReturn(null);
+
+        $gameVersion = GameVersion::firstWhere('key', GameVersion::GAME_VERSION_RETAIL);
+
+        // Act
+        $dungeons = $this->buildService($seasonService)->getDungeonsForGameVersion($gameVersion);
+
+        // Assert
+        $this->assertEqualsCanonicalizing(
+            $gameVersion->expansion->dungeons->pluck('id')->all(),
+            $dungeons->pluck('id')->all(),
+        );
+    }
+
+    /**
+     * Scenario: the real thing - a season for the current expansion is seeded weeks before it starts, the
+     * way a new season is prepared for review and QA. The whole site's dungeon selector used to switch to
+     * that season's dungeons the moment its row existed, dropping every current season dungeon (#3761).
+     */
+    #[Test]
+    public function getDungeonsForGameVersion_givenAFutureSeasonSeededForTheCurrentExpansion_returnsOnlyTheCurrentSeasonsDungeons(): void
+    {
+        // Arrange
+        $gameVersion   = GameVersion::firstWhere('key', GameVersion::GAME_VERSION_RETAIL);
+        $currentSeason = Season::findOrFail(Season::SEASON_MIDNIGHT_S1);
+        $expansion     = Expansion::firstWhere('shortname', Expansion::EXPANSION_MIDNIGHT);
+        // A dungeon that is not part of the current season, so the assert below can tell the two apart
+        $futureSeasonDungeon = Dungeon::firstWhere('key', Dungeon::DUNGEON_ARA_KARA_CITY_OF_ECHOES);
+
+        $futureSeason = Season::create([
+            'expansion_id'            => $expansion->id,
+            'seasonal_affix_id'       => null,
+            'index'                   => $currentSeason->index + 1,
+            'start'                   => Carbon::now()->addDays(60)->toDateTimeString(),
+            'presets'                 => 0,
+            'affix_group_count'       => 8,
+            'start_affix_group_index' => 0,
+            'key_level_min'           => 2,
+            'key_level_max'           => 25,
+            'item_level_min'          => 240,
+            'item_level_max'          => 300,
+        ]);
+
+        $futureSeasonDungeonRow = SeasonDungeon::create([
+            'season_id'  => $futureSeason->id,
+            'dungeon_id' => $futureSeasonDungeon->id,
+        ]);
+
+        try {
+            // Act - resolved after seeding the season so the season service starts with a cold cache
+            $dungeons = app(DungeonServiceInterface::class)->getDungeonsForGameVersion($gameVersion);
+
+            // Assert
+            $this->assertEqualsCanonicalizing(
+                $currentSeason->dungeons()->pluck('dungeons.id')->all(),
+                $dungeons->pluck('id')->all(),
+            );
+            $this->assertNotContains($futureSeasonDungeon->id, $dungeons->pluck('id')->all());
+        } finally {
+            // Through the query builder on purpose - SeederModel blocks deleting these models for anyone
+            // who is not an admin, and it does so silently, so $model->delete() would leave the rows behind.
+            // That skips the model events too, hence flushing the model cache by hand afterwards.
+            SeasonDungeon::query()->whereKey($futureSeasonDungeonRow->id)->delete();
+            Season::query()->whereKey($futureSeason->id)->delete();
+
+            new SeasonDungeon()->flushCache();
+            new Season()->flushCache();
+        }
     }
 }

--- a/tests/Feature/Controller/Dungeon/DungeonExploreControllerTest.php
+++ b/tests/Feature/Controller/Dungeon/DungeonExploreControllerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature\Controller\Dungeon;
+
+use App\Models\Dungeon;
+use App\Models\Expansion;
+use App\Models\GameVersion\GameVersion;
+use App\Models\Season;
+use App\Models\SeasonDungeon;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * The dungeon selection keeps opening on the current season's tab while an upcoming season is only seeded,
+ * not started (#3761). The upcoming season still gets a tab of its own - it is just no longer selected for
+ * you, unless it was explicitly asked for, which is what the header's "next season" card links to.
+ */
+#[Group('Controller')]
+#[Group('DungeonExplore')]
+final class DungeonExploreControllerTest extends PublicTestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAsGuest();
+
+        // ViewService caches the seasons it hands the composers for an hour in the 'tmp_file' store, which -
+        // unlike the array store the tests run on - survives between test runs
+        $this->flushSeasonCaches();
+    }
+
+    #[Test]
+    public function select_givenAnUpcomingSeason_opensOnTheCurrentSeasonsTab(): void
+    {
+        // Arrange
+        $upcomingSeason = $this->createUpcomingSeason();
+
+        try {
+            // Act
+            $response = $this->get(route('dungeon.explore.gameversion.select', [
+                'gameVersion' => GameVersion::GAME_VERSION_RETAIL,
+            ]));
+
+            // Assert
+            $response->assertOk();
+
+            $this->assertSeasonTabActive($response->content(), Season::SEASON_MIDNIGHT_S1);
+            $this->assertSeasonTabInactive($response->content(), $upcomingSeason->id);
+        } finally {
+            $this->deleteUpcomingSeason($upcomingSeason);
+        }
+    }
+
+    #[Test]
+    public function select_givenASeasonParameter_opensOnThatSeasonsTab(): void
+    {
+        // Arrange
+        $upcomingSeason = $this->createUpcomingSeason();
+
+        try {
+            // Act
+            $response = $this->get(route('dungeon.explore.gameversion.select', [
+                'gameVersion' => GameVersion::GAME_VERSION_RETAIL,
+                'season'      => $upcomingSeason->id,
+            ]));
+
+            // Assert
+            $response->assertOk();
+
+            $this->assertSeasonTabActive($response->content(), $upcomingSeason->id);
+            $this->assertSeasonTabInactive($response->content(), Season::SEASON_MIDNIGHT_S1);
+        } finally {
+            $this->deleteUpcomingSeason($upcomingSeason);
+        }
+    }
+
+    private function assertSeasonTabActive(string $content, int $seasonId): void
+    {
+        $this->assertStringContainsString('active', $this->getSeasonTabClasses($content, $seasonId));
+    }
+
+    private function assertSeasonTabInactive(string $content, int $seasonId): void
+    {
+        $this->assertStringNotContainsString('active', $this->getSeasonTabClasses($content, $seasonId));
+    }
+
+    private function getSeasonTabClasses(string $content, int $seasonId): string
+    {
+        $matches = [];
+
+        $this->assertSame(
+            1,
+            preg_match(sprintf('/id="season-%d-grid-tab"\s+class="([^"]*)"/', $seasonId), $content, $matches),
+            sprintf('Expected a tab for season %d to be rendered', $seasonId),
+        );
+
+        return $matches[1];
+    }
+
+    /**
+     * A season that is seeded but has not started yet - the situation a season dry run puts the site in.
+     */
+    private function createUpcomingSeason(): Season
+    {
+        $expansion = Expansion::firstWhere('shortname', Expansion::EXPANSION_MIDNIGHT);
+
+        $season = Season::create([
+            'expansion_id'            => $expansion->id,
+            'seasonal_affix_id'       => null,
+            'index'                   => 2,
+            'start'                   => Carbon::now()->addWeeks(8)->toDateTimeString(),
+            'presets'                 => 0,
+            'affix_group_count'       => 8,
+            'start_affix_group_index' => 0,
+            'key_level_min'           => 2,
+            'key_level_max'           => 25,
+            'item_level_min'          => 240,
+            'item_level_max'          => 300,
+        ]);
+
+        SeasonDungeon::create([
+            'season_id'  => $season->id,
+            'dungeon_id' => Dungeon::firstWhere('key', Dungeon::DUNGEON_ARA_KARA_CITY_OF_ECHOES)->id,
+        ]);
+
+        return $season;
+    }
+
+    /**
+     * Through the query builder on purpose - SeederModel silently blocks deleting these models for anyone who is
+     * not an admin, so $model->delete() would leave the rows behind. That skips the model events too, hence
+     * flushing the caches keyed on seasons by hand.
+     */
+    private function deleteUpcomingSeason(Season $season): void
+    {
+        SeasonDungeon::query()->where('season_id', $season->id)->delete();
+        Season::query()->whereKey($season->id)->delete();
+
+        $this->flushSeasonCaches();
+    }
+
+    private function flushSeasonCaches(): void
+    {
+        new SeasonDungeon()->flushCache();
+        new Season()->flushCache();
+        Cache::store('tmp_file')->flush();
+    }
+}

--- a/tests/Feature/Controller/Dungeon/DungeonExploreControllerTest.php
+++ b/tests/Feature/Controller/Dungeon/DungeonExploreControllerTest.php
@@ -37,10 +37,12 @@ final class DungeonExploreControllerTest extends PublicTestCase
     #[Test]
     public function select_givenAnUpcomingSeason_opensOnTheCurrentSeasonsTab(): void
     {
-        // Arrange
-        $upcomingSeason = $this->createUpcomingSeason();
+        // Arrange - inside the try so a failure halfway through still cleans up
+        $upcomingSeason = null;
 
         try {
+            $upcomingSeason = $this->createUpcomingSeason();
+
             // Act
             $response = $this->get(route('dungeon.explore.gameversion.select', [
                 'gameVersion' => GameVersion::GAME_VERSION_RETAIL,
@@ -52,17 +54,21 @@ final class DungeonExploreControllerTest extends PublicTestCase
             $this->assertSeasonTabActive($response->content(), Season::SEASON_MIDNIGHT_S1);
             $this->assertSeasonTabInactive($response->content(), $upcomingSeason->id);
         } finally {
-            $this->deleteUpcomingSeason($upcomingSeason);
+            if ($upcomingSeason !== null) {
+                $this->deleteUpcomingSeason($upcomingSeason);
+            }
         }
     }
 
     #[Test]
     public function select_givenASeasonParameter_opensOnThatSeasonsTab(): void
     {
-        // Arrange
-        $upcomingSeason = $this->createUpcomingSeason();
+        // Arrange - inside the try so a failure halfway through still cleans up
+        $upcomingSeason = null;
 
         try {
+            $upcomingSeason = $this->createUpcomingSeason();
+
             // Act
             $response = $this->get(route('dungeon.explore.gameversion.select', [
                 'gameVersion' => GameVersion::GAME_VERSION_RETAIL,
@@ -75,7 +81,9 @@ final class DungeonExploreControllerTest extends PublicTestCase
             $this->assertSeasonTabActive($response->content(), $upcomingSeason->id);
             $this->assertSeasonTabInactive($response->content(), Season::SEASON_MIDNIGHT_S1);
         } finally {
-            $this->deleteUpcomingSeason($upcomingSeason);
+            if ($upcomingSeason !== null) {
+                $this->deleteUpcomingSeason($upcomingSeason);
+            }
         }
     }
 

--- a/tests/Feature/View/Common/Dungeon/DungeonListTest.php
+++ b/tests/Feature/View/Common/Dungeon/DungeonListTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\View\Common\Dungeon;
+
+use App\Models\GameVersion\GameVersion;
+use App\Models\Season;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('View')]
+#[Group('DungeonList')]
+final class DungeonListTest extends PublicTestCase
+{
+    private const string NEXT_SEASON_LINK = '/explore/retail/select?season=17';
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseParams(): array
+    {
+        return [
+            'gameVersion'     => GameVersion::firstWhere('key', GameVersion::GAME_VERSION_RETAIL),
+            'dungeons'        => collect(),
+            'useAbbreviation' => true,
+            'selectable'      => true,
+            'showMore'        => false,
+        ];
+    }
+
+    /**
+     * Scenario: the next season is close enough to its start to be advertised, so it gets a card of its own
+     * next to the current season's dungeons rather than replacing them (#3761).
+     */
+    #[Test]
+    public function render_givenAnUpcomingSeason_showsTheNextSeasonCard(): void
+    {
+        // Arrange
+        $nextSeason = Season::findOrFail(Season::SEASON_MIDNIGHT_S1);
+
+        // Act
+        $html = view('common.dungeon.list', [
+            ...$this->baseParams(),
+            'nextSeason'     => $nextSeason,
+            'nextSeasonLink' => self::NEXT_SEASON_LINK,
+        ])->render();
+
+        // Assert
+        $this->assertStringContainsString(__('view_common.dungeon.list.next_season'), $html);
+        $this->assertStringContainsString(self::NEXT_SEASON_LINK, $html);
+    }
+
+    /**
+     * Scenario: no next season, or one that is still too far out to advertise - the header shows the current
+     * season's dungeons and nothing else.
+     */
+    #[Test]
+    public function render_givenNoUpcomingSeason_omitsTheNextSeasonCard(): void
+    {
+        // Act
+        $html = view('common.dungeon.list', [
+            ...$this->baseParams(),
+            'nextSeason'     => null,
+            'nextSeasonLink' => null,
+        ])->render();
+
+        // Assert
+        $this->assertStringNotContainsString(__('view_common.dungeon.list.next_season'), $html);
+        $this->assertStringNotContainsString(self::NEXT_SEASON_LINK, $html);
+    }
+}

--- a/tests/Feature/View/Common/Dungeon/DungeonListTest.php
+++ b/tests/Feature/View/Common/Dungeon/DungeonListTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Feature\View\Common\Dungeon;
 
+use App\Models\AffixGroup\AffixGroup;
 use App\Models\GameVersion\GameVersion;
 use App\Models\Season;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
@@ -12,7 +14,18 @@ use Tests\TestCases\PublicTestCase;
 #[Group('DungeonList')]
 final class DungeonListTest extends PublicTestCase
 {
-    private const string NEXT_SEASON_LINK = '/explore/retail/select?season=17';
+    private function nextSeason(): Season
+    {
+        return Season::findOrFail(Season::SEASON_MIDNIGHT_S1);
+    }
+
+    private function nextSeasonLink(): string
+    {
+        return route('dungeon.explore.gameversion.select', [
+            'gameVersion' => GameVersion::GAME_VERSION_RETAIL,
+            'season'      => $this->nextSeason()->id,
+        ]);
+    }
 
     /**
      * @return array<string, mixed>
@@ -35,19 +48,16 @@ final class DungeonListTest extends PublicTestCase
     #[Test]
     public function render_givenAnUpcomingSeason_showsTheNextSeasonCard(): void
     {
-        // Arrange
-        $nextSeason = Season::findOrFail(Season::SEASON_MIDNIGHT_S1);
-
         // Act
         $html = view('common.dungeon.list', [
             ...$this->baseParams(),
-            'nextSeason'     => $nextSeason,
-            'nextSeasonLink' => self::NEXT_SEASON_LINK,
+            'nextSeason'     => $this->nextSeason(),
+            'nextSeasonLink' => $this->nextSeasonLink(),
         ])->render();
 
         // Assert
         $this->assertStringContainsString(__('view_common.dungeon.list.next_season'), $html);
-        $this->assertStringContainsString(self::NEXT_SEASON_LINK, $html);
+        $this->assertStringContainsString($this->nextSeasonLink(), $html);
     }
 
     /**
@@ -66,6 +76,45 @@ final class DungeonListTest extends PublicTestCase
 
         // Assert
         $this->assertStringNotContainsString(__('view_common.dungeon.list.next_season'), $html);
-        $this->assertStringNotContainsString(self::NEXT_SEASON_LINK, $html);
+    }
+
+    /**
+     * A Blade @include inherits the enclosing scope, so `$thisWeekTier` - assigned per dungeon in the loop -
+     * stays set for whatever is rendered after it. Both the "More" and the "next season" card would show the
+     * last dungeon's "what's easy this week" badge, which means nothing for a card that is not a dungeon.
+     */
+    #[Test]
+    public function render_givenEaseTiers_showsThemOnDungeonCardsOnly(): void
+    {
+        // Arrange
+        $dungeons   = $this->nextSeason()->dungeons()->get();
+        $affixGroup = AffixGroup::firstOrFail();
+        $tieredIds  = $dungeons->pluck('id');
+        /** @var Collection<int, Collection<int, string>> $easeTiers */
+        $easeTiers = collect([$affixGroup->id => $tieredIds->mapWithKeys(static fn(int $id) => [$id => 'S'])]);
+
+        $this->assertGreaterThan(0, $dungeons->count(), 'Need seeded season dungeons to give a tier to');
+
+        // Act - every dungeon has a tier, and both extra cards render alongside them
+        $html = view('common.dungeon.list', [
+            ...$this->baseParams(),
+            'dungeons'          => $dungeons,
+            'maxColCount'       => $dungeons->count(),
+            'showMore'          => true,
+            'links'             => collect(['more' => '/explore/retail/select']),
+            'easeTiers'         => $easeTiers,
+            'currentAffixGroup' => $affixGroup,
+            'nextSeason'        => $this->nextSeason(),
+            'nextSeasonLink'    => $this->nextSeasonLink(),
+        ])->render();
+
+        // Assert - one badge per dungeon, none for the "More" and "next season" cards
+        $this->assertStringContainsString('More', $html);
+        $this->assertStringContainsString(__('view_common.dungeon.list.next_season'), $html);
+        $this->assertSame(
+            $dungeons->count(),
+            substr_count($html, 'dungeon_card_tiers'),
+            'Ease tier badges must render for dungeon cards only',
+        );
     }
 }

--- a/tests/Feature/View/HeaderComposerTest.php
+++ b/tests/Feature/View/HeaderComposerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\View;
+
+use App\Http\View\Composers\HeaderComposer;
+use App\Models\Expansion;
+use App\Models\Season;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * The dungeon context bar follows the current season only. The upcoming season is advertised next to it
+ * as a card of its own, but only once it is close enough to its start - seasons are seeded weeks before
+ * they start so their mapping can be reviewed, and until then they should not show up at all (#3761).
+ */
+#[Group('ViewComposers')]
+#[Group('HeaderComposer')]
+final class HeaderComposerTest extends PublicTestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAsGuest();
+
+        // ViewService caches the season it hands the composer for an hour in the 'tmp_file' store, which - unlike
+        // the array store the tests run on - survives between test runs. Seasons created below would otherwise be
+        // invisible to the composer, or worse, stay visible to whatever runs next.
+        $this->flushSeasonCaches();
+    }
+
+    #[Test]
+    public function compose_givenAnUpcomingSeasonWithinTheWindow_setsTheNextSeasonCard(): void
+    {
+        // Arrange
+        $upcomingSeason = $this->createUpcomingSeason(Carbon::now()->addWeek());
+
+        try {
+            $view = view('common.layout.header');
+
+            // Act
+            app(HeaderComposer::class)->compose($view);
+
+            // Assert
+            $data = $view->getData();
+
+            $this->assertNotNull($data['dungeonContextNextSeason']);
+            $this->assertSame($upcomingSeason->id, $data['dungeonContextNextSeason']->id);
+            $this->assertStringContainsString(sprintf('season=%d', $upcomingSeason->id), $data['dungeonContextNextSeasonLink']);
+        } finally {
+            $this->deleteSeason($upcomingSeason);
+        }
+    }
+
+    #[Test]
+    public function compose_givenAnUpcomingSeasonBeyondTheWindow_omitsTheNextSeasonCard(): void
+    {
+        // Arrange - the situation a season dry run puts the site in: seeded, but months out
+        $upcomingSeason = $this->createUpcomingSeason(Carbon::now()->addWeeks(8));
+
+        try {
+            $view = view('common.layout.header');
+
+            // Act
+            app(HeaderComposer::class)->compose($view);
+
+            // Assert
+            $data = $view->getData();
+
+            $this->assertSame($upcomingSeason->id, $data['nextSeason']?->id, 'The season should still be found, just not advertised');
+            $this->assertNull($data['dungeonContextNextSeason']);
+            $this->assertNull($data['dungeonContextNextSeasonLink']);
+        } finally {
+            $this->deleteSeason($upcomingSeason);
+        }
+    }
+
+    /**
+     * Removes a season created by this test. Through the query builder on purpose - SeederModel silently blocks
+     * deleting a Season for anyone who is not an admin, so $season->delete() would leave the row behind. That does
+     * mean no model events fire, so the caches keyed on seasons are flushed by hand.
+     */
+    private function deleteSeason(Season $season): void
+    {
+        Season::query()->whereKey($season->id)->delete();
+
+        $this->flushSeasonCaches();
+    }
+
+    private function flushSeasonCaches(): void
+    {
+        new Season()->flushCache();
+        Cache::store('tmp_file')->flush();
+    }
+
+    private function createUpcomingSeason(Carbon $start): Season
+    {
+        $expansion = Expansion::firstWhere('shortname', Expansion::EXPANSION_MIDNIGHT);
+
+        return Season::create([
+            'expansion_id'            => $expansion->id,
+            'seasonal_affix_id'       => null,
+            'index'                   => 2,
+            'start'                   => $start->toDateTimeString(),
+            'presets'                 => 0,
+            'affix_group_count'       => 8,
+            'start_affix_group_index' => 0,
+            'key_level_min'           => 2,
+            'key_level_max'           => 25,
+            'item_level_min'          => 240,
+            'item_level_max'          => 300,
+        ]);
+    }
+}

--- a/tests/Feature/View/HeaderComposerTest.php
+++ b/tests/Feature/View/HeaderComposerTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature\View;
 
 use App\Http\View\Composers\HeaderComposer;
 use App\Models\Expansion;
+use App\Models\GameVersion\GameVersion;
 use App\Models\Season;
+use App\Models\User;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use PHPUnit\Framework\Attributes\Group;
@@ -36,10 +38,12 @@ final class HeaderComposerTest extends PublicTestCase
     #[Test]
     public function compose_givenAnUpcomingSeasonWithinTheWindow_setsTheNextSeasonCard(): void
     {
-        // Arrange
-        $upcomingSeason = $this->createUpcomingSeason(Carbon::now()->addWeek());
+        // Arrange - inside the try so a failure halfway through still cleans up
+        $upcomingSeason = null;
 
         try {
+            $upcomingSeason = $this->createUpcomingSeason(Carbon::now()->addWeek());
+
             $view = view('common.layout.header');
 
             // Act
@@ -52,7 +56,9 @@ final class HeaderComposerTest extends PublicTestCase
             $this->assertSame($upcomingSeason->id, $data['dungeonContextNextSeason']->id);
             $this->assertStringContainsString(sprintf('season=%d', $upcomingSeason->id), $data['dungeonContextNextSeasonLink']);
         } finally {
-            $this->deleteSeason($upcomingSeason);
+            if ($upcomingSeason !== null) {
+                $this->deleteSeason($upcomingSeason);
+            }
         }
     }
 
@@ -60,9 +66,11 @@ final class HeaderComposerTest extends PublicTestCase
     public function compose_givenAnUpcomingSeasonBeyondTheWindow_omitsTheNextSeasonCard(): void
     {
         // Arrange - the situation a season dry run puts the site in: seeded, but months out
-        $upcomingSeason = $this->createUpcomingSeason(Carbon::now()->addWeeks(8));
+        $upcomingSeason = null;
 
         try {
+            $upcomingSeason = $this->createUpcomingSeason(Carbon::now()->addWeeks(8));
+
             $view = view('common.layout.header');
 
             // Act
@@ -75,7 +83,79 @@ final class HeaderComposerTest extends PublicTestCase
             $this->assertNull($data['dungeonContextNextSeason']);
             $this->assertNull($data['dungeonContextNextSeasonLink']);
         } finally {
-            $this->deleteSeason($upcomingSeason);
+            if ($upcomingSeason !== null) {
+                $this->deleteSeason($upcomingSeason);
+            }
+        }
+    }
+
+    /**
+     * Seasons are a retail concept. The dungeon selection hides every season tab for a game version without
+     * them, so advertising an upcoming season there would be a card leading to a page that cannot show it.
+     */
+    #[Test]
+    public function compose_givenAGameVersionWithoutSeasons_omitsTheNextSeasonCard(): void
+    {
+        // Arrange
+        $upcomingSeason = null;
+        $user           = null;
+
+        try {
+            $upcomingSeason = $this->createUpcomingSeason(Carbon::now()->addWeek());
+
+            $classicEra = GameVersion::firstWhere('key', GameVersion::GAME_VERSION_CLASSIC_ERA);
+
+            $this->assertFalse((bool)$classicEra->has_seasons, 'Classic Era must be a game version without seasons');
+
+            $user = User::factory()->create(['game_version_id' => $classicEra->id]);
+            $this->actingAs($user);
+
+            $view = view('common.layout.header');
+
+            // Act
+            app(HeaderComposer::class)->compose($view);
+
+            // Assert
+            $data = $view->getData();
+
+            $this->assertSame($upcomingSeason->id, $data['nextSeason']?->id, 'The season should still be found, just not advertised');
+            $this->assertNull($data['dungeonContextNextSeason']);
+            $this->assertNull($data['dungeonContextNextSeasonLink']);
+        } finally {
+            $user?->delete();
+
+            if ($upcomingSeason !== null) {
+                $this->deleteSeason($upcomingSeason);
+            }
+        }
+    }
+
+    /**
+     * The window is configuration, not a constant - the same season that is too far out by default is
+     * advertised once the window is widened past it.
+     */
+    #[Test]
+    public function compose_givenAWidenedWindow_setsTheNextSeasonCardForASeasonThatWasBeyondIt(): void
+    {
+        // Arrange
+        $upcomingSeason = null;
+
+        try {
+            $upcomingSeason = $this->createUpcomingSeason(Carbon::now()->addWeeks(8));
+
+            config(['keystoneguru.season.upcoming_visible_days' => 90]);
+
+            $view = view('common.layout.header');
+
+            // Act
+            app(HeaderComposer::class)->compose($view);
+
+            // Assert
+            $this->assertSame($upcomingSeason->id, $view->getData()['dungeonContextNextSeason']?->id);
+        } finally {
+            if ($upcomingSeason !== null) {
+                $this->deleteSeason($upcomingSeason);
+            }
         }
     }
 

--- a/tests/Feature/View/ViewComposerTest.php
+++ b/tests/Feature/View/ViewComposerTest.php
@@ -94,6 +94,7 @@ final class ViewComposerTest extends PublicTestCase
     {
         $this->assertComposerSetsKeys(HeaderComposer::class, 'common.layout.header', [
             'activeExpansions', 'currentSeason', 'nextSeason', 'allGameVersions', 'gameVersionDungeons',
+            'dungeonContextNextSeason', 'dungeonContextNextSeasonLink',
         ]);
     }
 
@@ -157,7 +158,7 @@ final class ViewComposerTest extends PublicTestCase
     public function dungeonGridTabsComposer_givenView_setsGridTabsKeys(): void
     {
         $this->assertComposerSetsKeys(DungeonGridTabsComposer::class, 'common.dungeon.gridtabs', [
-            'activeExpansions', 'currentSeason', 'nextSeason',
+            'activeExpansions', 'currentSeason', 'nextSeason', 'requestedSeasonId',
         ]);
     }
 


### PR DESCRIPTION
:robot:

Closes #3761

## What was wrong

`DungeonService::getDungeonsForGameVersion()` — which feeds the header dungeon context bar and the
dungeon context links on discover, explore, heatmap and route search — did this:

```php
$nextSeason = $currentSeason === null ? null : $this->seasonService->getNextSeason($currentSeason);

return ($nextSeason ?? $currentSeason)?->dungeons()->get() ?? $gameVersion->expansion->dungeons;
```

`getNextSeason()` only checks that a season is chronologically next, not that it has started. So the
selector **replaced** the current season's dungeons with the next season's the moment a next-season row
existed, however far out its start was. Since a season is seeded weeks ahead so its mapping can be
reviewed, that would drop every current season dungeon off the site long before the new ones are
playable — which is what blocks #3739 (Midnight Season 2 dry run).

The look-ahead was added in `881240700` (#3118) without a stated rationale, and master has had no future
season seeded since, so that branch has never actually fired in production.

## What changed

- **`DungeonService`** follows the current season only.
- **A "Next season" card** is added to the dungeon context bar, next to the existing "More" card. It
  shows once the next season starts within `keystoneguru.season.upcoming_visible_days` (default 14), so
  a season can be seeded months ahead without changing anything on the live site. `HeaderComposer` makes
  that decision; the blades only render what it hands them.
- **The dungeon selection page** (`common/dungeon/gridtabs`, where "More" and the new card lead) had the
  same problem one level down: it made the next season's tab the active one as soon as a season was
  seeded. It now opens on the current season, and opens the next season's tab only when asked for it
  (`?season=<id>`, which is what the new card links to).

## Deliberate choices

- **The next-season tab itself is not gated** on the window — only its auto-selection. It is a tab you
  have to click, it has been there for a long time, and it is how an upcoming season's mapping gets
  reviewed on staging before it starts.
- **The card links to the explore selection page from every page**, including heatmap and route search.
  Those pages have no `nextSeason` of their own to build a link from; the existing `dungeonContextLinks`
  mechanism can carry a per-page override later if this reads wrong.
- **`getDungeonsForGameVersionTest_givenAnUpcomingSeason_...` had its expectation flipped and renamed** —
  it asserted the exact behaviour being removed. Its "load both seasons as a collection" arrangement is
  kept, since that is what covers the #3746 lazy-loading regression.
- `getDungeonContext()` resolved the default dungeon from the current season only, so the header could
  list dungeons that the selected dungeon was not among. Pre-existing; this change removes it.

## Tests

- `GetDungeonsForGameVersionTest` — upcoming season, no upcoming season, no current season, plus an
  end-to-end case that seeds a real future season through the container-resolved services.
- `HeaderComposerTest` — the card is set inside the window and absent outside it.
- `DungeonListTest` — the card renders (and does not) in `common/dungeon/list`.
- `DungeonExploreControllerTest` — `/explore/retail/select` opens on the current season's tab with a
  future season seeded, and on the requested season's tab with `?season=<id>`.

While writing those: `SeederModel` silently refuses `$model->delete()` for non-admins, so the usual
`try/finally` cleanup leaves rows behind and poisons the shared test database. That, and the two caches
that hide freshly created rows from tests, are now written down in the `writing-tests` skill.
