### PR TITLE
Match an affix string on the affixes an affix group actually has (#3776)

### DIFF
--- a/app/Service/AffixGroup/AffixGroupEaseTierService.php
+++ b/app/Service/AffixGroup/AffixGroupEaseTierService.php
@@ -235,7 +235,7 @@ class AffixGroupEaseTierService implements AffixGroupEaseTierServiceInterface
     /**
      * {@inheritdoc}
      */
-    public function getAffixGroupByString(string $affixString): ?AffixGroup
+    public function getAffixGroupByString(string $easeTierAffixString): ?AffixGroup
     {
         $currentSeason = $this->seasonService->getCurrentSeason();
         if ($currentSeason === null) {
@@ -245,13 +245,13 @@ class AffixGroupEaseTierService implements AffixGroupEaseTierServiceInterface
         /** @var Collection<string, Affix> $affixesByName */
         $affixesByName = Affix::all()->keyBy(static fn(Affix $affix): string => (string)__($affix->name, [], 'en_US'));
 
-        $affixNames = collect(explode(',', $affixString))
+        $affixNames = collect(explode(',', $easeTierAffixString))
             ->map(static fn(string $affixName): string => trim($affixName))
             ->filter(static fn(string $affixName): bool => $affixName !== '');
 
         // Without any affixes to match on every affix group would be a match - refuse to guess instead
         if ($affixNames->isEmpty()) {
-            $this->log->getAffixGroupByStringNoAffixes($affixString);
+            $this->log->getAffixGroupByStringNoAffixes($easeTierAffixString);
 
             return null;
         }
@@ -291,7 +291,7 @@ class AffixGroupEaseTierService implements AffixGroupEaseTierServiceInterface
             ->filter(fn(AffixGroup $affixGroup): bool => $this->hasAllAffixes($affixGroup, $affixKeys));
 
         if ($matchingAffixGroups->isEmpty()) {
-            $this->log->getAffixGroupByStringNoMatchingAffixGroup($affixString);
+            $this->log->getAffixGroupByStringNoMatchingAffixGroup($easeTierAffixString);
 
             return null;
         }
@@ -302,7 +302,7 @@ class AffixGroupEaseTierService implements AffixGroupEaseTierServiceInterface
         )->unique();
 
         if ($matchingAffixes->count() > 1) {
-            $this->log->getAffixGroupByStringAmbiguousAffixes($affixString, $matchingAffixes->join(' / '));
+            $this->log->getAffixGroupByStringAmbiguousAffixes($easeTierAffixString, $matchingAffixes->join(' / '));
 
             return null;
         }

--- a/app/Service/AffixGroup/AffixGroupEaseTierService.php
+++ b/app/Service/AffixGroup/AffixGroupEaseTierService.php
@@ -237,41 +237,53 @@ class AffixGroupEaseTierService implements AffixGroupEaseTierServiceInterface
      */
     public function getAffixGroupByString(string $affixString): ?AffixGroup
     {
-        $result = null;
+        $currentSeason = $this->seasonService->getCurrentSeason();
+        if ($currentSeason === null) {
+            return null;
+        }
 
-        $affixList                = Affix::all();
-        $currentSeason            = $this->seasonService->getCurrentSeason();
-        $currentSeasonAffixGroups = $currentSeason->affixGroups;
+        /** @var Collection<string, Affix> $affixesByName */
+        $affixesByName = Affix::all()->keyBy(static fn(Affix $affix): string => (string)__($affix->name, [], 'en_US'));
 
-        $affixes = collect(explode(', ', $affixString));
+        $affixNames = collect(explode(',', $affixString))
+            ->map(static fn(string $affixName): string => trim($affixName))
+            ->filter(static fn(string $affixName): bool => $affixName !== '');
 
-        // Filter out properties that don't have the correct amount of affixes
-        if ($affixes->count() === 3 + (int)($currentSeason->seasonal_affix_id !== null)) {
-            // Check if there's any affixes in the list that we cannot find in our own database
-            $invalidAffixes = $affixes->filter(static fn(string $affixName) => $affixList->filter(static fn(
-                Affix $affix,
-            ) => __($affix->name, [], 'en_US') === $affixName)->isEmpty());
+        // Without any affixes to match on every affix group would be a match - refuse to guess instead
+        if ($affixNames->isEmpty()) {
+            $this->log->getAffixGroupByStringNoMatchingAffixGroup($affixString);
 
-            // No invalid affixes found, great!
-            if ($invalidAffixes->isEmpty()) {
-                // Now we must find affix groups that correspond to the affix list
-                foreach ($currentSeasonAffixGroups as $affixGroup) {
-                    // Loop over the affixes of the affix group and empty the list
-                    $notFoundAffixes = $affixGroup->affixes->filter(static fn(
-                        Affix $affix,
-                    ) => $affixes->search($affix->key) === false);
+            return null;
+        }
 
-                    // If we have found the match, we're done
-                    if ($notFoundAffixes->isEmpty()) {
-                        $result = $affixGroup;
-                        break;
-                    }
-                }
-            } else {
-                $this->log->getAffixGroupByStringUnknownAffixes($invalidAffixes->join(', '));
+        // Check if there's any affixes in the list that we cannot find in our own database
+        $invalidAffixes = $affixNames->reject(static fn(string $affixName): bool => $affixesByName->has($affixName));
+
+        if ($invalidAffixes->isNotEmpty()) {
+            $this->log->getAffixGroupByStringUnknownAffixes($invalidAffixes->join(', '));
+
+            return null;
+        }
+
+        $affixKeys = $affixNames->map(static function (string $affixName) use ($affixesByName): string {
+            /** @var Affix $affix Guaranteed to exist - any name that could not be resolved was rejected above */
+            $affix = $affixesByName->get($affixName);
+
+            return $affix->key;
+        });
+
+        // The amount of affixes an affix group has varies per season (three in DF S4, four in TWW S3, five in
+        // Midnight S1), so match on the affixes an affix group actually has rather than on a hardcoded count.
+        // A season may contain multiple affix groups with the exact same set of affixes - they share an ease tier,
+        // so returning the first affix group that has all the given affixes is fine.
+        foreach ($currentSeason->affixGroups as $affixGroup) {
+            if ($affixKeys->every(static fn(string $affixKey): bool => $affixGroup->hasAffix($affixKey))) {
+                return $affixGroup;
             }
         }
 
-        return $result;
+        $this->log->getAffixGroupByStringNoMatchingAffixGroup($affixString);
+
+        return null;
     }
 }

--- a/app/Service/AffixGroup/AffixGroupEaseTierService.php
+++ b/app/Service/AffixGroup/AffixGroupEaseTierService.php
@@ -278,7 +278,10 @@ class AffixGroupEaseTierService implements AffixGroupEaseTierServiceInterface
         // group of the current week whenever it has the given affixes.
         $currentAffixGroup = $this->seasonAffixGroupService->getCurrentAffixGroup($currentSeason);
 
-        if ($currentAffixGroup !== null && $this->hasAllAffixes($currentAffixGroup, $affixKeys)) {
+        // The current affix group may be that of a timewalking event, which is not an affix group of this season
+        if ($currentAffixGroup !== null &&
+            $currentAffixGroup->season_id === $currentSeason->id &&
+            $this->hasAllAffixes($currentAffixGroup, $affixKeys)) {
             return $currentAffixGroup;
         }
 

--- a/app/Service/AffixGroup/AffixGroupEaseTierService.php
+++ b/app/Service/AffixGroup/AffixGroupEaseTierService.php
@@ -251,7 +251,7 @@ class AffixGroupEaseTierService implements AffixGroupEaseTierServiceInterface
 
         // Without any affixes to match on every affix group would be a match - refuse to guess instead
         if ($affixNames->isEmpty()) {
-            $this->log->getAffixGroupByStringNoMatchingAffixGroup($affixString);
+            $this->log->getAffixGroupByStringNoAffixes($affixString);
 
             return null;
         }
@@ -272,18 +272,46 @@ class AffixGroupEaseTierService implements AffixGroupEaseTierServiceInterface
             return $affix->key;
         });
 
-        // The amount of affixes an affix group has varies per season (three in DF S4, four in TWW S3, five in
-        // Midnight S1), so match on the affixes an affix group actually has rather than on a hardcoded count.
-        // A season may contain multiple affix groups with the exact same set of affixes - they share an ease tier,
-        // so returning the first affix group that has all the given affixes is fine.
-        foreach ($currentSeason->affixGroups as $affixGroup) {
-            if ($affixKeys->every(static fn(string $affixKey): bool => $affixGroup->hasAffix($affixKey))) {
-                return $affixGroup;
-            }
+        // A season has multiple affix groups with the exact same affixes - one for each week that the affixes are
+        // active - which no affix string can tell apart. Ease tiers are stored and read per affix group, so picking
+        // the wrong one hides them entirely. The tier list is always that of the current week, so prefer the affix
+        // group of the current week whenever it has the given affixes.
+        $currentAffixGroup = $this->seasonAffixGroupService->getCurrentAffixGroup($currentSeason);
+
+        if ($currentAffixGroup !== null && $this->hasAllAffixes($currentAffixGroup, $affixKeys)) {
+            return $currentAffixGroup;
         }
 
-        $this->log->getAffixGroupByStringNoMatchingAffixGroup($affixString);
+        // The amount of affixes an affix group has varies per season (three in DF S4, four in TWW S3, five in
+        // Midnight S1), so match on the affixes an affix group actually has rather than on a hardcoded count
+        $matchingAffixGroups = $currentSeason->affixGroups
+            ->filter(fn(AffixGroup $affixGroup): bool => $this->hasAllAffixes($affixGroup, $affixKeys));
 
-        return null;
+        if ($matchingAffixGroups->isEmpty()) {
+            $this->log->getAffixGroupByStringNoMatchingAffixGroup($affixString);
+
+            return null;
+        }
+
+        // Too few affixes were given to tell affix groups with different affixes apart - refuse to guess
+        $matchingAffixes = $matchingAffixGroups->map(
+            static fn(AffixGroup $affixGroup): string => $affixGroup->affixes->pluck('key')->sort()->join(', '),
+        )->unique();
+
+        if ($matchingAffixes->count() > 1) {
+            $this->log->getAffixGroupByStringAmbiguousAffixes($affixString, $matchingAffixes->join(' / '));
+
+            return null;
+        }
+
+        return $matchingAffixGroups->first();
+    }
+
+    /**
+     * @param Collection<int, string> $affixKeys
+     */
+    private function hasAllAffixes(AffixGroup $affixGroup, Collection $affixKeys): bool
+    {
+        return $affixKeys->every(static fn(string $affixKey): bool => $affixGroup->hasAffix($affixKey));
     }
 }

--- a/app/Service/AffixGroup/AffixGroupEaseTierServiceInterface.php
+++ b/app/Service/AffixGroup/AffixGroupEaseTierServiceInterface.php
@@ -6,6 +6,7 @@ use App\Models\AffixGroup\AffixGroup;
 use App\Models\AffixGroup\AffixGroupEaseTier;
 use App\Models\AffixGroup\AffixGroupEaseTierPull;
 use App\Models\Dungeon;
+use Exception;
 use Illuminate\Support\Collection;
 
 interface AffixGroupEaseTierServiceInterface
@@ -35,8 +36,10 @@ interface AffixGroupEaseTierServiceInterface
     public function getTiers(): Collection;
 
     /**
-     * Finds the first affix group of the current season that has all affixes in the given comma separated list of
-     * (English) affix names, or null if no such affix group exists.
+     * Finds the affix group of the current season that has all affixes in the given comma separated list of (English)
+     * affix names, or null if no such affix group exists or if multiple affix groups with different affixes have them.
+     *
+     * @throws Exception
      */
     public function getAffixGroupByString(string $affixString): ?AffixGroup;
 }

