### PR TITLE
#3770 Drop SeederModel's deleting listener, it guarded nothing and broke things

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -204,6 +204,24 @@ is simply not among the methods it overrides.)
 ### Model Creation
 - Every new model must also have a repository. Create the interface at `app/Repositories/Interfaces/{Domain}/{ModelName}RepositoryInterface.php`, the implementation at `app/Repositories/Database/{Domain}/{ModelName}Repository.php`, and register the binding in `app/Providers/RepositoryServiceProvider.php`. See the `repository-pattern` skill for the full convention.
 
+### Seeded models (`SeederModel`)
+Models using the `App\Models\Traits\SeederModel` trait own **seeded data**: their rows come from
+`database/seeders`, not from users. The trait is a marker only — `DatabaseSeeder::getTempTableName()` uses it
+to stage the table as `<table>_temp` while seeding.
+
+- **Nothing outside the admin panel, the mapping editor and the seeders should delete these rows.** That is a
+  convention, not an enforced rule: the routes that delete them already sit behind `role:admin`, and there is
+  no model-level guard. Deleting mapping data is recoverable — it shows up as a diff the next time
+  `mapping:save` runs — but anything not exported to `database/seeders/dungeondata` (seasons, expansions,
+  published states, character classes, …) has no such safety net, so treat a delete there as permanent.
+- The trait used to register a `deleting` listener returning `false` for non-admins. It was removed because it
+  guarded nothing while breaking two things: `$model->delete()` silently became a no-op wherever no user is
+  authenticated (Artisan commands, queued jobs, tests), and because `deleting` is fired through the
+  dispatcher's `until()` — which halts on the first non-null result — it swallowed any `deleting` listener a
+  model registered in `booted()`. `Npc`'s cleanup listener was one of those, so deleting an NPC as an admin
+  left its spells, characteristics and couplings orphaned. Don't reintroduce it; authorization belongs on the
+  route.
+
 ### Controllers & Validation
 - Always create Form Request classes for validation rather than inline validation in controllers. Include both validation rules and custom error messages.
 - Check sibling Form Requests to see if the application uses array or string based validation rules.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -211,16 +211,9 @@ to stage the table as `<table>_temp` while seeding.
 
 - **Nothing outside the admin panel, the mapping editor and the seeders should delete these rows.** That is a
   convention, not an enforced rule: the routes that delete them already sit behind `role:admin`, and there is
-  no model-level guard. Deleting mapping data is recoverable — it shows up as a diff the next time
-  `mapping:save` runs — but anything not exported to `database/seeders/dungeondata` (seasons, expansions,
-  published states, character classes, …) has no such safety net, so treat a delete there as permanent.
-- The trait used to register a `deleting` listener returning `false` for non-admins. It was removed because it
-  guarded nothing while breaking two things: `$model->delete()` silently became a no-op wherever no user is
-  authenticated (Artisan commands, queued jobs, tests), and because `deleting` is fired through the
-  dispatcher's `until()` — which halts on the first non-null result — it swallowed any `deleting` listener a
-  model registered in `booted()`. `Npc`'s cleanup listener was one of those, so deleting an NPC as an admin
-  left its spells, characteristics and couplings orphaned. Don't reintroduce it; authorization belongs on the
-  route.
+  no model-level guard. A delete is recoverable directly from `database/seeders` — that's where these models'
+  rows are authored (some are being migrated to `.json` files under there instead, but the recovery path is
+  the same: restore from the seeder files).
 
 ### Controllers & Validation
 - Always create Form Request classes for validation rather than inline validation in controllers. Include both validation rules and custom error messages.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -205,15 +205,23 @@ is simply not among the methods it overrides.)
 - Every new model must also have a repository. Create the interface at `app/Repositories/Interfaces/{Domain}/{ModelName}RepositoryInterface.php`, the implementation at `app/Repositories/Database/{Domain}/{ModelName}Repository.php`, and register the binding in `app/Providers/RepositoryServiceProvider.php`. See the `repository-pattern` skill for the full convention.
 
 ### Seeded models (`SeederModel`)
