### PR TITLE
Stop a test's environment flip from redirecting structured logging to stderr

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -68,10 +68,14 @@ jobs:
       # Structured logging reaching the console during a test run interleaves ANSI-coloured log lines with the
       # progress output, and has now regressed twice (#3722, #3782) because every guard against it lived in
       # application state that a test is free to change. Assert on the PHPUnit step's own output only: the setup
-      # steps above run real artisan commands, which log to stderr legitimately.
+      # steps above run real artisan commands, which log to stderr legitimately. The pattern is verified against
+      # the log of the run that prompted #3782 - it matches all 965 of its leaked lines.
+      #
+      # Skipped when PHPUnit itself fails (the default success() condition), deliberately: a red shard has a real
+      # failure to fix first, and a failure diff is exactly the kind of output that could match by accident.
       - name: Assert no log lines leaked into the test output
         run: |
-          if grep -nE '\] [a-z_]+\.(DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY): ' phpunit-output.log; then
+          if grep -nE '\] [A-Za-z0-9_-]+\.(DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY): ' phpunit-output.log; then
             echo "::error::Log lines leaked into PHPUnit's own output - see #3782"
             exit 1
           fi

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -61,4 +61,17 @@ jobs:
         run: php artisan db:seed --class=LaratrustSeeder --database=migrate
 
       - name: Run PHPUnit (${{ matrix.shard }})
-        run: ./vendor/bin/phpunit ${{ matrix.phpunit-args }}
+        run: |
+          set -o pipefail
+          ./vendor/bin/phpunit ${{ matrix.phpunit-args }} 2>&1 | tee phpunit-output.log
+
+      # Structured logging reaching the console during a test run interleaves ANSI-coloured log lines with the
+      # progress output, and has now regressed twice (#3722, #3782) because every guard against it lived in
+      # application state that a test is free to change. Assert on the PHPUnit step's own output only: the setup
+      # steps above run real artisan commands, which log to stderr legitimately.
+      - name: Assert no log lines leaked into the test output
+        run: |
+          if grep -nE '\] [a-z_]+\.(DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|ALERT|EMERGENCY): ' phpunit-output.log; then
+            echo "::error::Log lines leaked into PHPUnit's own output - see #3782"
+            exit 1
+          fi

--- a/app/Logging/StructuredLogging.php
+++ b/app/Logging/StructuredLogging.php
@@ -342,6 +342,22 @@ abstract class StructuredLogging implements StructuredLoggingInterface
     }
 
     /**
+     * Whether this process is a test run - deliberately not just runningUnitTests().
+     *
+     * runningUnitTests() answers "is app.env equal to testing", which is not the question being asked: tests are
+     * free to change it, and several do to exercise production-only behaviour (ThumbnailServiceTest, FileTest,
+     * MigrateThumbnailDiskTest, RenderThumbnailTest, MDTMappingImportGameVersionScopingTest). One of those flipping
+     * the environment around a chatty service is what dumped ~1000 ANSI-coloured log lines into the CI test output
+     * in #3782. PHPUNIT_COMPOSER_INSTALL is defined by PHPUnit's own entrypoint (vendor/bin/phpunit, which is how
+     * both CI and `php artisan test` invoke it) and phpunit is a require-dev package, so the constant answers
+     * "is PHPUnit running" without depending on any application state that a test can rewrite.
+     */
+    private static function isRunningTests(Application $app): bool
+    {
+        return $app->runningUnitTests() || defined('PHPUNIT_COMPOSER_INSTALL');
+    }
+
+    /**
      * The channel every structured log line is written to: an explicit setChannel() override if one
      * was made, otherwise stderr for local console usage so an artisan command shows its own output,
      * and otherwise the configured default.
@@ -361,7 +377,7 @@ abstract class StructuredLogging implements StructuredLoggingInterface
         /** @var Application $app */
         $app = app();
 
