### PR TITLE
#3772 Clear a user's stored feature values when their roles change

### DIFF
--- a/app/Models/Feature/Feature.php
+++ b/app/Models/Feature/Feature.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Eloquent;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
+use Laravel\Pennant\Feature as PennantFeature;
 
 /**
  * @property int    $id
@@ -20,6 +21,11 @@ use Illuminate\Support\Carbon;
  */
 class Feature extends Model
 {
+    /**
+     * The user whose stored values double as the global on/off switch of each feature - see getAdminValue().
+     */
+    public const int ADMIN_USER_ID = 1;
+
     protected function casts(): array
     {
         return [
@@ -36,9 +42,25 @@ class Feature extends Model
     {
         /** @var Feature|null $feature */
         $feature = Feature::where('name', $name)
-            ->where('scope', sprintf('%s|%d', User::class, 1))
+            ->where('scope', sprintf('%s|%d', User::class, self::ADMIN_USER_ID))
             ->first();
 
         return $feature?->value === 'true';
+    }
+
+    /**
+     * Drop every stored feature value of the given user, so that they are resolved anew the next time the user
+     * requests them. Necessary whenever the user's roles change - every feature in App\Features resolves off the
+     * user's roles, but Pennant stores the value it resolved once and keeps serving it forever after.
+     */
+    public static function forgetAllForUser(User $user): void
+    {
+        // The admin user's stored values are the global on/off switch of each feature (see getAdminValue), so
+        // dropping them would disable every feature site-wide until an admin toggles them all back on by hand
+        if ($user->id === self::ADMIN_USER_ID) {
+            return;
+        }
+
+        PennantFeature::for($user)->forget(PennantFeature::stored());
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Exceptions\Handler;
+use App\Models\Feature\Feature;
 use App\Models\Laratrust\Role;
 use App\Models\User;
 use App\Overrides\CustomRateLimiter;
@@ -62,6 +63,19 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(CommandStarting::class, static function (): void {
             Context::addIf('trace_id', (string)Str::uuid());
         });
+
+        // Every feature in App\Features resolves off the user's roles, but Pennant stores the value it resolved
+        // once and keeps serving that forever after - so changing a user's roles has to drop their stored values.
+        // Laratrust passes the changed user as the first argument; the arguments following it differ per event
+        // (added/removed pass the role, synced passes the sync changes) so they're deliberately not accepted here.
+        $forgetFeatures = static function (User $user): void {
+            Feature::forgetAllForUser($user);
+        };
+
+        // removeRoles() loops removeRole() - unless it's handed an empty array, in which case it syncs instead
+        User::roleAdded($forgetFeatures);
+        User::roleRemoved($forgetFeatures);
+        User::roleSynced($forgetFeatures);
 
         $this->app->bind(ExceptionHandler::class, Handler::class);
 

--- a/tests/Feature/App/Models/Feature/FeatureForgetAllForUserTest.php
+++ b/tests/Feature/App/Models/Feature/FeatureForgetAllForUserTest.php
@@ -107,14 +107,17 @@ final class FeatureForgetAllForUserTest extends PublicTestCase
     public function forgetAllForUser_givenAdminUser_keepsStoredFeatureValues(): void
     {
         // Arrange - the admin's stored values are the global on/off switch of every feature, so dropping them
-        // would disable the lot site-wide. A synthetic name keeps the real switches out of this test entirely.
-        $admin = User::findOrFail(Feature::ADMIN_USER_ID);
+        // would disable the lot site-wide. Asserting on a synthetic name keeps the real switches out of it.
+        $admin      = User::findOrFail(Feature::ADMIN_USER_ID);
+        $adminScope = $this->serializeScopeOf($admin);
         $this->assertTrue($admin->hasRole(Role::ROLE_ADMIN), 'User id=1 must be admin (seed the DB).');
+
+        $storedValuesOfAdmin = Feature::query()->where('scope', $adminScope)->get();
 
         try {
             Feature::query()->insert([
                 'name'       => self::SYNTHETIC_FEATURE_NAME,
-                'scope'      => $this->serializeScopeOf($admin),
+                'scope'      => $adminScope,
                 'value'      => 'true',
                 'created_at' => now(),
                 'updated_at' => now(),
@@ -126,10 +129,24 @@ final class FeatureForgetAllForUserTest extends PublicTestCase
             // Assert
             $this->assertSame(1, Feature::query()
                 ->where('name', self::SYNTHETIC_FEATURE_NAME)
-                ->where('scope', $this->serializeScopeOf($admin))
+                ->where('scope', $adminScope)
                 ->count());
         } finally {
             Feature::query()->where('name', self::SYNTHETIC_FEATURE_NAME)->delete();
+
+            // The Act purges every stored name, not just the synthetic one - so should the guard under test ever
+            // regress, put the admin's real rows back rather than leaving the shared test database (which has no
+            // RefreshDatabase to save it) without the global on/off switch of every feature
+            foreach ($storedValuesOfAdmin as $storedValueOfAdmin) {
+                Feature::query()->updateOrInsert([
+                    'name'  => $storedValueOfAdmin->name,
+                    'scope' => $adminScope,
+                ], [
+                    'value'      => $storedValueOfAdmin->value,
+                    'created_at' => $storedValueOfAdmin->created_at,
+                    'updated_at' => $storedValueOfAdmin->updated_at,
+                ]);
+            }
         }
     }
 

--- a/tests/Feature/App/Models/Feature/FeatureForgetAllForUserTest.php
+++ b/tests/Feature/App/Models/Feature/FeatureForgetAllForUserTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\App\Models\Feature;
+
+use App\Features\NpcCompendium;
+use App\Models\Feature\Feature;
+use App\Models\Laratrust\Role;
+use App\Models\User;
+use Laravel\Pennant\Feature as PennantFeature;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Feature')]
+final class FeatureForgetAllForUserTest extends PublicTestCase
+{
+    /**
+     * A name that matches no class in App\Features, so that a test which needs a stored value for the admin user
+     * never touches (or restores incorrectly) the real rows that drive the global on/off switch of every feature.
+     */
+    private const string SYNTHETIC_FEATURE_NAME = 'Tests\\Feature\\App\\Models\\Feature\\SyntheticFeature';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The suite runs Pennant on its array store (see phpunit.xml), but what's under test here is precisely
+        // the rows in the features table - so these tests need the database store the application really runs on
+        config(['pennant.default' => 'database']);
+        PennantFeature::forgetDrivers();
+    }
+
+    protected function tearDown(): void
+    {
+        PennantFeature::forgetDrivers();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function addRole_givenUserWithStoredFeatureValues_forgetsThoseValues(): void
+    {
+        // Arrange - the user browsed the site before being given the role, so their 'false' is already stored
+        $user = User::factory()->create();
+
+        try {
+            PennantFeature::for($user)->deactivate(NpcCompendium::class);
+            $this->assertSame(1, $this->countStoredFeaturesOf($user), 'Expected the stored value to be arranged.');
+
+            // Act
+            $user->addRole(Role::ROLE_INTERNAL_TEAM);
+
+            // Assert
+            $this->assertSame(0, $this->countStoredFeaturesOf($user));
+        } finally {
+            $this->deleteStoredFeaturesOf($user);
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function removeRole_givenUserWithStoredFeatureValues_forgetsThoseValues(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        try {
+            $user->addRole(Role::ROLE_INTERNAL_TEAM);
+            PennantFeature::for($user)->activate(NpcCompendium::class);
+            $this->assertSame(1, $this->countStoredFeaturesOf($user), 'Expected the stored value to be arranged.');
+
+            // Act
+            $user->removeRole(Role::ROLE_INTERNAL_TEAM);
+
+            // Assert
+            $this->assertSame(0, $this->countStoredFeaturesOf($user));
+        } finally {
+            $this->deleteStoredFeaturesOf($user);
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function removeRoles_givenNoRolesToRemove_forgetsStoredFeatureValues(): void
+    {
+        // Arrange - removeRoles() only loops removeRole() when it's handed roles; an empty array syncs instead,
+        // which fires role.synced rather than role.removed
+        $user = User::factory()->create();
+
+        try {
+            $user->addRole(Role::ROLE_INTERNAL_TEAM);
+            PennantFeature::for($user)->activate(NpcCompendium::class);
+            $this->assertSame(1, $this->countStoredFeaturesOf($user), 'Expected the stored value to be arranged.');
+
+            // Act
+            $user->removeRoles();
+
+            // Assert
+            $this->assertSame(0, $this->countStoredFeaturesOf($user));
+        } finally {
+            $this->deleteStoredFeaturesOf($user);
+            $user->delete();
+        }
+    }
+
+    #[Test]
+    public function forgetAllForUser_givenAdminUser_keepsStoredFeatureValues(): void
+    {
+        // Arrange - the admin's stored values are the global on/off switch of every feature, so dropping them
+        // would disable the lot site-wide. A synthetic name keeps the real switches out of this test entirely.
+        $admin = User::findOrFail(Feature::ADMIN_USER_ID);
+        $this->assertTrue($admin->hasRole(Role::ROLE_ADMIN), 'User id=1 must be admin (seed the DB).');
+
+        try {
+            Feature::query()->insert([
+                'name'       => self::SYNTHETIC_FEATURE_NAME,
+                'scope'      => $this->serializeScopeOf($admin),
+                'value'      => 'true',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            // Act
+            Feature::forgetAllForUser($admin);
+
+            // Assert
+            $this->assertSame(1, Feature::query()
+                ->where('name', self::SYNTHETIC_FEATURE_NAME)
+                ->where('scope', $this->serializeScopeOf($admin))
+                ->count());
+        } finally {
+            Feature::query()->where('name', self::SYNTHETIC_FEATURE_NAME)->delete();
+        }
+    }
+
+    private function countStoredFeaturesOf(User $user): int
+    {
+        return Feature::query()->where('scope', $this->serializeScopeOf($user))->count();
+    }
+
+    private function deleteStoredFeaturesOf(User $user): void
+    {
+        Feature::query()->where('scope', $this->serializeScopeOf($user))->delete();
+    }
+
+    private function serializeScopeOf(User $user): string
+    {
+        return sprintf('%s|%d', User::class, $user->id);
+    }
+}


### PR DESCRIPTION
:robot: Closes #3772

## The problem

Every feature in `app/Features` resolves off the user's roles — `NpcCompendium` for instance requires `ROLE_ADMIN` or `ROLE_INTERNAL_TEAM`. Pennant stores the value it resolved *once* in the `features` table and keeps serving that forever after, so a user who browsed the site before being granted a role keeps their stale `false` and never gains access.

Hit for real on Staging: a user registered, was given Internal Team, and still could not see the NPC Compendium because their `App\Features\NpcCompendium = false` row was already there.

## The fix

`Feature::forgetAllForUser()` drops every stored value of a user, wired to Laratrust's `role.added` / `role.removed` / `role.synced` events on `User` in `AppServiceProvider`. Any role change — the admin panel, `RegisterController`, anything added later — now purges the user's rows, and they're resolved anew on that user's next request.

All three events are needed: `removeRoles([$roles])` loops `removeRole()` and fires `role.removed`, but `removeRoles()` with nothing to remove falls through to `syncRoles([])` and fires `role.synced` instead.

### The admin user is deliberately exempt

`Feature::getAdminValue()` reads the row scoped to **user 1** as the global on/off switch of each feature. Purging that user's rows would therefore take every feature down site-wide until an admin re-toggled them one by one — worse than the bug being fixed here. `forgetAllForUser()` returns early for that user, and the coupling now runs through a `Feature::ADMIN_USER_ID` constant instead of a hardcoded `1` in the `sprintf`, so the guard reads as intentional.

## Tests

`tests/Feature/App/Models/Feature/FeatureForgetAllForUserTest.php` — one test per event path (added / removed / synced-via-empty-`removeRoles`) plus one pinning the admin exemption. All four were verified to fail when the listeners / the guard are removed, so none of them pass vacuously.

The suite runs Pennant on its `array` store (`phpunit.xml`), so the test class swaps in the `database` store in `setUp()` — what's under test is precisely the rows in the `features` table. The admin test uses a synthetic feature name so it never touches the real switches.

## Note for after this deploys

The fix is forward-looking: it does not retroactively clean up users who are *already* stuck with a stale `false`. For the Staging user who prompted this, either delete their rows from `features` directly, or remove and re-add their role once this is live.