-Models using the `App\Models\Traits\SeederModel` trait own **seeded data**: their rows come from
-`database/seeders`, not from users. The trait is a marker only — `DatabaseSeeder::getTempTableName()` uses it
-to stage the table as `<table>_temp` while seeding.
+Models using the `App\Models\Traits\SeederModel` trait use `DatabaseSeeder::getTempTableName()` to stage
+their table as `<table>_temp` while seeding — the trait is a marker only, not a guarantee about where a
+model's rows come from.
 
-- **Nothing outside the admin panel, the mapping editor and the seeders should delete these rows.** That is a
-  convention, not an enforced rule: the routes that delete them already sit behind `role:admin`, and there is
-  no model-level guard. A delete is recoverable directly from `database/seeders` — that's where these models'
-  rows are authored (some are being migrated to `.json` files under there instead, but the recovery path is
-  the same: restore from the seeder files).
+For the mapping/season/expansion-style models (dungeons, seasons, expansions, mapping objects, …), rows are
+authored in `database/seeders` (some are being migrated to `.json` files under there instead), so a delete
+is recoverable directly from those files.
+
+- **A subset of trait users are combat-log-derived instead and are *not* recoverable from seeders:**
+  `SpellDungeon`, `NpcCharacteristic` and `NpcSpell` are intentionally omitted from the seeder export (see
+  `DungeonDataSeeder::getAffectedModelClasses()`), and `CombatLogNpcEvent`, `CombatLogSpellEvent` and
+  `ParsedCombatLog` (declared via grouped `use` statements, so `grep "use SeederModel;"` misses them) hold
+  pure runtime/audit data that was never seeder-sourced to begin with. A delete of one of these rows is
+  permanent unless fresh combat log data re-derives it.
+- **Nothing outside the admin panel, the mapping editor, the seeders and the hourly
+  `combatlog:detectstaledata` sweep should delete these rows.** That is a convention, not an enforced rule:
+  the routes that delete them already sit behind `role:admin`, and there is no model-level guard.
 
 ### Controllers & Validation
 - Always create Form Request classes for validation rather than inline validation in controllers. Include both validation rules and custom error messages.

--- a/.claude/skills/combatlog-data-pipeline/SKILL.md
+++ b/.claude/skills/combatlog-data-pipeline/SKILL.md
@@ -133,7 +133,7 @@ precedes `PropertyChanged` in the feed:
 a warning if there is no current season). Three phases:
 
 1. `removeStaleNpcCharacteristics()` — deletes `NpcCharacteristic` rows with no fresh observation