--- a/app/Service/AffixGroup/AffixGroupEaseTierServiceInterface.php
+++ b/app/Service/AffixGroup/AffixGroupEaseTierServiceInterface.php
@@ -34,5 +34,9 @@ interface AffixGroupEaseTierServiceInterface
      */
     public function getTiers(): Collection;
 
+    /**
+     * Finds the first affix group of the current season that has all affixes in the given comma separated list of
+     * (English) affix names, or null if no such affix group exists.
+     */
     public function getAffixGroupByString(string $affixString): ?AffixGroup;
 }

--- a/app/Service/AffixGroup/AffixGroupEaseTierServiceInterface.php
+++ b/app/Service/AffixGroup/AffixGroupEaseTierServiceInterface.php
@@ -37,9 +37,11 @@ interface AffixGroupEaseTierServiceInterface
 
     /**
      * Finds the affix group of the current season that has all affixes in the given comma separated list of (English)
-     * affix names, or null if no such affix group exists or if multiple affix groups with different affixes have them.
+     * affix names - the affix group may have more affixes than were given. Prefers the affix group of the current
+     * week when it has them; otherwise returns the matching affix group, or null when no affix group of the season
+     * has them, or when multiple affix groups with differing affixes do.
      *
      * @throws Exception
      */
-    public function getAffixGroupByString(string $affixString): ?AffixGroup;
+    public function getAffixGroupByString(string $easeTierAffixString): ?AffixGroup;
 }