-        if ($app->runningInConsole() && !$app->runningUnitTests() && config('app.type') === 'local') {
+        if ($app->runningInConsole() && !self::isRunningTests($app) && config('app.type') === 'local') {
             return 'stderr';
         }
 

--- a/app/Logging/StructuredLogging.php
+++ b/app/Logging/StructuredLogging.php
@@ -376,7 +376,27 @@ abstract class StructuredLogging implements StructuredLoggingInterface
         /** @var Application $app */
         $app = app();
 
-        if ($app->runningInConsole() && !self::isRunningTests($app) && config('app.type') === 'local') {
+        // Named arguments here on purpose: all three parameters are bool, so a transposition (e.g.
+        // runningInConsole <-> isRunningTests) would type-check and pass PHPStan while silently
+        // inverting the decision. Naming them makes that mistake visible at the call site.
+        return self::resolveConsoleChannel(
+            runningInConsole: $app->runningInConsole(),
+            isRunningTests: self::isRunningTests($app),
+            isLocalAppType: config('app.type') === 'local',
+        );
+    }
+
+    /**
+     * Pure decision extracted from resolveChannel() so the stderr branch can be unit-tested directly.
+     * Under PHPUnit, defined('PHPUNIT_COMPOSER_INSTALL') is true for the entire lifetime of the process,
+     * so that branch is permanently unreachable from resolveChannel() itself - there is no way to make
+     * isRunningTests() return false from within a test. Public (rather than private) for the same reason
+     * the other resolve/get/set methods here are public: it is stateless and side-effect-free, and a
+     * subclass-based test double cannot expose a private static method the way it can a protected instance one.
+     */
+    public static function resolveConsoleChannel(bool $runningInConsole, bool $isRunningTests, bool $isLocalAppType): ?string
+    {
+        if ($runningInConsole && !$isRunningTests && $isLocalAppType) {
             return 'stderr';
         }
 

--- a/app/Logging/StructuredLogging.php
+++ b/app/Logging/StructuredLogging.php
@@ -345,10 +345,9 @@ abstract class StructuredLogging implements StructuredLoggingInterface
      * Whether this process is a test run - deliberately not just runningUnitTests().
      *
      * runningUnitTests() answers "is app.env equal to testing", which is not the question being asked: tests are
-     * free to change it, and several do to exercise production-only behaviour (ThumbnailServiceTest, FileTest,
-     * MigrateThumbnailDiskTest, RenderThumbnailTest, MDTMappingImportGameVersionScopingTest). One of those flipping
-     * the environment around a chatty service is what dumped ~1000 ANSI-coloured log lines into the CI test output
-     * in #3782. PHPUNIT_COMPOSER_INSTALL is defined by PHPUnit's own entrypoint (vendor/bin/phpunit, which is how
+     * free to change it, and several do to exercise production-only behaviour. One of those flipping the
+     * environment around a chatty service is what dumped ~1000 ANSI-coloured log lines into the CI test output in
+     * #3782. PHPUNIT_COMPOSER_INSTALL is defined by PHPUnit's own entrypoint (vendor/bin/phpunit, which is how
      * both CI and `php artisan test` invoke it) and phpunit is a require-dev package, so the constant answers
      * "is PHPUnit running" without depending on any application state that a test can rewrite.
      */

--- a/tests/Feature/App/Service/MDT/MDTMappingImportGameVersionScopingTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportGameVersionScopingTest.php
@@ -13,9 +13,11 @@ use App\Service\Cache\CacheServiceInterface;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use App\Service\Mapping\MappingServiceInterface;
 use App\Service\MDT\MDTMappingImportServiceInterface;
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
 use Tests\TestCases\PublicTestCase;
 
 /**
@@ -97,8 +99,17 @@ final class MDTMappingImportGameVersionScopingTest extends PublicTestCase
             // mapping:save runbook does via `APP_ENV=production`). That also made runningUnitTests() answer
             // false, so StructuredLogging::resolveChannel() selected 'stderr' and the import dumped ~1000
             // ANSI-coloured log lines straight into the CI test output - see #3782.
-            $preventsLazyLoading = Model::preventsLazyLoading();
-            Model::preventLazyLoading(false);
+            //
+            // Swapping the violation handler is what replaces that flip, NOT Model::preventLazyLoading(false):
+            // the handler is a static consulted at violation time (Model::handleLazyLoadingViolation), which is
+            // exactly why flipping the environment worked, whereas the prevention flag is snapshotted onto each
+            // model instance as it is hydrated (Builder::hydrate()). Instances that laravel-model-caching
+            // unserializes from cache therefore carry whatever the flag was when they were cached and still
+            // throw - which is why the flag variant passed locally (MODEL_CACHE_ENABLED=false) and errored in
+            // CI (MODEL_CACHE_ENABLED=true).
+            /** @var Closure|null $originalViolationCallback */
+            $originalViolationCallback = new ReflectionProperty(Model::class, 'lazyLoadingViolationCallback')->getValue();
+            Model::handleLazyLoadingViolationUsing(static fn() => null);
 
             try {
                 $newMappingVersion = $mappingImportService->importMappingVersionFromMDT(
@@ -110,7 +121,7 @@ final class MDTMappingImportGameVersionScopingTest extends PublicTestCase
                     false,
                 );
             } finally {
-                Model::preventLazyLoading($preventsLazyLoading);
+                Model::handleLazyLoadingViolationUsing($originalViolationCallback);
             }
 
             // Assert

--- a/tests/Feature/App/Service/MDT/MDTMappingImportGameVersionScopingTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportGameVersionScopingTest.php
@@ -87,30 +87,15 @@ final class MDTMappingImportGameVersionScopingTest extends PublicTestCase
         try {
             // Act
 
-            // importNpcsDataFromMDT() lazy-loads Npc::$npcHealths (App\Models\Npc.php:353,
-            // getHealthByGameVersion()) without eager-loading it first - the mapping-import pipeline is designed
-            // to run from the scheduler/CLI in production, where Model::preventLazyLoading()'s violation handler
-            // only logs (see [[project_autoeager_no_lazyviolation]]); it THROWS in dev/test. This is a
-            // pre-existing gap in the import pipeline, unrelated to #3757, not something to paper over with a
-            // production code change here - so switch off exactly the guard that gets in the way, for the Act
-            // step only.
-            //
-            // This used to flip the whole application environment to 'production' instead (the way the
-            // mapping:save runbook does via `APP_ENV=production`). That also made runningUnitTests() answer
-            // false, so StructuredLogging::resolveChannel() selected 'stderr' and the import dumped ~1000
-            // ANSI-coloured log lines straight into the CI test output - see #3782.
-            //
-            // Swapping the violation handler is what replaces that flip, NOT Model::preventLazyLoading(false):
-            // the handler is a static consulted at violation time (Model::handleLazyLoadingViolation), which is
-            // exactly why flipping the environment worked, whereas the prevention flag is snapshotted onto each
-            // model instance as it is hydrated (Builder::hydrate()). Instances that laravel-model-caching
-            // unserializes from cache therefore carry whatever the flag was when they were cached and still
-            // throw - which is why the flag variant passed locally (MODEL_CACHE_ENABLED=false) and errored in
-            // CI (MODEL_CACHE_ENABLED=true).
-            //
-            // Reflection rather than re-registering AppServiceProvider to restore it: Application::register()
-            // re-runs boot(), which would duplicate its Event::listen() registrations. A Laravel rename of the
-            // property fails loudly here with a ReflectionException rather than silently skipping the restore.
+            // importNpcsDataFromMDT() lazy-loads Npc::$npcHealths without eager-loading it first. That only
+            // logs in production (see [[project_autoeager_no_lazyviolation]]) but throws in dev/test - a
+            // pre-existing gap unrelated to #3757 - so swap out just the violation handler for the Act step.
+            // Not a whole-environment flip to 'production' (the old approach here): that made
+            // StructuredLogging::resolveChannel() dump the import's ~1000 log lines to stderr into CI output
+            // (#3782). Not Model::preventLazyLoading(false) either: that flag is snapshotted per model
+            // instance at hydration, so instances laravel-model-caching unserializes from cache keep whatever
+            // value was cached and still throw. Restored via reflection rather than re-registering
+            // AppServiceProvider, which would duplicate its Event::listen() registrations.
             /** @var Closure|null $originalViolationCallback */
             $originalViolationCallback = new ReflectionProperty(Model::class, 'lazyLoadingViolationCallback')->getValue();
             Model::handleLazyLoadingViolationUsing(static fn() => null);

--- a/tests/Feature/App/Service/MDT/MDTMappingImportGameVersionScopingTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportGameVersionScopingTest.php
@@ -13,6 +13,7 @@ use App\Service\Cache\CacheServiceInterface;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use App\Service\Mapping\MappingServiceInterface;
 use App\Service\MDT\MDTMappingImportServiceInterface;
+use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
@@ -87,11 +88,17 @@ final class MDTMappingImportGameVersionScopingTest extends PublicTestCase
             // importNpcsDataFromMDT() lazy-loads Npc::$npcHealths (App\Models\Npc.php:353,
             // getHealthByGameVersion()) without eager-loading it first - the mapping-import pipeline is designed
             // to run from the scheduler/CLI in production, where Model::preventLazyLoading()'s violation handler
-            // only logs (see [[project_autoeager_no_lazyviolation]]); it THROWS in dev/test. Temporarily flip
-            // the environment for the Act step only, exactly as the mapping:save runbook does via
-            // `APP_ENV=production` for the same reason - this is a pre-existing gap in the import pipeline,
-            // unrelated to #3757, not something to paper over with a production code change here.
-            $this->app->detectEnvironment(static fn() => 'production');
+            // only logs (see [[project_autoeager_no_lazyviolation]]); it THROWS in dev/test. This is a
+            // pre-existing gap in the import pipeline, unrelated to #3757, not something to paper over with a
+            // production code change here - so switch off exactly the guard that gets in the way, for the Act
+            // step only.
+            //
+            // This used to flip the whole application environment to 'production' instead (the way the
+            // mapping:save runbook does via `APP_ENV=production`). That also made runningUnitTests() answer
+            // false, so StructuredLogging::resolveChannel() selected 'stderr' and the import dumped ~1000
+            // ANSI-coloured log lines straight into the CI test output - see #3782.
+            $preventsLazyLoading = Model::preventsLazyLoading();
+            Model::preventLazyLoading(false);
 
             try {
                 $newMappingVersion = $mappingImportService->importMappingVersionFromMDT(
@@ -103,7 +110,7 @@ final class MDTMappingImportGameVersionScopingTest extends PublicTestCase
                     false,
                 );
             } finally {
-                $this->app->detectEnvironment(static fn() => 'testing');
+                Model::preventLazyLoading($preventsLazyLoading);
             }
 
             // Assert

--- a/tests/Feature/App/Service/MDT/MDTMappingImportGameVersionScopingTest.php
+++ b/tests/Feature/App/Service/MDT/MDTMappingImportGameVersionScopingTest.php
@@ -107,6 +107,10 @@ final class MDTMappingImportGameVersionScopingTest extends PublicTestCase
             // unserializes from cache therefore carry whatever the flag was when they were cached and still
             // throw - which is why the flag variant passed locally (MODEL_CACHE_ENABLED=false) and errored in
             // CI (MODEL_CACHE_ENABLED=true).
+            //
+            // Reflection rather than re-registering AppServiceProvider to restore it: Application::register()
+            // re-runs boot(), which would duplicate its Event::listen() registrations. A Laravel rename of the
+            // property fails loudly here with a ReflectionException rather than silently skipping the restore.
             /** @var Closure|null $originalViolationCallback */
             $originalViolationCallback = new ReflectionProperty(Model::class, 'lazyLoadingViolationCallback')->getValue();
             Model::handleLazyLoadingViolationUsing(static fn() => null);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,6 +57,13 @@ abstract class TestCase extends BaseTestCase
         // previous test must not leak into this one
         StructuredLogging::flushConfigCache();
 
+        // An explicit channel is the one input resolveChannel() honours before any of its "am I running tests"
+        // checks, so a setChannel() a previous test failed to unwind would send every later test's log lines to
+        // that channel - the #3782 leak again, through the one door the guard there cannot close. Not folded into
+        // flushConfigCache() because that is also called from StructuredLogging::enable(), where clearing a
+        // deliberately-set channel would be wrong.
+        StructuredLogging::setChannel(null);
+
         // Use a hacky global so that we really only execute this once
         global $initialized;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,8 +54,10 @@ abstract class TestCase extends BaseTestCase
         $this->testStartTime = microtime(true);
 
         // StructuredLogging caches config values in statics that survive across tests - a config() change made by a
-        // previous test must not leak into this one
-        StructuredLogging::flushConfigCache();
+        // previous test must not leak into this one. enable() is used instead of flushConfigCache() alone because
+        // it also resets the $ENABLED latch: a disable() left unwound by some other test would otherwise silence
+        // structured logging for the rest of the shard, and the CI leak-guard would then pass for the wrong reason.
+        StructuredLogging::enable();
 
         // An explicit channel is the one input resolveChannel() honours before any of its "am I running tests"
         // checks, so a setChannel() a previous test failed to unwind would send every later test's log lines to

--- a/tests/Unit/App/Logging/StructuredLoggingTest.php
+++ b/tests/Unit/App/Logging/StructuredLoggingTest.php
@@ -342,6 +342,34 @@ class StructuredLoggingTest extends PublicTestCase
         self::assertNull($channel, 'Structured logging must fall through to the default channel while testing');
     }
 
+    /**
+     * #3782: a test is free to change app.env, and several do to exercise production-only behaviour -
+     * MDTMappingImportGameVersionScopingTest did it around a full MDT mapping import and put ~1000
+     * ANSI-coloured log lines in the CI test output. "Am I running tests" must therefore not be answered
+     * by app.env alone.
+     */
+    #[Test]
+    public function resolveChannel_GivenTheApplicationEnvironmentIsFlippedToProduction_ShouldNotSelectAConsoleChannel(): void
+    {
+        // Arrange
+        config(['app.type' => 'local']);
+        self::assertTrue($this->app->runningInConsole(), 'Only meaningful when run from the console');
+
+        $originalEnvironment = $this->app['env'];
+        $this->app->detectEnvironment(static fn() => 'production');
+
+        try {
+            // Act
+            $channel = StructuredLogging::resolveChannel();
+
+            // Assert
+            self::assertFalse($this->app->runningUnitTests(), 'The environment flip must actually have taken effect');
+            self::assertNull($channel, 'A test flipping app.env must not redirect structured logging to the console');
+        } finally {
+            $this->app->detectEnvironment(static fn() => $originalEnvironment);
+        }
+    }
+
     #[Test]
     public function resolveChannel_GivenAnExplicitChannel_ShouldReturnIt(): void
     {

--- a/tests/Unit/App/Logging/StructuredLoggingTest.php
+++ b/tests/Unit/App/Logging/StructuredLoggingTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\App\Logging;
 use App\Logging\StructuredLogging;
 use Illuminate\Support\Facades\Context;
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Exception;
@@ -382,5 +383,40 @@ class StructuredLoggingTest extends PublicTestCase
         } finally {
             StructuredLogging::setChannel(null);
         }
+    }
+
+    /**
+     * resolveChannel() can never observe the 'stderr' branch under PHPUnit - PHPUNIT_COMPOSER_INSTALL is
+     * defined for the whole process, so isRunningTests() can never return false from within a test. The
+     * decision was extracted into resolveConsoleChannel() specifically so this branch stays testable.
+     */
+    #[Test]
+    #[DataProvider('resolveConsoleChannelDataProvider')]
+    public function resolveConsoleChannel_GivenInputCombination_ShouldReturnExpectedChannel(
+        bool    $runningInConsole,
+        bool    $isRunningTests,
+        bool    $isLocalAppType,
+        ?string $expectedChannel,
+    ): void {
+        // Act
+        $channel = StructuredLogging::resolveConsoleChannel($runningInConsole, $isRunningTests, $isLocalAppType);
+
+        // Assert
+        self::assertSame($expectedChannel, $channel);
+    }
+
+    /** @return array<string, array{bool, bool, bool, ?string}> */
+    public static function resolveConsoleChannelDataProvider(): array
+    {
+        return [
+            'console + not tests + local => stderr'       => [true, false, true, 'stderr'],
+            'console + tests + local => null'             => [true, true, true, null],
+            'console + not tests + non-local => null'     => [true, false, false, null],
+            'console + tests + non-local => null'         => [true, true, false, null],
+            'not console + not tests + local => null'     => [false, false, true, null],
+            'not console + tests + local => null'         => [false, true, true, null],
+            'not console + not tests + non-local => null' => [false, false, false, null],
+            'not console + tests + non-local => null'     => [false, true, false, null],
+        ];
     }
 }