-   (`->toBase()->delete()` to bypass the `SeederModel` admin-only observer) + emits
+   (`->toBase()->delete()`, a bulk delete that skips Eloquent's caching builder layer) + emits
    `CharacteristicRemoved`.
 2. `removeStaleSpellProperties()` — clears stale `aura`/`debuff`/miss-type bits on `Spell` + emits
    `PropertyRemoved`.

--- a/.claude/skills/mapping-versioned-models/SKILL.md
+++ b/.claude/skills/mapping-versioned-models/SKILL.md
@@ -157,10 +157,9 @@ example** — its diff contains exactly one of everything below; when in doubt, 
    `use SeederModel`, implement `getDungeonId()` (typically `$this->floor->dungeon_id`), add
    `mappingVersion(): BelongsTo`. Put `mappingVersion`/`floor`/`laravel_through_key` in `$hidden`
    so the map-context JSON stays lean; `$timestamps = false` like its siblings.
-   ⚠️ If deleting the model must release rows pointing at it, hook `static::deleted()`, **not**
-   `deleting`: `SeederModel` already registers a `deleting` listener that returns a bool, and
-   Eloquent fires `deleting` through the dispatcher's `until()`, which halts on the first
-   non-null result — a second `deleting` listener would silently never run.
+   If deleting the model must release rows pointing at it, prefer hooking `static::deleted()` over
+   `deleting`: the referencing rows only need detaching once the delete is confirmed to have gone
+   through, not beforehand — see `EnemyForcesCheckpoint::booted()` for a worked example.
 3. Repository interface + implementation + `RepositoryServiceProvider` binding — see the
    **repository-pattern** skill.
 

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -57,27 +57,20 @@ try {
 
 `DungeonRoute` has no soft-deletes, so `delete()` truly removes the row.
 
-### `SeederModel` models silently refuse `$model->delete()`
+### Seeded rows leak loudly — a leftover breaks unrelated tests
 
-~51 models use the `SeederModel` trait (`Season`, `SeasonDungeon`, `Expansion`, `EnemyPack`,
-`GameServerRegion`, … — check with `grep -rln "use SeederModel;" app/Models/`; `Dungeon` is **not** one of
-them). It registers a `deleting` hook that returns `false` unless the **authenticated** user is an admin.
-`$model->delete()` then does nothing and returns `false` — no exception — so a `finally` that looks
-correct leaves the row behind and poisons the shared DB for every later test (a leftover `Season` with no
-dungeons breaks any test doing `Season::orderByDesc('id')->first()->dungeons()`). The hook exempts
-`MappingVersion`, `Floor` and `Enemy`, which delete normally.
+The ~51 models using the `SeederModel` trait (`Season`, `SeasonDungeon`, `Expansion`, `EnemyPack`,
+`GameServerRegion`, … — `grep -rln "use SeederModel;" app/Models/`) hold the data every other test reads, so
+one leaked row is not a private mess: a leftover `Season` with no dungeons breaks any test doing
+`Season::orderByDesc('id')->first()->dungeons()`. Create as few as you can get away with, and always clean
+up in a `finally`.
 
-Clean these up through the query builder, which does not fire model events:
+`$model->delete()` works on them — the trait is a marker now. Prefer it over a query-builder delete: it fires
+the model events, so laravel-model-caching invalidates on its own and any cleanup the model registers in
+`booted()` still runs. Reach for `Model::query()->where(...)->delete()` only for bulk cleanup, and flush by
+hand there (`new Model()->flushCache()`), since no events fire.
 
-```php
-} finally {
-    Season::query()->whereKey($season->id)->delete();
-    // No model events fired, so laravel-model-caching does not invalidate on its own
-    new Season()->flushCache();
-}
-```
-
-Two caches make freshly created/deleted rows invisible in tests, and neither is the `array` store
+Two caches can still make freshly created/deleted rows invisible in tests, and neither is the `array` store
 `phpunit.xml` configures:
 - **laravel-model-caching** (every `CacheModel`) — flush with `new Model()->flushCache()`.
 - **`RemembersToFile`** (`ViewService::cachedGlobal`, map context, …) writes to `Cache::store('tmp_file')`,

--- a/app/Console/Commands/CombatLog/DetectStaleCombatLogDataCommand.php
+++ b/app/Console/Commands/CombatLog/DetectStaleCombatLogDataCommand.php
@@ -117,7 +117,8 @@ class DetectStaleCombatLogDataCommand extends Command
                 }
 
                 if (!empty($staleIds)) {
-                    // Use toBase() to bypass SeederModel's deleting observer, which only allows admin users to delete
+                    // toBase() drops to the plain query builder for this bulk delete, skipping Eloquent's
+                    // caching builder layer.
                     NpcCharacteristic::query()->whereIn('id', $staleIds)->toBase()->delete();
                 }
             });

--- a/app/Models/EnemyForcesCheckpoint.php
+++ b/app/Models/EnemyForcesCheckpoint.php
@@ -100,10 +100,11 @@ class EnemyForcesCheckpoint extends CacheModel implements HasLatLngInterface, Ma
     }
 
     /**
-     * Registered as `deleted` rather than `deleting` on purpose: SeederModel's `deleting` listener
-     * always returns a boolean, and Eloquent fires `deleting` through the dispatcher's `until()`,
-     * which halts on the first non-null result. A second `deleting` listener would therefore never
-     * run at all.
+     * Registered as `deleted` rather than `deleting`: the members only need detaching once the checkpoint is
+     * really gone. It also used to be the only option that worked at all - SeederModel registered a
+     * `deleting` listener returning a boolean, and Eloquent fires `deleting` through the dispatcher's
+     * `until()`, which halts on the first non-null result, so a second `deleting` listener never ran. That
+     * listener has since been removed.
      */
     #[Override]
     protected static function booted(): void

--- a/app/Models/EnemyForcesCheckpoint.php
+++ b/app/Models/EnemyForcesCheckpoint.php
@@ -101,10 +101,7 @@ class EnemyForcesCheckpoint extends CacheModel implements HasLatLngInterface, Ma
 
     /**
      * Registered as `deleted` rather than `deleting`: the members only need detaching once the checkpoint is
-     * really gone. It also used to be the only option that worked at all - SeederModel registered a
-     * `deleting` listener returning a boolean, and Eloquent fires `deleting` through the dispatcher's
-     * `until()`, which halts on the first non-null result, so a second `deleting` listener never ran. That
-     * listener has since been removed.
+     * really gone.
      */
     #[Override]
     protected static function booted(): void