--- a/app/Service/AffixGroup/Logging/AffixGroupEaseTierServiceLogging.php
+++ b/app/Service/AffixGroup/Logging/AffixGroupEaseTierServiceLogging.php
@@ -54,4 +54,9 @@ class AffixGroupEaseTierServiceLogging extends StructuredLogging implements Affi
     {
         $this->error(__METHOD__, get_defined_vars());
     }
+
+    public function getAffixGroupByStringNoMatchingAffixGroup(string $affixString): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
+    }
 }

--- a/app/Service/AffixGroup/Logging/AffixGroupEaseTierServiceLogging.php
+++ b/app/Service/AffixGroup/Logging/AffixGroupEaseTierServiceLogging.php
@@ -55,7 +55,17 @@ class AffixGroupEaseTierServiceLogging extends StructuredLogging implements Affi
         $this->error(__METHOD__, get_defined_vars());
     }
 
+    public function getAffixGroupByStringNoAffixes(string $affixString): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
+    }
+
     public function getAffixGroupByStringNoMatchingAffixGroup(string $affixString): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
+    }
+
+    public function getAffixGroupByStringAmbiguousAffixes(string $affixString, string $matchingAffixes): void
     {
         $this->error(__METHOD__, get_defined_vars());
     }

--- a/app/Service/AffixGroup/Logging/AffixGroupEaseTierServiceLoggingInterface.php
+++ b/app/Service/AffixGroup/Logging/AffixGroupEaseTierServiceLoggingInterface.php
@@ -23,4 +23,6 @@ interface AffixGroupEaseTierServiceLoggingInterface
     public function parseTierListDataNotUpdatedYet(): void;
 
     public function getAffixGroupByStringUnknownAffixes(string $unknownAffixes): void;
+
+    public function getAffixGroupByStringNoMatchingAffixGroup(string $affixString): void;
 }

--- a/app/Service/AffixGroup/Logging/AffixGroupEaseTierServiceLoggingInterface.php
+++ b/app/Service/AffixGroup/Logging/AffixGroupEaseTierServiceLoggingInterface.php
@@ -24,5 +24,9 @@ interface AffixGroupEaseTierServiceLoggingInterface
 
     public function getAffixGroupByStringUnknownAffixes(string $unknownAffixes): void;
 
+    public function getAffixGroupByStringNoAffixes(string $affixString): void;
+
     public function getAffixGroupByStringNoMatchingAffixGroup(string $affixString): void;
+
+    public function getAffixGroupByStringAmbiguousAffixes(string $affixString, string $matchingAffixes): void;
 }

--- a/tests/Feature/App/Service/AffixGroup/AffixGroupEaseTierServiceTest.php
+++ b/tests/Feature/App/Service/AffixGroup/AffixGroupEaseTierServiceTest.php
@@ -392,6 +392,49 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
      */
     #[Test]
     #[Group('AffixGroupEaseTierService')]