--- a/tests/Unit/App/Logging/StructuredLoggingTest.php
+++ b/tests/Unit/App/Logging/StructuredLoggingTest.php
@@ -356,17 +356,17 @@ class StructuredLoggingTest extends PublicTestCase
         self::assertTrue($this->app->runningInConsole(), 'Only meaningful when run from the console');
 
         $originalEnvironment = $this->app['env'];
-        $this->app->detectEnvironment(static fn() => 'production');
+        $this->app['env']    = 'production';
+        self::assertFalse($this->app->runningUnitTests(), 'The environment flip must actually have taken effect');
 
         try {
             // Act
             $channel = StructuredLogging::resolveChannel();
 
             // Assert
-            self::assertFalse($this->app->runningUnitTests(), 'The environment flip must actually have taken effect');
             self::assertNull($channel, 'A test flipping app.env must not redirect structured logging to the console');
         } finally {
-            $this->app->detectEnvironment(static fn() => $originalEnvironment);
+            $this->app['env'] = $originalEnvironment;
         }
     }
 


### PR DESCRIPTION
:robot: Closes #3782

## Root cause

`php-tests (feature-other)` printed **965** ANSI-coloured `production.INFO`/`production.DEBUG` lines into the job output. #3722 / PR #3724 had already made `StructuredLogging::resolveChannel()` resolve per log call instead of latching the channel in the constructor — a real fix, but for a different cause.