--- a/app/Models/Traits/SeederModel.php
+++ b/app/Models/Traits/SeederModel.php
@@ -2,29 +2,23 @@
 
 namespace App\Models\Traits;
 
-use App\Models\Enemy;
-use App\Models\Floor\Floor;
-use App\Models\Laratrust\Role;
-use App\Models\Mapping\MappingVersion;
-use App\Models\User;
-use Auth;
 use Illuminate\Database\Eloquent\Model;
 
 /**
+ * Marks a model whose rows come from the seeders in database/seeders rather than from users, so that
+ * DatabaseSeeder::getTempTableName() knows to stage it in a `_temp` table while seeding. These models are
+ * read-mostly - see "Seeded models" in CLAUDE.md.
+ *
+ * This used to also register a `deleting` listener returning false for everyone but an admin. It guarded
+ * nothing - every route that deletes one of these models already sits behind `role:admin` - while doing two
+ * kinds of damage: it silently turned `$model->delete()` into a no-op wherever there is no authenticated
+ * user (Artisan commands, queued jobs, tests), and because Eloquent fires `deleting` through the
+ * dispatcher's `until()`, which halts on the first non-null result, it swallowed every `deleting` listener
+ * a model registered in `booted()` - including Npc's, so deleting an NPC as an admin left its spells,
+ * characteristics, bolstering whitelists, enemy forces and dungeon couplings behind.
+ *
  * @mixin Model
  */
 trait SeederModel
 {
-    public static function boot(): void
-    {
-        parent::boot();
-
-        // This model may NOT be deleted, it's read only! But if you're an admin, sure you can delete everything.
-        static::deleting(function (Model $model) {
-            /** @var User|null $user */
-            $user = Auth::getUser();
-
-            return $user?->hasRole(Role::ROLE_ADMIN) || $model instanceof MappingVersion || $model instanceof Floor || $model instanceof Enemy;
-        });
-    }
 }

--- a/app/Models/Traits/SeederModel.php
+++ b/app/Models/Traits/SeederModel.php
@@ -9,14 +9,6 @@ use Illuminate\Database\Eloquent\Model;
  * DatabaseSeeder::getTempTableName() knows to stage it in a `_temp` table while seeding. These models are
  * read-mostly - see "Seeded models" in CLAUDE.md.
  *
- * This used to also register a `deleting` listener returning false for everyone but an admin. It guarded
- * nothing - every route that deletes one of these models already sits behind `role:admin` - while doing two
- * kinds of damage: it silently turned `$model->delete()` into a no-op wherever there is no authenticated
- * user (Artisan commands, queued jobs, tests), and because Eloquent fires `deleting` through the
- * dispatcher's `until()`, which halts on the first non-null result, it swallowed every `deleting` listener
- * a model registered in `booted()` - including Npc's, so deleting an NPC as an admin left its spells,
- * characteristics, bolstering whitelists, enemy forces and dungeon couplings behind.
- *
  * @mixin Model
  */
 trait SeederModel

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -686,10 +686,9 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
             $enemyForcesCheckpointsToPrune->count(),
         );
 
-        // A query builder delete, not an Eloquent one: SeederModel's `deleting` listener refuses the delete
-        // unless an admin is authenticated, and this import runs from the scheduler with nobody logged in.
-        // The EnemyForcesCheckpoint `deleted` hook it also skips only releases member enemies - and these
-        // checkpoints have none by definition.
+        // A bulk query builder delete rather than looping model deletes: it skips per-model events, including
+        // the EnemyForcesCheckpoint `deleted` hook - which only releases member enemies, and these checkpoints
+        // have none by definition, so skipping it here is fine.
         EnemyForcesCheckpoint::query()
             ->whereIn('id', $enemyForcesCheckpointsToPrune->pluck('id'))
             ->delete();