+    public function getAffixGroupByString_givenCurrentAffixGroupIsOfADifferentSeason_doesNotShortCircuitToThatAffixGroup(): void
+    {
+        // Arrange
+        // The current affix group can be that of a timewalking event, which belongs to a different season than the
+        // one getAffixGroupByString() is resolving against (SeasonAffixGroupService::getAffixGroupAt() defers to
+        // TimewalkingEventService::getAffixGroupAt() in that case, which returns an affix group of
+        // getCurrentSeason($expansion) rather than the queried season). Pick a current affix group whose affixes
+        // would otherwise satisfy the requested string, to prove the season_id guard - not a lack of matching
+        // affixes - is what stops the wrong affix group from being returned.
+        $affixGroupsOfADifferentSeason = $this->getAffixGroupsWithTheSameAffixes(
+            Season::SEASON_DF_S4,
+            'Fortified, Entangling, Bolstering',
+        );
+        $this->assertGreaterThan(0, $affixGroupsOfADifferentSeason->count());
+        $currentAffixGroupOfADifferentSeason = $affixGroupsOfADifferentSeason->first();
+        $this->assertInstanceOf(AffixGroup::class, $currentAffixGroupOfADifferentSeason);
+
+        $log                       = LoggingFixtures::createAffixGroupEaseTierServiceLogging($this);
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService(Season::SEASON_MIDNIGHT_S1),
+            $log,
+            [],
+            $this->getSeasonAffixGroupService($currentAffixGroupOfADifferentSeason),
+        );
+
+        $log->expects($this->once())
+            ->method('getAffixGroupByStringNoMatchingAffixGroup');
+
+        // Act
+        // None of Midnight S1's affix groups have Entangling or Bolstering, so without the season_id guard this
+        // would incorrectly short-circuit to $currentAffixGroupOfADifferentSeason instead of falling through
+        $result = $affixGroupEaseTierService->getAffixGroupByString('Fortified, Entangling, Bolstering');
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
     public function getAffixGroupByString_givenPartialAffixStringOfTheCurrentSeason_returnsAffixGroupHavingThoseAffixes(): void
     {
         // Arrange
@@ -437,6 +480,45 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
 
         // Act
         // Five affix groups of DF S3 have Tyrannical, all with different other affixes
+        $result = $affixGroupEaseTierService->getAffixGroupByString('Tyrannical');
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
+    public function getAffixGroupByString_givenTooFewAffixesToTellAffixGroupsApartAndACurrentAffixGroupThatDoesNotMatch_returnsNull(): void
+    {
+        // Arrange
+        // Unlike getAffixGroupByString_givenTooFewAffixesToTellAffixGroupsApart_returnsNull, this sets a real current
+        // affix group (a live season always has one) that does not have the requested affixes, so the current-week
+        // fast path is skipped on its own merits and the ambiguity check below it is reached the way it would be in
+        // production, not only because getCurrentAffixGroup() was mocked to null.
+        $currentAffixGroup = $this->getAffixGroupsWithTheSameAffixes(
+            Season::SEASON_DF_S3,
+            'Fortified, Incorporeal, Sanguine',
+        )->first();
+        $this->assertInstanceOf(AffixGroup::class, $currentAffixGroup);
+
+        $log                       = LoggingFixtures::createAffixGroupEaseTierServiceLogging($this);
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService(Season::SEASON_DF_S3),
+            $log,
+            [],
+            $this->getSeasonAffixGroupService($currentAffixGroup),
+        );
+
+        $log->expects($this->once())
+            ->method('getAffixGroupByStringAmbiguousAffixes');
+
+        // Act
+        // Five affix groups of DF S3 have Tyrannical, all with different other affixes; the current affix group
+        // (Fortified, Incorporeal, Sanguine) is not one of them
         $result = $affixGroupEaseTierService->getAffixGroupByString('Tyrannical');
 
         // Assert

--- a/tests/Feature/App/Service/AffixGroup/AffixGroupEaseTierServiceTest.php
+++ b/tests/Feature/App/Service/AffixGroup/AffixGroupEaseTierServiceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\App\Service\AffixGroup;
 use App\Models\AffixGroup\AffixGroup;
 use App\Models\AffixGroup\AffixGroupEaseTierPull;
 use App\Models\Season;
+use App\Service\Season\SeasonAffixGroupServiceInterface;
 use App\Service\Season\SeasonServiceInterface;
 use DB;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -278,16 +279,20 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
             $this,
             $this->getSeasonService($seasonId),
             LoggingFixtures::createAffixGroupEaseTierServiceLogging($this),
+            [],
+            $this->getSeasonAffixGroupService(null),
         );
 
         // Act
         $result = $affixGroupEaseTierService->getAffixGroupByString($affixString);
 
         // Assert
-        // Multiple affix groups of a season may have the exact same affixes, so assert the affixes of the affix
-        // group we found rather than which affix group specifically we found
+        // Multiple affix groups of a season have the exact same affixes, so assert the affixes of the affix group we
+        // found rather than which affix group specifically we found - which affix group of those is the correct one
+        // is decided by the current affix group instead, see getAffixGroupByString_givenAffixesOfTheCurrentAffixGroup_
         $this->assertInstanceOf(AffixGroup::class, $result);
         $this->assertSame($seasonId, $result->season_id);
