### PR TITLE
#3774 Stop the feature-toggle admin action from blanket-granting stored user values

### DIFF
--- a/app/Http/Controllers/AdminTools/AdminToolsFeaturesController.php
+++ b/app/Http/Controllers/AdminTools/AdminToolsFeaturesController.php
@@ -3,11 +3,13 @@
 namespace App\Http\Controllers\AdminTools;
 
 use App\Http\Controllers\Controller;
+use App\Models\Feature\Feature;
+use App\Models\User;
 use HaydenPierce\ClassFinder\ClassFinder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
-use Laravel\Pennant\Feature;
+use Laravel\Pennant\Feature as PennantFeature;
 use Session;
 
 class AdminToolsFeaturesController extends Controller
@@ -23,11 +25,17 @@ class AdminToolsFeaturesController extends Controller
     {
         $feature = (string)$request->get('feature');
 
-        $wasActive = Feature::active($feature);
+        $wasActive = Feature::getAdminValue($feature);
+
+        // Purge every stored value first, so that each user's feature re-resolves against their own roles the
+        // next time it's checked, instead of blanket-flipping their already-cached rows to the new switch value
+        PennantFeature::purge($feature);
+
+        $adminUser = User::findOrFail(Feature::ADMIN_USER_ID);
         if ($wasActive) {
-            Feature::deactivateForEveryone($feature);
+            PennantFeature::for($adminUser)->deactivate($feature);
         } else {
-            Feature::activateForEveryone($feature);
+            PennantFeature::for($adminUser)->activate($feature);
         }
 
         Session::flash('status', __(!$wasActive ?
@@ -43,8 +51,8 @@ class AdminToolsFeaturesController extends Controller
     {
         $feature = (string)$request->get('feature');
 
-        Feature::forget($feature);
-        Feature::for(null)->forget($feature);
+        PennantFeature::forget($feature);
+        PennantFeature::for(null)->forget($feature);
 
         Session::flash('status', __('controller.admintools.flash.feature_forgotten', ['feature' => $feature]));
 

--- a/app/Http/Controllers/AdminTools/AdminToolsFeaturesController.php
+++ b/app/Http/Controllers/AdminTools/AdminToolsFeaturesController.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use HaydenPierce\ClassFinder\ClassFinder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 use Laravel\Pennant\Feature as PennantFeature;
 use Session;
@@ -27,16 +28,19 @@ class AdminToolsFeaturesController extends Controller
 
         $wasActive = Feature::getAdminValue($feature);
 
-        // Purge every stored value first, so that each user's feature re-resolves against their own roles the
-        // next time it's checked, instead of blanket-flipping their already-cached rows to the new switch value
-        PennantFeature::purge($feature);
+        // Purge every stored value and set the new switch value in one transaction - otherwise a request that
+        // resolves this feature in the gap between the purge and the set would read a momentarily-missing switch
+        // row as an admin-disabled feature, and (for an otherwise-entitled user) persist that stale 'false' again
+        DB::transaction(function () use ($feature, $wasActive): void {
+            PennantFeature::purge($feature);
 
-        $adminUser = User::findOrFail(Feature::ADMIN_USER_ID);
-        if ($wasActive) {
-            PennantFeature::for($adminUser)->deactivate($feature);
-        } else {
-            PennantFeature::for($adminUser)->activate($feature);
-        }
+            $adminUser = User::findOrFail(Feature::ADMIN_USER_ID);
+            if ($wasActive) {
+                PennantFeature::for($adminUser)->deactivate($feature);
+            } else {
+                PennantFeature::for($adminUser)->activate($feature);
+            }
+        });
 
         Session::flash('status', __(!$wasActive ?
             'controller.admintools.flash.feature_toggle_activated' :

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Email\CustomPasswordResetEmail;
 use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\Feature\Feature;
 use App\Models\GameVersion\GameVersion;
 use App\Models\Laratrust\Role;
 use App\Models\Patreon\PatreonAdFreeGiveaway;
@@ -399,6 +400,11 @@ class User extends Authenticatable implements LaratrustUser
 
         // Delete user properly if it gets deleted
         static::deleting(static function (User $user) {
+            // Laratrust's own deleting hook clears roles via roles()->sync([]) rather than syncRoles()/
+            // removeRoles(), so no role.removed/role.synced event fires here and Feature::forgetAllForUser()
+            // never runs - drop the user's stored feature values explicitly instead
+            Feature::forgetAllForUser($user);
+
             $user->dungeonRoutes()->delete();
             $user->reports()->delete();
             $user->patreonUserLink()->delete();

--- a/tests/Feature/App/Models/Feature/FeatureForgetAllForUserTest.php
+++ b/tests/Feature/App/Models/Feature/FeatureForgetAllForUserTest.php
@@ -104,6 +104,28 @@ final class FeatureForgetAllForUserTest extends PublicTestCase
     }
 
     #[Test]
+    public function delete_givenUserWithStoredFeatureValues_forgetsThoseValues(): void
+    {
+        // Arrange - Laratrust's own deleting hook clears roles via roles()->sync([]), which fires neither
+        // role.removed nor role.synced, so User::boot() must drop the stored values itself
+        $user = User::factory()->create();
+
+        try {
+            $user->addRole(Role::ROLE_INTERNAL_TEAM);
+            PennantFeature::for($user)->activate(NpcCompendium::class);
+            $this->assertSame(1, $this->countStoredFeaturesOf($user), 'Expected the stored value to be arranged.');
+
+            // Act
+            $user->delete();
+
+            // Assert
+            $this->assertSame(0, $this->countStoredFeaturesOf($user));
+        } finally {
+            $this->deleteStoredFeaturesOf($user);
+        }
+    }
+
+    #[Test]
     public function forgetAllForUser_givenAdminUser_keepsStoredFeatureValues(): void
     {
         // Arrange - the admin's stored values are the global on/off switch of every feature, so dropping them

--- a/tests/Feature/Controller/AdminTools/AdminToolsFeaturesControllerTest.php
+++ b/tests/Feature/Controller/AdminTools/AdminToolsFeaturesControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Controller\AdminTools;
 
 use App\Features\NpcCompendium;
 use App\Models\Feature\Feature;
+use App\Models\Laratrust\Role;
 use App\Models\User;
 use Laravel\Pennant\Feature as PennantFeature;
 use PHPUnit\Framework\Attributes\Group;
@@ -14,8 +15,6 @@ use Tests\TestCases\PublicTestCase;
 #[Group('AdminTools')]
 final class AdminToolsFeaturesControllerTest extends PublicTestCase
 {
-    private const int ADMIN_USER_ID = 1;
-
     #[\Override]
     protected function setUp(): void
     {
@@ -40,9 +39,10 @@ final class AdminToolsFeaturesControllerTest extends PublicTestCase
     {
         // Arrange - the admin switch starts off, and an ordinary (non-internal-team) user already has a stored
         // 'false' from browsing the site before the toggle, which is exactly the row #3774 was blanket-flipped
-        $admin        = User::findOrFail(self::ADMIN_USER_ID);
+        $admin        = User::findOrFail(Feature::ADMIN_USER_ID);
         $ordinaryUser = User::factory()->create();
-        $adminBackup  = Feature::query()->where('scope', $this->serializeScopeOf($admin))
+        $this->assertTrue($admin->hasRole(Role::ROLE_ADMIN), 'User id=1 must be admin (seed the DB).');
+        $adminBackup = Feature::query()->where('scope', $this->serializeScopeOf($admin))
             ->where('name', NpcCompendium::class)
             ->first();
 
@@ -90,15 +90,22 @@ final class AdminToolsFeaturesControllerTest extends PublicTestCase
     #[Test]
     public function toggleFeature_givenActiveSwitch_deactivatesItAndPurgesStoredValues(): void
     {
-        // Arrange
-        $admin       = User::findOrFail(self::ADMIN_USER_ID);
+        // Arrange - an entitled user's stored 'true' row must be purged, not merely updated to 'false' in place;
+        // updating it in place would leave a row that never re-resolves once the switch is turned back on, which
+        // would recreate the exact stale-value bug #3772 fixed for the role-change direction
+        $admin        = User::findOrFail(Feature::ADMIN_USER_ID);
+        $ordinaryUser = User::factory()->create();
+        $this->assertTrue($admin->hasRole(Role::ROLE_ADMIN), 'User id=1 must be admin (seed the DB).');
         $adminBackup = Feature::query()->where('scope', $this->serializeScopeOf($admin))
             ->where('name', NpcCompendium::class)
             ->first();
 
         try {
+            $ordinaryUser->addRole(Role::ROLE_INTERNAL_TEAM);
             PennantFeature::for($admin)->activate(NpcCompendium::class);
+            PennantFeature::for($ordinaryUser)->activate(NpcCompendium::class);
             $this->assertTrue(Feature::getAdminValue(NpcCompendium::class), 'Expected the switch to be arranged on.');
+            $this->assertSame(1, $this->countStoredFeaturesOf($ordinaryUser), 'Expected the stored value to be arranged.');
 
             // Act
             $this->be($admin);
@@ -107,7 +114,15 @@ final class AdminToolsFeaturesControllerTest extends PublicTestCase
             // Assert
             $response->assertRedirect(route('admin.tools.features.list'));
             $this->assertFalse(Feature::getAdminValue(NpcCompendium::class), 'Expected the switch to be flipped off.');
+            $this->assertSame(
+                0,
+                $this->countStoredFeaturesOf($ordinaryUser),
+                'Expected the stored row to be purged, not updated to false in place.',
+            );
         } finally {
+            $this->deleteStoredFeaturesOf($ordinaryUser);
+            $ordinaryUser->delete();
+
             Feature::query()->where('scope', $this->serializeScopeOf($admin))
                 ->where('name', NpcCompendium::class)
                 ->delete();

--- a/tests/Feature/Controller/AdminTools/AdminToolsFeaturesControllerTest.php
+++ b/tests/Feature/Controller/AdminTools/AdminToolsFeaturesControllerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Feature\Controller\AdminTools;
+
+use App\Features\NpcCompendium;
+use App\Models\Feature\Feature;
+use App\Models\User;
+use Laravel\Pennant\Feature as PennantFeature;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Controller')]
+#[Group('AdminTools')]
+final class AdminToolsFeaturesControllerTest extends PublicTestCase
+{
+    private const int ADMIN_USER_ID = 1;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The suite runs Pennant on its array store (see phpunit.xml), but what's under test here is precisely
+        // the rows in the features table - so these tests need the database store the application really runs on
+        config(['pennant.default' => 'database']);
+        PennantFeature::forgetDrivers();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        PennantFeature::forgetDrivers();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function toggleFeature_givenOrdinaryUserWithStoredFalseValue_doesNotGrantTheFeatureToThatUser(): void
+    {
+        // Arrange - the admin switch starts off, and an ordinary (non-internal-team) user already has a stored
+        // 'false' from browsing the site before the toggle, which is exactly the row #3774 was blanket-flipped
+        $admin        = User::findOrFail(self::ADMIN_USER_ID);
+        $ordinaryUser = User::factory()->create();
+        $adminBackup  = Feature::query()->where('scope', $this->serializeScopeOf($admin))
+            ->where('name', NpcCompendium::class)
+            ->first();
+
+        try {
+            PennantFeature::for($admin)->deactivate(NpcCompendium::class);
+            PennantFeature::for($ordinaryUser)->deactivate(NpcCompendium::class);
+            $this->assertFalse(Feature::getAdminValue(NpcCompendium::class), 'Expected the switch to be arranged off.');
+
+            // Act
+            $this->be($admin);
+            $response = $this->post(route('admin.tools.features.toggle'), ['feature' => NpcCompendium::class]);
+
+            // Assert
+            $response->assertRedirect(route('admin.tools.features.list'));
+            $this->assertTrue(Feature::getAdminValue(NpcCompendium::class), 'Expected the switch to be flipped on.');
+
+            $this->assertSame(
+                0,
+                $this->countStoredFeaturesOf($ordinaryUser),
+                'Expected the stored row of a user with no entitling role to be purged, not flipped to true.',
+            );
+            $this->assertFalse(
+                PennantFeature::for($ordinaryUser)->active(NpcCompendium::class),
+                'Expected the feature to resolve to false for a user without the entitling role.',
+            );
+        } finally {
+            $this->deleteStoredFeaturesOf($ordinaryUser);
+            $ordinaryUser->delete();
+
+            Feature::query()->where('scope', $this->serializeScopeOf($admin))
+                ->where('name', NpcCompendium::class)
+                ->delete();
+            if ($adminBackup !== null) {
+                Feature::query()->insert([
+                    'name'       => $adminBackup->name,
+                    'scope'      => $adminBackup->scope,
+                    'value'      => $adminBackup->value,
+                    'created_at' => $adminBackup->created_at,
+                    'updated_at' => $adminBackup->updated_at,
+                ]);
+            }
+        }
+    }
+
+    #[Test]
+    public function toggleFeature_givenActiveSwitch_deactivatesItAndPurgesStoredValues(): void
+    {
+        // Arrange
+        $admin       = User::findOrFail(self::ADMIN_USER_ID);
+        $adminBackup = Feature::query()->where('scope', $this->serializeScopeOf($admin))
+            ->where('name', NpcCompendium::class)
+            ->first();
+
+        try {
+            PennantFeature::for($admin)->activate(NpcCompendium::class);
+            $this->assertTrue(Feature::getAdminValue(NpcCompendium::class), 'Expected the switch to be arranged on.');
+
+            // Act
+            $this->be($admin);
+            $response = $this->post(route('admin.tools.features.toggle'), ['feature' => NpcCompendium::class]);
+
+            // Assert
+            $response->assertRedirect(route('admin.tools.features.list'));
+            $this->assertFalse(Feature::getAdminValue(NpcCompendium::class), 'Expected the switch to be flipped off.');
+        } finally {
+            Feature::query()->where('scope', $this->serializeScopeOf($admin))
+                ->where('name', NpcCompendium::class)
+                ->delete();
+            if ($adminBackup !== null) {
+                Feature::query()->insert([
+                    'name'       => $adminBackup->name,
+                    'scope'      => $adminBackup->scope,
+                    'value'      => $adminBackup->value,
+                    'created_at' => $adminBackup->created_at,
+                    'updated_at' => $adminBackup->updated_at,
+                ]);
+            }
+        }
+    }
+
+    private function countStoredFeaturesOf(User $user): int
+    {
+        return Feature::query()->where('scope', $this->serializeScopeOf($user))->count();
+    }
+
+    private function deleteStoredFeaturesOf(User $user): void
+    {
+        Feature::query()->where('scope', $this->serializeScopeOf($user))->delete();
+    }
+
+    private function serializeScopeOf(User $user): string
+    {
+        return sprintf('%s|%d', User::class, $user->id);
+    }
+}


### PR DESCRIPTION
:robot: Closes #3774

## What
`AdminToolsFeaturesController::toggleFeature()` called Pennant's `activateForEveryone()`/
`deactivateForEveryone()`, which bottom out in `DatabaseDriver::setForAllScopes()` — an
`UPDATE features SET value WHERE name = ?` with **no scope predicate**. Toggling a feature
on/off in the admin panel therefore flipped *every* stored row for that feature name,
regardless of whether the user's roles actually entitled them to it.

Fix: purge every stored row for the feature, then set only the row scoped to the admin
user (`Feature::ADMIN_USER_ID`, i.e. the global on/off switch read by `getAdminValue()`).
Every other user's value is then resolved fresh — off their current roles — the next time
`Feature::active()` runs for them.

I deliberately deviated from the snippet in the issue body: `Feature::for(null)->activate(...)`
would store scope `__laravel_null`, which `getAdminValue()` (which queries scope
`App\Models\User|1`) would never find — the switch would never actually turn on. Using
`Feature::for($adminUser)` instead targets that exact scope.

`$wasActive` now reads `Feature::getAdminValue()` instead of `Laravel\Pennant\Feature::active()`
— the latter resolves for whichever admin happens to be logged in and clicking the button,
the former reads the literal global switch. Same outcome in practice (an admin always has
`ROLE_ADMIN`), but it's the more direct/correct read for what's actually being displayed
and toggled.

Also fixes the smaller leak flagged in the same review: Laratrust's own `deleting` hook on
`User` calls `roles()->sync([])` directly rather than going through `syncRoles()`/`removeRoles()`,
so no `role.removed`/`role.synced` event fires and #3773's `Feature::forgetAllForUser()` wiring
never runs for a deleted user. `User::boot()` now calls it explicitly in its own `deleting` hook.

## Not in scope here
- **`forgetFeature()`** is untouched. It has an adjacent, pre-existing sharp edge: if the
  logged-in admin happens to be user 1, pressing "Forget" clears that feature's global switch
  row (since it forgets for the *currently authenticated* user, unscoped). Not touching it —
  "what should Forget do" is a product/behavior question, not a bug this issue is about.
- **Already-leaked data.** The issue itself notes ordinary users in the dev DB already carry
  `NpcCompendium = true` from a prior toggle. This MR only stops it from happening again — it
  does not retroactively clean up rows already flipped. If prod/staging carry the same shape,
  the cleanup is a manual one-time step *after* this deploys: toggle each affected feature off
  then on from Admin → Tools → Features (which, with this fix, purges + re-sets it cleanly).

## Test plan
- [x] New `AdminToolsFeaturesControllerTest`: toggling on with an ordinary user's stored
  `false` row purges it (not blanket-flips it) and the feature still resolves `false` for
  that user; toggling off flips the global switch off.
- [x] New `FeatureForgetAllForUserTest::delete_givenUserWithStoredFeatureValues_forgetsThoseValues`
  covers the deletion-hook gap.
- [x] `php artisan test --compact` — 413 passed across the Feature/Controller/AdminTools groups.
- [x] `composer run analyse` (PHPStan) — no errors.
- [x] `composer run fix` (PHP CS Fixer) — no changes needed beyond the new test file.
- Visual verification: N/A, no rendering change to the features list page.

## Cold review
An independent agent reviewed this PR and confirmed the core logic (scope-string match
between `Feature::for($adminUser)` and `getAdminValue()`, and that `purge($feature)` scopes
to just that one feature name). It raised two real findings, both addressed in a follow-up
commit:
- The purge-then-set wasn't atomic - a request resolving the feature in that gap could read
  a momentarily-missing admin-switch row as "disabled" and persist a stale `false`,
  recreating the #3772 bug this issue is adjacent to. Now wrapped in `DB::transaction()`.
- The deactivate-direction test only asserted the admin switch flipped, which the old buggy
  `deactivateForEveryone()` code would have passed identically - it didn't actually prove
  purging happens. It now also arranges an entitled user's stored `true` row and asserts
  it's purged rather than updated to `false` in place.