--- a/tests/Feature/App/Model/Trait/SeederModelTest.php
+++ b/tests/Feature/App/Model/Trait/SeederModelTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\App\Model\Trait;
+
+use App\Models\Dungeon;
+use App\Models\Season;
+use App\Models\SeasonDungeon;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * SeederModel used to register a `deleting` listener returning false for everyone but an admin. It guarded
+ * nothing - every route deleting one of these models sits behind `role:admin` - while silently turning
+ * `$model->delete()` into a no-op wherever nobody is authenticated (Artisan commands, queued jobs, tests),
+ * and swallowing any `deleting` listener a model registered in `booted()`, because Eloquent fires `deleting`
+ * through the dispatcher's `until()`, which halts on the first non-null result.
+ */
+#[Group('SeederModel')]
+final class SeederModelTest extends PublicTestCase
+{
+    #[Test]
+    public function delete_givenNoAuthenticatedUser_removesTheRow(): void
+    {
+        // Arrange
+        $this->actingAsGuest();
+
+        $seasonDungeon = null;
+
+        try {
+            $seasonDungeon = SeasonDungeon::create([
+                'season_id'  => Season::SEASON_MIDNIGHT_S1,
+                'dungeon_id' => Dungeon::query()->firstOrFail()->id,
+            ]);
+
+            // Act
+            $deleted = $seasonDungeon->delete();
+
+            // Assert
+            $this->assertTrue((bool)$deleted);
+            $this->assertNull(SeasonDungeon::query()->find($seasonDungeon->id));
+        } finally {
+            SeasonDungeon::query()->whereKey($seasonDungeon?->id)->delete();
+
+            new SeasonDungeon()->flushCache();
+        }
+    }
+}

--- a/tests/Feature/App/Models/Trait/SeederModelTest.php
+++ b/tests/Feature/App/Models/Trait/SeederModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\App\Model\Trait;
+namespace Tests\Feature\App\Models\Trait;
 
 use App\Models\Dungeon;
 use App\Models\Season;

--- a/tests/Feature/App/Service/Dungeon/DungeonService/GetDungeonsForGameVersionTest.php
+++ b/tests/Feature/App/Service/Dungeon/DungeonService/GetDungeonsForGameVersionTest.php
@@ -168,15 +168,12 @@ final class GetDungeonsForGameVersionTest extends PublicTestCase
             );
             $this->assertNotContains($futureSeasonDungeon->id, $dungeons->pluck('id')->all());
         } finally {
-            // Through the query builder on purpose - SeederModel blocks deleting these models for anyone
-            // who is not an admin, and it does so silently, so $model->delete() would leave the rows behind.
-            // That skips the model events too, hence flushing the model cache by hand afterwards.
             if ($futureSeason !== null) {
-                SeasonDungeon::query()->where('season_id', $futureSeason->id)->delete();
-                Season::query()->whereKey($futureSeason->id)->delete();
+                foreach ($futureSeason->seasonDungeons as $seasonDungeon) {
+                    $seasonDungeon->delete();
+                }
 
-                new SeasonDungeon()->flushCache();
-                new Season()->flushCache();
+                $futureSeason->delete();
             }
         }
     }

--- a/tests/Feature/Controller/Dungeon/DungeonExploreControllerTest.php
+++ b/tests/Feature/Controller/Dungeon/DungeonExploreControllerTest.php
@@ -139,23 +139,23 @@ final class DungeonExploreControllerTest extends PublicTestCase
         return $season;
     }
 
-    /**
-     * Through the query builder on purpose - SeederModel silently blocks deleting these models for anyone who is
-     * not an admin, so $model->delete() would leave the rows behind. That skips the model events too, hence
-     * flushing the caches keyed on seasons by hand.
-     */
     private function deleteUpcomingSeason(Season $season): void
     {
-        SeasonDungeon::query()->where('season_id', $season->id)->delete();
-        Season::query()->whereKey($season->id)->delete();
+        foreach ($season->seasonDungeons as $seasonDungeon) {
+            $seasonDungeon->delete();
+        }
+
+        $season->delete();
 
         $this->flushSeasonCaches();
     }
 
+    /**
+     * The model events take care of laravel-model-caching; ViewService's 'tmp_file' store is a plain file cache
+     * that nothing invalidates, and it holds the seasons it hands the composers for an hour.
+     */
     private function flushSeasonCaches(): void
     {
-        new SeasonDungeon()->flushCache();
-        new Season()->flushCache();
         Cache::store('tmp_file')->flush();
     }
 }