+        // The affixes are compared by name, which is currently the same as the key of an affix
         $this->assertEqualsCanonicalizing(
             explode(', ', $affixString),
             $result->affixes->pluck('key')->toArray(),
@@ -301,11 +306,41 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
     {
         return [
             // The amount of affixes an affix group has differs per season - it must not be assumed to be 3 or 4
-            'DF S4 (3 affixes)'            => [13, 'Fortified, Entangling, Bolstering'],
-            'TWW S3 (4 affixes)'           => [16, "Xal'atath's Bargain: Ascendant, Fortified, Tyrannical, Xal'atath's Guile"],
-            'Midnight S1 (5 affixes)'      => [17, "Lindormi's Guidance, Fortified, Tyrannical, Xal'atath's Bargain: Devour, Xal'atath's Guile"],
-            'Affixes in a different order' => [17, "Xal'atath's Guile, Tyrannical, Lindormi's Guidance, Xal'atath's Bargain: Devour, Fortified"],
+            'DF S4 (3 affixes)'            => [Season::SEASON_DF_S4, 'Fortified, Entangling, Bolstering'],
+            'TWW S3 (4 affixes)'           => [Season::SEASON_TWW_S3, "Xal'atath's Bargain: Ascendant, Fortified, Tyrannical, Xal'atath's Guile"],
+            'Midnight S1 (5 affixes)'      => [Season::SEASON_MIDNIGHT_S1, "Lindormi's Guidance, Fortified, Tyrannical, Xal'atath's Bargain: Devour, Xal'atath's Guile"],
+            'Affixes in a different order' => [Season::SEASON_MIDNIGHT_S1, "Xal'atath's Guile, Tyrannical, Lindormi's Guidance, Xal'atath's Bargain: Devour, Fortified"],
         ];
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
+    public function getAffixGroupByString_givenAffixesOfTheCurrentAffixGroup_returnsTheCurrentAffixGroup(): void
+    {
+        // Arrange
+        // A season has multiple affix groups with the exact same affixes - the one of the current week must be
+        // returned, since ease tiers are looked up by the id of the current affix group
+        $currentAffixGroup = AffixGroup::findOrFail(167);
+
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService(Season::SEASON_MIDNIGHT_S1),
+            LoggingFixtures::createAffixGroupEaseTierServiceLogging($this),
+            [],
+            $this->getSeasonAffixGroupService($currentAffixGroup),
+        );
+
+        // Act
+        $result = $affixGroupEaseTierService->getAffixGroupByString(
+            $currentAffixGroup->affixes->pluck('key')->join(', '),
+        );
+
+        // Assert
+        $this->assertInstanceOf(AffixGroup::class, $result);
+        $this->assertSame($currentAffixGroup->id, $result->id);
     }
 
     /**
@@ -318,17 +353,50 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
         // Arrange
         $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
             $this,
-            $this->getSeasonService(17),
+            $this->getSeasonService(Season::SEASON_MIDNIGHT_S1),
             LoggingFixtures::createAffixGroupEaseTierServiceLogging($this),
+            [],
+            $this->getSeasonAffixGroupService(null),
         );
 
         // Act
         $result = $affixGroupEaseTierService->getAffixGroupByString("Fortified, Xal'atath's Bargain: Devour");
 
         // Assert
+        // Only the affix groups of the Devour weeks have both affixes, and they all have the exact same affixes
         $this->assertInstanceOf(AffixGroup::class, $result);
-        $this->assertTrue($result->hasAffix('Fortified'));
-        $this->assertTrue($result->hasAffix("Xal'atath's Bargain: Devour"));
+        $this->assertEqualsCanonicalizing(
+            ["Lindormi's Guidance", 'Fortified', 'Tyrannical', "Xal'atath's Bargain: Devour", "Xal'atath's Guile"],
+            $result->affixes->pluck('key')->toArray(),
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
+    public function getAffixGroupByString_givenTooFewAffixesToTellAffixGroupsApart_returnsNull(): void
+    {
+        // Arrange
+        $log                       = LoggingFixtures::createAffixGroupEaseTierServiceLogging($this);
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService(Season::SEASON_DF_S3),
+            $log,
+            [],
+            $this->getSeasonAffixGroupService(null),
+        );
+
+        $log->expects($this->once())
+            ->method('getAffixGroupByStringAmbiguousAffixes');
+
+        // Act
+        // Five affix groups of DF S3 have Tyrannical, all with different other affixes
+        $result = $affixGroupEaseTierService->getAffixGroupByString('Tyrannical');
+
+        // Assert
+        $this->assertNull($result);
     }
 
     /**
@@ -342,8 +410,10 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
         $log                       = LoggingFixtures::createAffixGroupEaseTierServiceLogging($this);
         $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
             $this,
-            $this->getSeasonService(17),
+            $this->getSeasonService(Season::SEASON_MIDNIGHT_S1),
             $log,
+            [],
+            $this->getSeasonAffixGroupService(null),
         );
 
         $log->expects($this->once())
@@ -369,7 +439,7 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
         $log                       = LoggingFixtures::createAffixGroupEaseTierServiceLogging($this);
         $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
             $this,
-            $this->getSeasonService(17),
+            $this->getSeasonService(Season::SEASON_MIDNIGHT_S1),
             $log,
         );
 
@@ -396,12 +466,12 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
         $log                       = LoggingFixtures::createAffixGroupEaseTierServiceLogging($this);
         $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
             $this,
-            $this->getSeasonService(17),
+            $this->getSeasonService(Season::SEASON_MIDNIGHT_S1),
             $log,
         );
 
         $log->expects($this->once())
-            ->method('getAffixGroupByStringNoMatchingAffixGroup');
+            ->method('getAffixGroupByStringNoAffixes');
 
         // Act
         $result = $affixGroupEaseTierService->getAffixGroupByString($affixString);
@@ -448,7 +518,7 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
      * @return SeasonServiceInterface|MockObject
      * @throws Exception
      */
-    private function getSeasonService(?int $seasonId = 13): MockObject|SeasonServiceInterface
+    private function getSeasonService(?int $seasonId = Season::SEASON_DF_S4): MockObject|SeasonServiceInterface
     {
         // Hard code a season that fits the affix groups for the response, DF S4
         $season        = $seasonId === null ? null : Season::findOrFail($seasonId);
@@ -464,5 +534,25 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
             ->willReturn($season);
 
         return $seasonService;
+    }
+
+    /**
+     * @param  AffixGroup|null                             $currentAffixGroup Which affix group is active this week
+     * @return SeasonAffixGroupServiceInterface|MockObject
+     * @throws Exception
+     */
+    private function getSeasonAffixGroupService(
+        ?AffixGroup $currentAffixGroup,
+    ): MockObject|SeasonAffixGroupServiceInterface {
+        $seasonAffixGroupService = ServiceFixtures::getSeasonAffixGroupServiceMock(
+            $this,
+            null,
+            null,
+            ['getCurrentAffixGroup'],
+        );
+        $seasonAffixGroupService->method('getCurrentAffixGroup')
+            ->willReturn($currentAffixGroup);
+
+        return $seasonAffixGroupService;
     }
 }