Sorting the [raw job log](https://github.com/RaiderIO/keystone.guru/actions/runs/30668384463/job/91280579449) by its own per-line timestamps splits the output in two (the on-screen interleaving with PHPUnit's block-buffered progress dots is a rendering artifact, which is what made the leak look like it spanned ~63 tests):

| window | lines | source |
| --- | --- | --- |
| 22:05:49.10 | 6 × `CacheServiceLogging::deleteKeysByPattern*` | the `php artisan db:seed` CI step, which runs *before* the workflow appends `APP_ENV=testing` — **legitimate**, not a leak |
| 22:06:43.10 → 22:06:45.94 | 959 × `MDTMappingImportServiceLogging::*`, exactly one `importMappingVersionFromMDTStart`/`End` pair, `dungeonId 49`, `elapsedMS: 2807.34` | **the leak** — one test, not the whole run |

The culprit is `MDTMappingImportGameVersionScopingTest` (landed the day of that CI run, in `0d6220580` / #3762 for #3757), which flipped the whole application environment to `production` around its Act step so `AppServiceProvider`'s lazy-loading violation handler would log rather than throw on `Npc::$npcHealths`:

```php
$this->app->detectEnvironment(static fn() => 'production');
```

`Application::runningUnitTests()` is `$this->bound('env') && $this['env'] === 'testing'`, so the flip turns it **false**. The other two conditions in `resolveChannel()` are always true in CI (`runningInConsole()` under phpunit; `config('app.type') === 'local'` from `.env.ci.example`, and `phpunit.xml` never sets `APP_TYPE`) — so every line went to the `stderr` channel with its `ColoredLineFormatter` tap. It also explains the `production.` prefix specifically: `ParsesLogConfiguration::parseChannel()` names a channel after `$app->environment()` when the config carries no explicit name.

Nothing here is transient or ordering-dependent; it reproduces deterministically.

## The fix

**1. The test stops lying about the environment.** It now swaps the lazy-loading *violation handler* for a no-op around the Act step, restoring the original in a `finally`.

Worth calling out, because the first attempt at this got it wrong and CI caught it: `Model::preventLazyLoading(false)` is **not** equivalent and does not work. That flag is snapshotted onto each model instance as it is hydrated (`Builder::hydrate()`), so instances `laravel-model-caching` unserializes from cache still carry `preventsLazyLoading = true` and throw anyway — which is why the flag variant passed locally (`MODEL_CACHE_ENABLED=false`) and errored in CI (`MODEL_CACHE_ENABLED=true`). The handler, by contrast, is a static consulted at violation time, which is exactly the mechanism the original environment flip relied on.

**2. `resolveChannel()` no longer decides "am I running tests" from `app.env` alone.** Five other test files already flip it to exercise production-only behaviour (`ThumbnailServiceTest`, `FileTest`, `MigrateThumbnailDiskTest`, `RenderThumbnailTest`, `TrustProxiesTest`); they just don't happen to drive a chatty service today. Fixing only the one test would leave the trap armed for the next one. `PHPUNIT_COMPOSER_INSTALL` is defined by PHPUnit's own entrypoint (`vendor/bin/phpunit`, which is how both CI and `php artisan test` invoke it), and phpunit is `require-dev`, so the constant cannot exist in production.

**3. A regression test** in `StructuredLoggingTest` pinning the exact trigger: environment flipped to `production`, channel must still be `null`.

**4. CI now fails the build on any leak.** This guard has regressed twice (#3722 → #3782) and each time the protection lived in application state a test can rewrite, so `php-tests.yml` asserts the PHPUnit step's own output carries no log lines. Scoped to that step deliberately — the setup steps run real artisan commands and log to stderr legitimately. Verified all five shards were already clean by this check on the previous run, so it goes in green rather than papering over an existing leak.

## Verification

| check | result |
| --- | --- |
| `MDTMappingImportGameVersionScopingTest`, before the change | 230 leaked lines |
| same, after | **0**, test green |
| same, with the environment flip deliberately put **back** | **0** — part 2 closes the leak on its own, independently of part 1 |
| same, under the CI condition (`MODEL_CACHE_ENABLED=true`) | errors before part 1's correction, green after |
| full `feature-other` shard locally (725 tests) | **0** leaked lines |
| `tests/Unit/App/Logging/` | 19/19 green |
| `composer run fix` / `composer run analyse` | clean |

The leak grep used here matches `<channel>.<LEVEL>:` for **any** channel name, not just `production.` — `FileTest` and `ThumbnailServiceTest` flip to `local`, and a `production.`-only grep would have reported those clean regardless.

**Pre-existing local failures, not caused by this change:** 5 MDT fixture tests (`MDTImportStringServiceMDT2AuthoritativeTest` for Kings' Rest / Ruby Life Pools, `MDTNpcMappingCoverageTest`) fail identically with this branch's `app/` and `tests/` reverted to master, in the same worktree. They are worktree-DB drift for those two dungeons — the main checkout on master passes all 49, and CI is green on them.

## Adjacent findings, deliberately not addressed

- `config/logging.php` defines `stack_docker` / `stack_docker_local`, both `['stderr', 'daily']`. If `LOG_CHANNEL` ever resolved to one of those, `resolveChannel()` returning `null` would not help. Nothing sets it today, and change 4 would now catch it at build time. Cold review suggested `force="true"` on `phpunit.xml`'s `LOG_CHANNEL`; not doing that, because it would also block a deliberate local `LOG_CHANNEL=stdout vendor/bin/phpunit` override, and the CI assertion covers the case that actually matters.
- Five other sites answer "am I in a test" from `app.env` alone (`ApiAuthentication`, `ApiMetrics`, `DebugInfoContextLogger`, `KeystoneGuruServiceProvider`, `AppServiceProvider`) and are exposed to the same environment flips. Deliberately **not** converging them on `isRunningTests()` — widening "in a test" is fine for picking a log channel and materially worse for an auth-bypass guard. Worth a separate issue.
- `StructuredLogging::$ENABLED` is a process-wide static that `SaveToOpensearch` and `ConvertToEvents` `disable()` without re-enabling. No test invokes those commands today, but it is the same class of latch with the opposite symptom — it would silence logging and make a leak-detection test pass for the wrong reason.
- The underlying gap that made the test need a workaround at all (the import pipeline lazy-loads `Npc::$npcHealths`) stays out of scope, exactly as #3757 scoped it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Cold review (two rounds, fresh-context agents)

Round 1 found no defects in the change; its nits (a docblock enumeration that this MR makes stale, an arrange guard sitting in the Assert block, an asymmetric `app['env']` save/restore) are applied.

Round 2 found one real gap, now fixed in `480f4c62a`: `resolveChannel()` honours an explicit `setChannel()` **before** any of its test-detection checks, and nothing resets `$CHANNEL` between tests — `TestCase::setUp()` already flushes StructuredLogging's other statics for exactly this reason, but `flushConfigCache()` covers only `$LOG_LEVEL` and `$PRETTY_PRINT`. A `setChannel('stderr')` a future test failed to unwind would latch the leak on for the rest of the shard, through the one door part 2 cannot close. Reset in `setUp()`; deliberately *not* folded into `flushConfigCache()`, which `StructuredLogging::enable()` also calls, where clearing a deliberately-set channel would be wrong.

Two round-2 suggestions were considered and declined, both stated here so they can be overridden:
- Adding the same assertion to `php-coverage.yml`. It is `schedule`/`workflow_dispatch` and gates nothing, and the `$CHANNEL` reset above addresses the single-process risk it was raised for.
- `force="true"` on `phpunit.xml`'s `LOG_CHANNEL`. It would also block a deliberate local `LOG_CHANNEL=stdout vendor/bin/phpunit` override, and the CI assertion covers the case that matters.

## CI result

The `feature-other` shard that this issue is about now runs **725 tests with 0 leaked lines** (was 959), and the new assertion step ran and passed on all five shards.