--- a/tests/Feature/View/HeaderComposerTest.php
+++ b/tests/Feature/View/HeaderComposerTest.php
@@ -159,21 +159,19 @@ final class HeaderComposerTest extends PublicTestCase
         }
     }
 
-    /**
-     * Removes a season created by this test. Through the query builder on purpose - SeederModel silently blocks
-     * deleting a Season for anyone who is not an admin, so $season->delete() would leave the row behind. That does
-     * mean no model events fire, so the caches keyed on seasons are flushed by hand.
-     */
     private function deleteSeason(Season $season): void
     {
-        Season::query()->whereKey($season->id)->delete();
+        $season->delete();
 
         $this->flushSeasonCaches();
     }
 
+    /**
+     * The model events take care of laravel-model-caching; ViewService's 'tmp_file' store is a plain file cache
+     * that nothing invalidates, and it holds the season for an hour.
+     */
     private function flushSeasonCaches(): void
     {
-        new Season()->flushCache();
         Cache::store('tmp_file')->flush();
     }
 


### PR DESCRIPTION
:robot:

Closes #3770

Spun out of #3769's review round — the commit was written there, but that PR merged before this landed, so
it gets its own issue and branch.

## What this removes

`SeederModel` registered a `deleting` listener refusing to delete any of the 51 models using the trait
unless an admin was authenticated. It goes; the trait stays as the marker
`DatabaseSeeder::getTempTableName()` uses to stage a table as `<table>_temp`.

## Why

- **It guarded nothing.** Every route deleting one of these models already sits behind
  `['auth', 'role:admin']`, so any request reaching a delete is an admin — for whom the listener returned
  `true` anyway.
- **It broke deletes with no authenticated user** — Artisan commands, queued jobs, tests. `$model->delete()`
  returned `false` and did nothing, silently. `DetectStaleCombatLogDataCommand:121` already worked around it
  with `->toBase()`, and in tests it meant a correct-looking `try/finally` left rows in the shared seeded
  database, breaking unrelated tests later.
- **It swallowed other `deleting` listeners.** Eloquent fires `deleting` through the dispatcher's `until()`,
  which halts on the first non-null result, and this listener always returned a boolean from `boot()` —
  before anything a model registers in `booted()`. So `Npc`'s cleanup listener never ran, and since `true`
  halts as readily as `false`, **deleting an NPC through the admin panel left its spells, characteristics,
  bolstering whitelists, enemy forces and dungeon couplings orphaned**. Verified on the dev database:

  ```
  Auth::login(User::findOrFail(1));   // admin
  Event::until('eloquent.deleting: App\Models\Npc\Npc', [$npc]);   // => true, halts here
  // npc spells before: 1, after: 1   — Npc's own listener never ran
  ```

`EnemyForcesCheckpoint` already documented this hazard and registered on `deleted` to dodge it; its comment
is trimmed down to just the still-true reason for using `deleted` over `deleting`, since the hazard itself
is gone. `MappingVersion` and `EnemyPatrol` define `boot()` themselves, which overrides the trait's, so
the guard never applied to them at all.

## In its place

CLAUDE.md gains a "Seeded models" section carrying the convention the listener half-enforced: these models
hold seeded data and nothing outside the admin panel, the mapping editor and the seeders should delete their
rows. A delete there is recoverable directly from `database/seeders`, since that's where these models' rows
are authored.

**Edit:** per Wotuu's review, cleaned up several comments/docs that were left narrating the now-removed
listener instead of documenting current behaviour — `.claude/CLAUDE.md`'s "Seeded models" section (including
the recoverability wording above, corrected per his note), the `SeederModel` trait docblock, and
`EnemyForcesCheckpoint`'s `booted()` docblock.

## Tests

`SeederModelTest` asserts a seeded model deletes with nobody authenticated — it fails with the listener
restored, which I checked. The three test classes that came out of #3769 drop their query-builder cleanup
workarounds and use `$model->delete()` again, which also restores proper model-cache invalidation. The
`writing-tests` skill section that documented the trap is rewritten.

I did not ship a test for the NPC cascade itself: creating an `Npc` also spawns 23 `translations` rows, and
cleaning that up reliably in the shared database costs more than the test is worth. The behaviour is covered
by the verification above and documented in CLAUDE.md.