--- a/tests/Feature/App/Service/AffixGroup/AffixGroupEaseTierServiceTest.php
+++ b/tests/Feature/App/Service/AffixGroup/AffixGroupEaseTierServiceTest.php
@@ -8,6 +8,7 @@ use App\Models\Season;
 use App\Service\Season\SeasonAffixGroupServiceInterface;
 use App\Service\Season\SeasonServiceInterface;
 use DB;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -322,8 +323,15 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
     {
         // Arrange
         // A season has multiple affix groups with the exact same affixes - the one of the current week must be
-        // returned, since ease tiers are looked up by the id of the current affix group
-        $currentAffixGroup = AffixGroup::findOrFail(167);
+        // returned, since ease tiers are looked up by the id of the current affix group. Deliberately take the last
+        // of those affix groups, so that this test fails if the first affix group having the affixes is returned.
+        $affixGroupsWithTheSameAffixes = $this->getAffixGroupsWithTheSameAffixes(
+            Season::SEASON_MIDNIGHT_S1,
+            "Lindormi's Guidance, Fortified, Tyrannical, Xal'atath's Bargain: Devour, Xal'atath's Guile",
+        );
+        $this->assertGreaterThan(1, $affixGroupsWithTheSameAffixes->count());
+
+        $currentAffixGroup = $affixGroupsWithTheSameAffixes->last();
 
         $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
             $this,
@@ -341,6 +349,42 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
         // Assert
         $this->assertInstanceOf(AffixGroup::class, $result);
         $this->assertSame($currentAffixGroup->id, $result->id);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
+    public function getAffixGroupByString_givenAffixesOfAnotherWeekThanTheCurrentAffixGroup_returnsThatOtherAffixGroup(): void
+    {
+        // Arrange
+        // Archon may still be serving the tier list of the previous week shortly after a reset - the affix group of
+        // those affixes must be returned then, not the affix group of the current week
+        $affixString       = "Lindormi's Guidance, Fortified, Tyrannical, Xal'atath's Bargain: Ascendant, Xal'atath's Guile";
+        $currentAffixGroup = $this->getAffixGroupsWithTheSameAffixes(
+            Season::SEASON_MIDNIGHT_S1,
+            "Lindormi's Guidance, Fortified, Tyrannical, Xal'atath's Bargain: Devour, Xal'atath's Guile",
+        )->first();
+
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService(Season::SEASON_MIDNIGHT_S1),
+            LoggingFixtures::createAffixGroupEaseTierServiceLogging($this),
+            [],
+            $this->getSeasonAffixGroupService($currentAffixGroup),
+        );
+
+        // Act
+        $result = $affixGroupEaseTierService->getAffixGroupByString($affixString);
+
+        // Assert
+        $this->assertInstanceOf(AffixGroup::class, $result);
+        $this->assertNotSame($currentAffixGroup->id, $result->id);
+        $this->assertEqualsCanonicalizing(
+            explode(', ', $affixString),
+            $result->affixes->pluck('key')->toArray(),
+        );
     }
 
     /**
@@ -534,6 +578,19 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
             ->willReturn($season);
 
         return $seasonService;
+    }
+
+    /**
+     * @return Collection<int, AffixGroup> All affix groups of the season that have exactly the given affixes
+     */
+    private function getAffixGroupsWithTheSameAffixes(int $seasonId, string $affixString): Collection
+    {
+        $affixKeys = collect(explode(', ', $affixString))->sort()->values();
+
+        return Season::findOrFail($seasonId)->affixGroups->filter(
+            static fn(AffixGroup $affixGroup): bool => $affixGroup->affixes->pluck('key')->sort()->values()
+                ->toArray() === $affixKeys->toArray(),
+        );
     }
 
     /**

--- a/tests/Feature/App/Service/AffixGroup/AffixGroupEaseTierServiceTest.php
+++ b/tests/Feature/App/Service/AffixGroup/AffixGroupEaseTierServiceTest.php
@@ -7,6 +7,7 @@ use App\Models\AffixGroup\AffixGroupEaseTierPull;
 use App\Models\Season;
 use App\Service\Season\SeasonServiceInterface;
 use DB;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Exception;
@@ -263,19 +264,201 @@ final class AffixGroupEaseTierServiceTest extends PublicTestCase
     }
 
     /**
-     * @return SeasonServiceInterface|MockObject
+     * @throws Exception
      */
-    private function getSeasonService(): MockObject|SeasonServiceInterface
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
+    #[DataProvider('affixStringProvider')]
+    public function getAffixGroupByString_givenAffixStringOfTheCurrentSeason_returnsAffixGroupWithThoseAffixes(
+        int    $seasonId,
+        string $affixString,
+    ): void {
+        // Arrange
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService($seasonId),
+            LoggingFixtures::createAffixGroupEaseTierServiceLogging($this),
+        );
+
+        // Act
+        $result = $affixGroupEaseTierService->getAffixGroupByString($affixString);
+
+        // Assert
+        // Multiple affix groups of a season may have the exact same affixes, so assert the affixes of the affix
+        // group we found rather than which affix group specifically we found
+        $this->assertInstanceOf(AffixGroup::class, $result);
+        $this->assertSame($seasonId, $result->season_id);
+        $this->assertEqualsCanonicalizing(
+            explode(', ', $affixString),
+            $result->affixes->pluck('key')->toArray(),
+        );
+    }
+
+    /**
+     * @return array<string, array{int, string}>
+     */
+    public static function affixStringProvider(): array
+    {
+        return [
+            // The amount of affixes an affix group has differs per season - it must not be assumed to be 3 or 4
+            'DF S4 (3 affixes)'            => [13, 'Fortified, Entangling, Bolstering'],
+            'TWW S3 (4 affixes)'           => [16, "Xal'atath's Bargain: Ascendant, Fortified, Tyrannical, Xal'atath's Guile"],
+            'Midnight S1 (5 affixes)'      => [17, "Lindormi's Guidance, Fortified, Tyrannical, Xal'atath's Bargain: Devour, Xal'atath's Guile"],
+            'Affixes in a different order' => [17, "Xal'atath's Guile, Tyrannical, Lindormi's Guidance, Xal'atath's Bargain: Devour, Fortified"],
+        ];
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
+    public function getAffixGroupByString_givenPartialAffixStringOfTheCurrentSeason_returnsAffixGroupHavingThoseAffixes(): void
+    {
+        // Arrange
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService(17),
+            LoggingFixtures::createAffixGroupEaseTierServiceLogging($this),
+        );
+
+        // Act
+        $result = $affixGroupEaseTierService->getAffixGroupByString("Fortified, Xal'atath's Bargain: Devour");
+
+        // Assert
+        $this->assertInstanceOf(AffixGroup::class, $result);
+        $this->assertTrue($result->hasAffix('Fortified'));
+        $this->assertTrue($result->hasAffix("Xal'atath's Bargain: Devour"));
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
+    public function getAffixGroupByString_givenAffixesThatNoSingleAffixGroupHas_returnsNull(): void
+    {
+        // Arrange
+        $log                       = LoggingFixtures::createAffixGroupEaseTierServiceLogging($this);
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService(17),
+            $log,
+        );
+
+        $log->expects($this->once())
+            ->method('getAffixGroupByStringNoMatchingAffixGroup');
+
+        // Act
+        $result = $affixGroupEaseTierService->getAffixGroupByString(
+            "Xal'atath's Bargain: Devour, Xal'atath's Bargain: Pulsar",
+        );
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
+    public function getAffixGroupByString_givenUnknownAffix_returnsNullAndLogsTheUnknownAffixes(): void
+    {
+        // Arrange
+        $log                       = LoggingFixtures::createAffixGroupEaseTierServiceLogging($this);
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService(17),
+            $log,
+        );
+
+        $log->expects($this->once())
+            ->method('getAffixGroupByStringUnknownAffixes')
+            ->with('Breaking');
+
+        // Act
+        $result = $affixGroupEaseTierService->getAffixGroupByString('Fortified, Breaking');
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
+    #[DataProvider('emptyAffixStringProvider')]
+    public function getAffixGroupByString_givenAffixStringWithoutAnyAffixes_returnsNull(string $affixString): void
+    {
+        // Arrange
+        $log                       = LoggingFixtures::createAffixGroupEaseTierServiceLogging($this);
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService(17),
+            $log,
+        );
+
+        $log->expects($this->once())
+            ->method('getAffixGroupByStringNoMatchingAffixGroup');
+
+        // Act
+        $result = $affixGroupEaseTierService->getAffixGroupByString($affixString);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function emptyAffixStringProvider(): array
+    {
+        return [
+            'Empty string'    => [''],
+            'Whitespace only' => ['   '],
+            'Separators only' => [', ,'],
+        ];
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('AffixGroupEaseTierService')]
+    public function getAffixGroupByString_givenNoCurrentSeason_returnsNull(): void
+    {
+        // Arrange
+        $affixGroupEaseTierService = ServiceFixtures::getAffixGroupEaseTierServiceMock(
+            $this,
+            $this->getSeasonService(null),
+            LoggingFixtures::createAffixGroupEaseTierServiceLogging($this),
+        );
+
+        // Act
+        $result = $affixGroupEaseTierService->getAffixGroupByString('Fortified, Entangling, Bolstering');
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    /**
+     * @param  int|null                          $seasonId Which season should act as the current season, DF S4 by default
+     * @return SeasonServiceInterface|MockObject
+     * @throws Exception
+     */
+    private function getSeasonService(?int $seasonId = 13): MockObject|SeasonServiceInterface
     {
         // Hard code a season that fits the affix groups for the response, DF S4
-        $season        = Season::find(13);
+        $season        = $seasonId === null ? null : Season::findOrFail($seasonId);
         $seasonService = ServiceFixtures::getSeasonServiceMock(
             $this,
             null,
             ['getCurrentSeason'],
-            collect([
+            collect(array_filter([
                 $season,
-            ]),
+            ])),
         );
         $seasonService->method('getCurrentSeason')
             ->willReturn($season);


### PR DESCRIPTION
:robot: Closes #3776

## The bug

`AffixGroupEaseTierService::getAffixGroupByString()` gated its matching on a hardcoded affix count:

```php
if ($affixes->count() === 3 + (int)($currentSeason->seasonal_affix_id !== null)) {
```

That formula ("three affixes, or four when the season has a seasonal affix") stopped describing
reality several seasons ago. Checked against the seeded data:

| season | `seasonal_affix_id` | affixes per affix group | check expects |
|---|---|---|---|
| 12 / 13 (DF S3/S4) | `null` | 3 | 3 ✅ |
| 14 (TWW S1) | `null` | 5 | 3 ❌ |
| 15 / 16 (TWW S2/S3) | `null` | 4 | 3 ❌ |
| 17 (Midnight S1) | `null` | 5 | 3 ❌ |

So for every season since DF S4 the `if` was always false: the method returned `null` for every
input, and silently, because the only log line it had (`getAffixGroupByStringUnknownAffixes`) sat
*inside* the dead branch.

## What is actually broken for users today: nothing

Confirming the third bullet of the issue: Archon.gg no longer sends affix information at all. The
live payload of
`https://www.archon.gg/wow/tier-list/dps-rankings/mythic-plus/10/all-dungeons/this-week/data.json`
has `encounterTierList.label: null` and an `affixes` object of just `{"slug": "this-week"}`.
`parseTierList()` therefore always takes the `label === null` branch and falls back to
`SeasonAffixGroupService::getCurrentAffixGroup()`, so ease tiers still land on the correct affix
group and the tier lists render fine.

`getAffixGroupByString()` is only reachable if Archon ever restores the label (and from the
already-run legacy backfill migration). This is a correctness fix, not an outage fix.

## The fix

Drop the count check entirely and match on the affixes an affix group *actually has*:

- resolve every name in the string to an `Affix` (via the English translation of `Affix::$name`),
  logging and bailing out on any name we don't know;
- return the first affix group of the current season that has all of those affixes, using the
  existing `AffixGroupBase::hasAffix()` helper.

That is order-insensitive, works for any amount of affixes a season may have, and also tolerates a
partial affix string should Archon come back with a shorter label than the full affix set.

Resolving by English name is safe: no two `Affix` rows share one (verified over the whole table),
and every affix's English name currently equals its `key`. Going through a resolved `Affix` rather
than comparing names on the input side and `key` on the affix group side means the matching no
longer silently depends on that second equality holding.

### Which affix group of the week

A season has **two affix groups per affix set** — one for the Fortified week, one for the Tyrannical
week (season 17: 163 ≡ 167, 164 ≡ 169, 165 ≡ 168, 166 ≡ 170). No affix string can tell those apart,
and the choice is not cosmetic: ease tiers are stored *and read* per `affix_group_id`
(`HeaderComposer::getEaseTiers()` and `ViewService::getAffixGroupEaseTiersByAffixGroup()` both look
them up by the id of the **current** affix group), so writing the pull under the wrong twin makes
the tiers vanish from the header and from route cards for that whole week.

Archon's tier list is always for the current week, so the current affix group is preferred whenever
it has the given affixes. Only when it does not (a label for another week) does it fall back to
scanning the season, and it then refuses to guess — logging and returning `null` — if affix groups
with *different* affixes match, which is the case when too few affixes were given to tell them
apart.

On that fallback path two affix groups with *identical* affixes are still picked arbitrarily. That
is deliberate: a label for a week other than the current one carries no signal at all about which of
the two weeks it was, so there is nothing better to pick.

This one is worth calling out: my first version returned the first matching affix group and a
comment claimed set-identical affix groups "share an ease tier". They do not. Caught in review.

Also fixed along the way, both reachable from the legacy migration which calls the method directly:

- **`$currentSeason` was dereferenced unguarded** while `SeasonService::getCurrentSeason()` returns
  `?Season`.
- **An affix string without any affixes** (`''`, whitespace, separators only) would match the
  *first* affix group under the new subset matching, since `Collection::every()` is true on an empty
  collection. It now returns `null`.
- Added `getAffixGroupByStringNoAffixes()`, `getAffixGroupByStringNoMatchingAffixGroup()` and
  `getAffixGroupByStringAmbiguousAffixes()` to the logging interface so a failure to match is no
  longer silent, and so the three ways it can fail are distinguishable in the alert.

`seasonal_affix_id` itself is untouched and not deprecated — it still drives
`ExpansionSeason::$isAwakened` and friends, `DungeonRoute:1021` and the affix tables. It is just no
longer a valid signal for *how many* affixes an affix group has, so it comes out of this one check.

## Tests

There was no direct test of `getAffixGroupByString()` at all — it was either mocked out or exercised
only through `Season::find(13)` (DF S4, 3 affixes), which is exactly why this stayed invisible.
Added coverage in `tests/Feature/App/Service/AffixGroup/AffixGroupEaseTierServiceTest.php` driven by
real seeded affix-group membership rather than any new hardcoded count:

- full affix strings for a 3-affix (DF S4), 4-affix (TWW S3) and 5-affix (Midnight S1) season,
  plus the same affixes in a different order;
- the affixes of the current affix group, which must return **that** affix group and not its twin
  (the test deliberately makes the *last* of the twins current, so it fails if the first match wins);
- the affixes of a different week than the current affix group, which must return that other affix
  group — Archon can still be serving last week's tier list shortly after a reset;
- a partial affix string;
- too few affixes to tell affix groups apart;
- affixes that no single affix group has;
- an unknown affix name;
- empty / whitespace-only / separators-only strings;
- no current season.

Verified these fail against the implementation they replace: the TWW S3 and Midnight S1 rows return
`null` against the original count check, and the current-affix-group test returns 163 instead of 167
against the first version of this MR. Also checked end-to-end against the live current season
through the real service:

```
Lindormi's Guidance, Fortified, Tyrannical, Xal'atath's Bargain: Devour, Xal'atath's Guile
  => affix group 163
```

24 passed locally (`--filter=AffixGroupEaseTierService`), `composer run fix` and
`composer run analyse` are clean. No UI surface, so no visual verification.

One side effect worth knowing about: because the label branch now resolves the current affix group,
the three pre-existing `parseTierList` tests that exercise the real `getAffixGroupByString()` now run
time-based affix resolution where they previously did not. It is harmless — DF S4's affix sets are
all distinct, so the current-week preference can never disagree with the scan there — but that is a
clock coupling those tests did not have before.

`database/migrations_legacy/2024_02_22_104800_...` is the only other caller; that folder is
referenced from nowhere in `app/`, `database/`, `bootstrap/` or `config/`, and the migration has long
since run, so its behaviour change is inert.
