### PR TITLE
Remove the HasIconFile trait from Faction, CharacterClass and CharacterClassSpecialization

### DIFF
--- a/app/Logic/MapContext/MapContextStaticData.php
+++ b/app/Logic/MapContext/MapContextStaticData.php
@@ -63,7 +63,7 @@ class MapContextStaticData implements Arrayable
                 'characterClasses'                  => $characterClasses,
                 'characterClassSpecializations'     => CharacterClassSpecialization::all(),
                 'raidMarkers'                       => RaidMarker::all(),
-                'factions'                          => Faction::where('name', '<>', 'Unspecified')->get(),
+                'factions'                          => Faction::where('key', '<>', Faction::FACTION_UNSPECIFIED)->get(),
                 'publishStates'                     => PublishedState::all(),
                 'gameVersions'                      => GameVersion::all(),
                 'selectableSpells'                  => $selectableSpells,

--- a/app/Logic/MapContext/MapContextStaticData.php
+++ b/app/Logic/MapContext/MapContextStaticData.php
@@ -63,7 +63,7 @@ class MapContextStaticData implements Arrayable
                 'characterClasses'                  => $characterClasses,
                 'characterClassSpecializations'     => CharacterClassSpecialization::all(),
                 'raidMarkers'                       => RaidMarker::all(),
-                'factions'                          => Faction::where('name', '<>', 'Unspecified')->with('iconfile')->get(),
+                'factions'                          => Faction::where('name', '<>', 'Unspecified')->get(),
                 'publishStates'                     => PublishedState::all(),
                 'gameVersions'                      => GameVersion::all(),
                 'selectableSpells'                  => $selectableSpells,

--- a/app/Models/Affix.php
+++ b/app/Models/Affix.php
@@ -11,10 +11,7 @@ use Str;
 
 /**
  * @property int    $id           The ID of this Affix.
- * @property int    $icon_file_id Vestigial - always -1. The icon itself is a static asset from the
- *                                assets project (see image_url), not an admin-editable File upload.
- *                                Column kept for now (int NOT NULL, no default); dropping it needs
- *                                its own migration - see #3786.
+ * @property int    $icon_file_id
  * @property int    $affix_id     The ID of the affix in-game.
  * @property string $key          The identifying key of the Affix.
  * @property string $name         The name of the Affix.

--- a/app/Models/Affix.php
+++ b/app/Models/Affix.php
@@ -13,8 +13,8 @@ use Str;
  * @property int    $id           The ID of this Affix.
  * @property int    $icon_file_id Vestigial - always -1. The icon itself is a static asset from the
  *                                assets project (see image_url), not an admin-editable File upload.
- *                                Column kept for now (NOT NULL, no default); dropping it needs its
- *                                own migration - see #3775.
+ *                                Column kept for now (int NOT NULL, no default); dropping it needs
+ *                                its own migration - see #3786.
  * @property int    $affix_id     The ID of the affix in-game.
  * @property string $key          The identifying key of the Affix.
  * @property string $name         The name of the Affix.

--- a/app/Models/CharacterClass.php
+++ b/app/Models/CharacterClass.php
@@ -17,10 +17,7 @@ use Str;
  * @property string $key
  * @property string $name
  * @property string $color
- * @property string $icon_file_id Vestigial - always -1. The icon itself is a static asset from the
- *                                assets project (see icon_url), not an admin-editable File upload.
- *                                Column kept for now (varchar(255) NOT NULL, no default); dropping
- *                                it needs its own migration - see #3786.
+ * @property string $icon_file_id
  *
  * @property string $icon_url Appended
  *

--- a/app/Models/CharacterClass.php
+++ b/app/Models/CharacterClass.php
@@ -14,13 +14,13 @@ use Str;
 /**
  * @property int    $id
  * @property int    $class_id     Blizzard class ID
+ * @property string $key
+ * @property string $name
+ * @property string $color
  * @property string $icon_file_id Vestigial - always -1. The icon itself is a static asset from the
  *                                assets project (see icon_url), not an admin-editable File upload.
  *                                Column kept for now (varchar(255) NOT NULL, no default); dropping
  *                                it needs its own migration - see #3786.
- * @property string $key
- * @property string $name
- * @property string $color
  *
  * @property string $icon_url Appended
  *

--- a/app/Models/CharacterClass.php
+++ b/app/Models/CharacterClass.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use App\Models\DungeonRoute\DungeonRoutePlayerClass;
 use App\Models\DungeonRoute\DungeonRoutePlayerRace;
-use App\Models\Traits\HasIconFile;
 use App\Models\Traits\SeederModel;
 use Eloquent;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -14,7 +13,11 @@ use Str;
 
 /**
  * @property int    $id
- * @property int    $class_id Blizzard class ID
+ * @property int    $class_id     Blizzard class ID
+ * @property string $icon_file_id Vestigial - always -1. The icon itself is a static asset from the
+ *                                assets project (see icon_url), not an admin-editable File upload.
+ *                                Column kept for now (varchar(255) NOT NULL, no default); dropping
+ *                                it needs its own migration - see #3786.
  * @property string $key
  * @property string $name
  * @property string $color
@@ -30,7 +33,6 @@ use Str;
  */
 class CharacterClass extends CacheModel
 {
-    use HasIconFile;
     use SeederModel;
 
     public $timestamps = false;

--- a/app/Models/CharacterClassSpecialization.php
+++ b/app/Models/CharacterClassSpecialization.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use App\Models\Interfaces\CombatLogCriterionModelInterface;
 use App\Models\Traits\HasCombatLogCriterion;
-use App\Models\Traits\HasIconFile;
 use App\Models\Traits\SeederModel;
 use Eloquent;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -14,7 +13,10 @@ use Str;
  * @property int    $id
  * @property int    $character_class_id Internal ID - not a blizzard ID!
  * @property int    $specialization_id  Blizzard ID
- * @property int    $icon_file_id
+ * @property string $icon_file_id       Vestigial - always -1. The icon itself is a static asset from
+ *                                      the assets project (see icon_url), not an admin-editable File
+ *                                      upload. Column kept for now (varchar(255) NOT NULL, no
+ *                                      default); dropping it needs its own migration - see #3786.
  * @property string $key
  * @property string $name
  *
@@ -27,7 +29,6 @@ use Str;
 class CharacterClassSpecialization extends CacheModel implements CombatLogCriterionModelInterface
 {
     use HasCombatLogCriterion;
-    use HasIconFile;
     use SeederModel;
 
     public $timestamps = false;

--- a/app/Models/CharacterClassSpecialization.php
+++ b/app/Models/CharacterClassSpecialization.php
@@ -15,10 +15,7 @@ use Str;
  * @property int    $specialization_id  Blizzard ID
  * @property string $key
  * @property string $name
- * @property string $icon_file_id       Vestigial - always -1. The icon itself is a static asset from
- *                                      the assets project (see icon_url), not an admin-editable File
- *                                      upload. Column kept for now (varchar(255) NOT NULL, no
- *                                      default); dropping it needs its own migration - see #3786.
+ * @property string $icon_file_id
  *
  * @property string $icon_url Appended
  *

--- a/app/Models/CharacterClassSpecialization.php
+++ b/app/Models/CharacterClassSpecialization.php
@@ -13,12 +13,12 @@ use Str;
  * @property int    $id
  * @property int    $character_class_id Internal ID - not a blizzard ID!
  * @property int    $specialization_id  Blizzard ID
+ * @property string $key
+ * @property string $name
  * @property string $icon_file_id       Vestigial - always -1. The icon itself is a static asset from
  *                                      the assets project (see icon_url), not an admin-editable File
  *                                      upload. Column kept for now (varchar(255) NOT NULL, no
  *                                      default); dropping it needs its own migration - see #3786.
- * @property string $key
- * @property string $name
  *
  * @property string $icon_url Appended
  *

--- a/app/Models/CharacterRace.php
+++ b/app/Models/CharacterRace.php
@@ -96,7 +96,6 @@ class CharacterRace extends CacheModel
     public $timestamps = false;
 
     public $hidden = [
-        'icon_file_id',
         'pivot',
     ];
 

--- a/app/Models/Dungeon.php
+++ b/app/Models/Dungeon.php
@@ -554,14 +554,6 @@ class Dungeon extends CacheModel implements CombatLogCriterionModelInterface, Ma
         return $this->loadMappingVersions()->mappingVersions->map(static fn(MappingVersion $mappingVersion) => $mappingVersion->gameVersion)->unique('id');
     }
 
-    public function isFactionSelectionRequired(): bool
-    {
-        return in_array($this->key, [
-            self::DUNGEON_SIEGE_OF_BORALUS,
-            self::DUNGEON_THE_NEXUS,
-        ]);
-    }
-
     public function getImageLink(): ?string
     {
         return $this->getImageUrl();

--- a/app/Models/Faction.php
+++ b/app/Models/Faction.php
@@ -10,10 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property int    $id
- * @property int    $icon_file_id Vestigial - always -1. The icon itself is a static asset from the
- *                                assets project (see icon_url), not an admin-editable File upload.
- *                                Column kept for now (int NOT NULL, no default); dropping it needs
- *                                its own migration - see #3786.
+ * @property int    $icon_file_id
  * @property string $key
  * @property string $name
  * @property string $color

--- a/app/Models/Faction.php
+++ b/app/Models/Faction.php
@@ -3,7 +3,6 @@
 namespace App\Models;
 
 use App\Models\DungeonRoute\DungeonRoute;
-use App\Models\Traits\HasIconFile;
 use App\Models\Traits\SeederModel;
 use Eloquent;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -11,10 +10,15 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property int    $id
- * @property int    $icon_file_id
+ * @property int    $icon_file_id Vestigial - always -1. The icon itself is a static asset from the
+ *                                assets project (see icon_url), not an admin-editable File upload.
+ *                                Column kept for now (int NOT NULL, no default); dropping it needs
+ *                                its own migration - see #3786.
  * @property string $key
  * @property string $name
  * @property string $color
+ *
+ * @property string $icon_url Appended
  *
  * @property EloquentCollection<int, CharacterRace> $races
  * @property EloquentCollection<int, DungeonRoute>  $dungeonRoutes
@@ -23,7 +27,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class Faction extends CacheModel
 {
-    use HasIconFile;
     use SeederModel;
 
     public $timestamps = false;
@@ -41,7 +44,7 @@ class Faction extends CacheModel
         'color',
     ];
 
-    protected $with = ['iconfile'];
+    protected $appends = ['icon_url'];
 
     public const FACTION_ANY         = 'any';
     public const FACTION_UNSPECIFIED = 'unspecified';
@@ -53,6 +56,11 @@ class Faction extends CacheModel
         self::FACTION_HORDE       => 2,
         self::FACTION_ALLIANCE    => 3,
     ];
+
+    public function getIconUrlAttribute(): string
+    {
+        return ksgAssetImage(sprintf('factions/%s.png', $this->key));
+    }
 
     /** @return HasMany<CharacterRace, $this> */
     public function races(): HasMany

--- a/database/seeders/AffixSeeder.php
+++ b/database/seeders/AffixSeeder.php
@@ -6,7 +6,6 @@ use App\Models\Affix;
 use App\Models\AffixGroup\AffixGroup;
 use App\Models\AffixGroup\AffixGroupCoupling;
 use App\Models\Expansion;
-use App\Models\File;
 use App\Models\Season;
 use App\SeederHelpers\Traits\FindsAffixes;
 use Illuminate\Database\Seeder;
@@ -73,17 +72,6 @@ class AffixSeeder extends Seeder implements TableSeederInterface
 
         foreach ($affixes as $affix) {
             /** @var Affix $affix */
-            $affix->setTable(DatabaseSeeder::getTempTableName(Affix::class))->save();
-
-            $iconName          = $affix->image_url;
-            $icon              = new File();
-            $icon->model_id    = $affix->id;
-            $icon->model_class = get_class($affix);
-            $icon->disk        = 'public';
-            $icon->path        = sprintf('images/affixes/%s.jpg', $iconName);
-            $icon->save();
-
-            $affix->icon_file_id = $icon->id;
             $affix->setTable(DatabaseSeeder::getTempTableName(Affix::class))->save();
         }
 

--- a/database/seeders/CharacterClassSpecializationsSeeder.php
+++ b/database/seeders/CharacterClassSpecializationsSeeder.php
@@ -4,7 +4,6 @@ namespace Database\Seeders;
 
 use App\Models\CharacterClass;
 use App\Models\CharacterClassSpecialization;
-use App\Models\File;
 use Exception;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Collection;
@@ -262,6 +261,7 @@ class CharacterClassSpecializationsSeeder extends Seeder implements TableSeederI
                 'character_class_id' => $characterClasses->get(CharacterClass::CHARACTER_CLASS_DEMON_HUNTER)->id,
             ],
         ];
+        // @formatter:on
 
         CharacterClassSpecialization::from(DatabaseSeeder::getTempTableName(CharacterClassSpecialization::class))
             ->insert(collect($characterClassSpecializationsAttributes)->map(function ($row) {
@@ -269,27 +269,6 @@ class CharacterClassSpecializationsSeeder extends Seeder implements TableSeederI
 
                 return $row;
             })->toArray());
-
-        $characterClasses              = $characterClasses->keyBy('id');
-        $characterClassSpecializations = CharacterClassSpecialization::all();
-        // @formatter:on
-
-        // For each class with a bunch of specs
-        foreach ($characterClassSpecializations as $characterClassSpecialization) {
-            /** @var CharacterClass $class */
-            $class = $characterClasses->get($characterClassSpecialization->character_class_id);
-
-            $icon = File::create([
-                'model_id'    => $characterClassSpecialization->id,
-                'model_class' => get_class($characterClassSpecialization),
-                'disk'        => 'public',
-                'path'        => sprintf('images/specializations/%s/%s_%s.png', $class->key, $class->key, $characterClassSpecialization->key),
-            ]);
-
-            $characterClassSpecialization->setTable(DatabaseSeeder::getTempTableName(CharacterClassSpecialization::class))->update([
-                'icon_file_id' => $icon->id,
-            ]);
-        }
     }
 
     public static function getAffectedModelClasses(): array

--- a/database/seeders/CharacterClassesSeeder.php
+++ b/database/seeders/CharacterClassesSeeder.php
@@ -4,9 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\CharacterClass;
 use App\Models\Faction;
-use App\Models\File;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Collection;
 
 class CharacterClassesSeeder extends Seeder implements TableSeederInterface
 {
@@ -112,21 +110,6 @@ class CharacterClassesSeeder extends Seeder implements TableSeederInterface
 
         // Insert all classes at once
         CharacterClass::from(DatabaseSeeder::getTempTableName(CharacterClass::class))->insert($characterClassesAttributes);
-
-        // Set icons for each inserted class
-        /** @var Collection<int, CharacterClass> $characterClasses */
-        $characterClasses = CharacterClass::from(DatabaseSeeder::getTempTableName(CharacterClass::class))->get();
-        foreach ($characterClasses as $characterClass) {
-            $icon = File::create([
-                'model_id'    => $characterClass->id,
-                'model_class' => CharacterClass::class,
-                'disk'        => 'public',
-                'path'        => sprintf('images/classes/%s.png', strtolower(str_replace(' ', '', $characterClass->key))),
-            ]);
-
-            // Update the class with the icon ID
-            $characterClass->setTable(DatabaseSeeder::getTempTableName(CharacterClass::class))->update(['icon_file_id' => $icon->id]);
-        }
     }
 
     public static function getAffectedModelClasses(): array

--- a/database/seeders/FactionsSeeder.php
+++ b/database/seeders/FactionsSeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\Faction;
-use App\Models\File;
 use Illuminate\Database\Seeder;
 
 class FactionsSeeder extends Seeder implements TableSeederInterface
@@ -39,18 +38,6 @@ class FactionsSeeder extends Seeder implements TableSeederInterface
 
         foreach ($factions as $faction) {
             /** @var $faction Faction */
-            $faction->setTable(DatabaseSeeder::getTempTableName(Faction::class))->save();
-
-            // Translate faction name to English and convert it to lower case
-            $iconName          = strtolower(str_replace(' ', '', $faction->key));
-            $icon              = new File();
-            $icon->model_id    = $faction->id;
-            $icon->model_class = get_class($faction);
-            $icon->disk        = 'public';
-            $icon->path        = sprintf('images/factions/%s.png', $iconName);
-            $icon->save();
-
-            $faction->icon_file_id = $icon->id;
             $faction->setTable(DatabaseSeeder::getTempTableName(Faction::class))->save();
         }
     }

--- a/resources/assets/js/custom/mapcontrols/factiondisplaycontrols.js
+++ b/resources/assets/js/custom/mapcontrols/factiondisplaycontrols.js
@@ -10,7 +10,6 @@ class FactionDisplayControls extends MapControl {
             onAdd: function (leafletMap) {
                 let template = Handlebars.templates['map_faction_display_controls_template'];
 
-                // factionsData is defined in map.blade.php
                 let factionsData = [];
                 let stateFactions = getState().getMapContext().getStaticFactions();
                 for (let index in stateFactions) {
@@ -19,7 +18,7 @@ class FactionDisplayControls extends MapControl {
                         factionsData.push({
                             name: lang.get(faction.name),
                             name_lc: lang.get(faction.name).toLowerCase(),
-                            icon_url: faction.iconfile.icon_url,
+                            icon_url: faction.icon_url,
                             fa_class: parseInt(index) === 0 ? 'fas' : 'far'
                         });
                     }

--- a/resources/views/common/maps/map.blade.php
+++ b/resources/views/common/maps/map.blade.php
@@ -254,29 +254,6 @@ if ($isAdmin) {
         });
     </script>
 
-    @if($dungeon->isFactionSelectionRequired())
-        <script id="map_faction_display_controls_template" type="text/x-handlebars-template">
-            <div id="map_faction_display_controls" class="leaflet-draw-section">
-                <div class="leaflet-draw-toolbar leaflet-bar leaflet-draw-toolbar-top">
-            @foreach(Faction::where('key', '<>', Faction::FACTION_UNSPECIFIED)->get() as $faction)
-                <a class="map_faction_display_control map_controls_custom" href="#"
-                   data-faction="{{ strtolower($faction->key) }}"
-                           title="{{ __($faction->name) }}">
-                            <i class="{{ $loop->index === 0 ? 'fas' : 'far' }} fa-circle radiobutton"
-                               style="width: 15px"></i>
-                            <img src="{{ $faction->iconfile->icon_url }}" class="select_icon faction_icon"
-                                 data-bs-toggle="tooltip" title="{{ __($faction->name) }}"
-                                 alt="Faction"/>
-                        </a>
-
-            @endforeach
-            </div>
-            <ul class="leaflet-draw-actions"></ul>
-        </div>
-
-
-        </script>
-    @endif
 @endsection
 
 @if(!$noUI)

--- a/tests/Feature/App/Logic/MapContext/MapContextStaticDataTest.php
+++ b/tests/Feature/App/Logic/MapContext/MapContextStaticDataTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\App\Logic\MapContext;
 
+use App\Models\Faction;
 use App\Service\MapContext\MapContextServiceInterface;
 use Illuminate\Support\Facades\Cache;
 use Override;
@@ -41,5 +42,20 @@ final class MapContextStaticDataTest extends PublicTestCase
             $this->assertArrayNotHasKey('iconfile', $faction);
             $this->assertSame(ksgAssetImage(sprintf('factions/%s.png', $faction['key'])), $faction['icon_url']);
         }
+    }
+
+    #[Test]
+    public function toArray_givenFactions_excludesUnspecifiedFaction(): void
+    {
+        // Arrange
+        $mapContextStaticData = app(MapContextServiceInterface::class)->createMapContextStaticData('en_US');
+
+        // Act
+        $factions = json_decode(json_encode($mapContextStaticData->toArray()['static']['factions']), true);
+
+        // Assert - FactionDisplayControls only ever offers a Horde/Alliance toggle; the Unspecified
+        // faction should never be part of this payload.
+        $factionKeys = array_column($factions, 'key');
+        $this->assertNotContains(Faction::FACTION_UNSPECIFIED, $factionKeys);
     }
 }

--- a/tests/Feature/App/Logic/MapContext/MapContextStaticDataTest.php
+++ b/tests/Feature/App/Logic/MapContext/MapContextStaticDataTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\App\Logic\MapContext;
+
+use App\Service\MapContext\MapContextServiceInterface;
+use Illuminate\Support\Facades\Cache;
+use Override;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('MapContext')]
+final class MapContextStaticDataTest extends PublicTestCase
+{
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // RemembersToFile writes to the `tmp_file` file store, which survives between test runs -
+        // without this the assertions below could run against a payload built by older code.
+        Cache::store('tmp_file')->flush();
+    }
+
+    #[Test]
+    public function toArray_givenFactions_serializesIconUrlWithoutIconFile(): void
+    {
+        // Arrange
+        $mapContextStaticData = app(MapContextServiceInterface::class)->createMapContextStaticData('en_US');
+
+        // Act - round-trip through json, since that is exactly what JavascriptController and
+        // make:mapcontextstatic hand to the front-end.
+        $factions = json_decode(json_encode($mapContextStaticData->toArray()['static']['factions']), true);
+
+        // Assert - FactionDisplayControls reads faction.icon_url; it used to read
+        // faction.iconfile.icon_url, which no longer exists.
+        $this->assertNotEmpty($factions);
+
+        foreach ($factions as $faction) {
+            $this->assertArrayHasKey('icon_url', $faction);
+            $this->assertArrayNotHasKey('iconfile', $faction);
+            $this->assertSame(ksgAssetImage(sprintf('factions/%s.png', $faction['key'])), $faction['icon_url']);
+        }
+    }
+}

--- a/tests/Feature/App/Models/CharacterClassTest.php
+++ b/tests/Feature/App/Models/CharacterClassTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\App\Models;
+
+use App\Models\CharacterClass;
+use App\Models\CharacterClassSpecialization;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('CharacterClass')]
+final class CharacterClassTest extends PublicTestCase
+{
+    #[Test]
+    public function toArray_givenSeededCharacterClass_containsIconUrlAndOmitsIconFile(): void
+    {
+        // Arrange
+        $characterClass = CharacterClass::query()->firstOrFail();
+
+        // Act
+        $array = $characterClass->toArray();
+
+        // Assert - the icon comes from the assets project, never from a File upload.
+        $this->assertArrayHasKey('icon_url', $array);
+        $this->assertArrayNotHasKey('iconfile', $array);
+        $this->assertArrayNotHasKey('icon_file_id', $array);
+    }
+
+    #[Test]
+    public function iconUrl_givenSeededCharacterClassSpecialization_returnsAssetsImageUrl(): void
+    {
+        // Arrange
+        $specialization = CharacterClassSpecialization::query()->firstOrFail();
+        $className      = str_replace('_', '', $specialization->class->key);
+
+        // Act
+        $iconUrl = $specialization->icon_url;
+
+        // Assert
+        $this->assertSame(
+            ksgAssetImage(sprintf(
+                '/specializations/%s/%s_%s.png',
+                $className,
+                $className,
+                str_replace('_', '', $specialization->key),
+            )),
+            $iconUrl,
+        );
+        $this->assertArrayNotHasKey('iconfile', $specialization->toArray());
+    }
+}

--- a/tests/Feature/App/Models/FactionTest.php
+++ b/tests/Feature/App/Models/FactionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\App\Models;
+
+use App\Models\Faction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Faction')]
+final class FactionTest extends PublicTestCase
+{
+    #[Test]
+    #[DataProvider('factionKeyProvider')]
+    public function iconUrl_givenSeededFaction_returnsAssetsImageUrl(string $key): void
+    {
+        // Arrange
+        $faction = Faction::query()->where('key', $key)->firstOrFail();
+
+        // Act
+        $iconUrl = $faction->icon_url;
+
+        // Assert
+        $this->assertSame(ksgAssetImage(sprintf('factions/%s.png', $key)), $iconUrl);
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function factionKeyProvider(): array
+    {
+        return [
+            Faction::FACTION_UNSPECIFIED => [Faction::FACTION_UNSPECIFIED],
+            Faction::FACTION_HORDE       => [Faction::FACTION_HORDE],
+            Faction::FACTION_ALLIANCE    => [Faction::FACTION_ALLIANCE],
+        ];
+    }
+
+    #[Test]
+    public function toArray_givenSeededFaction_containsIconUrlAndOmitsIconFile(): void
+    {
+        // Arrange
+        $faction = Faction::query()->firstOrFail();
+
+        // Act
+        $array = $faction->toArray();
+
+        // Assert - the map controls read faction.icon_url off this payload; the `iconfile` File
+        // relation and the vestigial icon_file_id column must never reach the front-end again.
+        $this->assertArrayHasKey('icon_url', $array);
+        $this->assertArrayNotHasKey('iconfile', $array);
+        $this->assertArrayNotHasKey('icon_file_id', $array);
+    }
+}


### PR DESCRIPTION
:robot: Closes #3775

Removes `App\Models\Traits\HasIconFile` from `Faction`, `CharacterClass` and
`CharacterClassSpecialization`, finishing what #3350 did for `Expansion` and #3766 for `Affix`.
Icons for all of these come from the assets project via `ksgAssetImage()`, and none of the three has
an admin controller, route, view or form request — so the trait's `iconfile()` relation and
`saveUploadedFile()` were dead weight. The trait itself stays: `User` and `Team` still genuinely
upload avatars and team logos.

## Faction was the only one that still rendered from the `File` relation

`CharacterClass` and `CharacterClassSpecialization` already had `ksgAssetImage()`-backed `icon_url`
accessors and nothing anywhere read their `iconfile` — for them this is a pure deletion.

`Faction` needed a real replacement, so it gains an appended `icon_url` accessor (mirroring
`CharacterClass`) and loses `protected $with = ['iconfile']`:

| File | Change |
| --- | --- |
| `app/Models/Faction.php` | `getIconUrlAttribute()` + `$appends`, `$with` removed |
| `app/Logic/MapContext/MapContextStaticData.php` | dropped `->with('iconfile')` |
| `resources/assets/js/custom/mapcontrols/factiondisplaycontrols.js` | `faction.iconfile.icon_url` → `faction.icon_url` |
| `resources/views/common/maps/map.blade.php` | dead handlebars block deleted (see below) |

The appended accessor rather than a plain `getIconUrl()` method is deliberate: unlike `Expansion`
(Blade-only), this value is consumed by **JS** off the serialized map-context payload.

**The 23-line Blade deletion is not as reckless as it looks.** The
`<script id="map_faction_display_controls_template" type="text/x-handlebars-template">` block was a
pre-precompilation leftover — nothing compiles inline `x-handlebars-template` script tags any more
(it was the last one left in all of `resources/views/`). The live template is
`resources/assets/js/handlebars/map_faction_display_controls_template.handlebars`, generated into
`resources/assets/js/handlebars.js` by `scripts/build/handlebars.mjs`, and it already reads
`{{ icon_url }}` off the JS-built `factionsData`. So only the JS needed rewiring.

Removing `$with` changes the serialized shape of *every* `Faction`, not just the map context. A
repo-wide `iconfile` sweep over `app/ resources/ database/ tests/ routes/` found exactly one
non-`User`/non-`Team` consumer (the JS above). The API v1 contract is untouched — not because
`app/Http/Resources/` contains no "Faction" (it does reach one indirectly: `DungeonRoute::$appends`
includes `setup`, and `getSetupAttribute()` returns `'faction' => $this->faction`), but because
`DungeonRouteSummaryResource::toArray()` is an explicit field allowlist with no `setup` in it.
`setup.faction` *does* change shape on the non-API surfaces (ajax datatables, biglist, map inline);
its only consumer is `resources/views/common/handlebars/groupsetup.blade.php`, which reads
`data.faction.key` / `.name`. Each serialized faction loses a nested `{url, icon_url}` object and
gains one string, so payloads get slightly smaller.

**User-visible URL change**: the faction icon now comes from `{ASSETS_BASE_URL}/images/factions/*.png`
instead of `{APP_URL}/storage/images/factions/*.png`, the same move `Expansion` made in #3350.

## The `icon_file_id` columns are deliberately left in place

They stay vestigial (`-1`) on `factions`, `character_classes`, `character_class_specializations` and
`affixes` — so `icon_file_id` stays in `$fillable`/`$hidden`. Dropping them is **#3786**, and it must
land in a *later* release. (Per review, the `@property` docblocks for these columns no longer carry
an explanatory note pointing at #3786 — the issue itself tracks that, so the four models just declare
the bare `@property` line.)

Before this MR, `map.blade.php:267` rendered `$faction->iconfile->icon_url` unguarded, so the
`DELETE FROM files WHERE model_class = Faction::class` half of the Expansion-shaped migration would
have 500'd every The Nexus / Siege of Boralus map page on the still-running old containers during
the deploy window — the #3497 failure mode `.claude/CLAUDE.md`'s expand/contract rule exists to
prevent. As of this MR nothing reads those rows, so #3786 is trivially safe to ship next release.

The four seeders do stop creating the now-dead `File` rows, but keep `'icon_file_id' => -1` (all
four columns are `NOT NULL` with no default). Two freebies fell out of that:

- `CharacterClassSpecializationsSeeder` read `CharacterClassSpecialization::all()` — the **live**
  table, not the `_temp` one the seeder was writing to. That particular read is gone with the loop
  (the seeder still opens with a live-table `CharacterClass::all()`, which is pre-existing and out
  of scope here).
- `AffixSeeder`'s `File` rows have been garbage since #3766: `$affix->image_url` is now a full URL,
  so it was seeding paths like `images/affixes/http://.../afflicted.jpg.jpg`.

Also swept one dangling leftover flagged by step 6 of the issue: `CharacterRace` listed
`icon_file_id` in `$hidden` even though `character_races` has no such column and it never used the
trait.

## Also removed: `Dungeon::isFactionSelectionRequired()`

The deleted Blade block was its only consumer — after this MR a repo-wide sweep returns nothing but
the declaration itself. It reads as live gating logic, so leaving it behind invites the next person
adding faction UI to wire against a method nothing calls. It never agreed with the real gate anyway:
`dungeonmap.js` and `admindungeonmap.js` both check `DUNGEON_THE_NEXUS` only, not Siege of Boralus.

## Update: the `Unspecified` filter is now actually fixed

`MapContextStaticData`'s `Faction::where('name', '<>', 'Unspecified')` filter matched nothing —
`name` holds a translation key (`factions.unspecified`), not the literal string `'Unspecified'`, so
all three factions shipped in the payload both before and (originally) after this MR. Per review,
this is now `Faction::where('key', '<>', Faction::FACTION_UNSPECIFIED)`, matching the pattern the
deleted Blade block used and `MapContextMappingVersion.php:41` still uses. `FactionDisplayControls`
iterates the payload by raw index and assigns the active radio (`fas`) to index 0; with Unspecified
excluded, index 0 is now Horde, which also happens to line up with the "start as Horde visible"
default a few lines below — previously Unspecified rendered as the (visually) selected radio despite
Horde being what was actually toggled on. `MapContextStaticDataTest` gained an assertion pinning
Unspecified's absence from the payload.

Filed rather than fixed: **#3788** — the faction control's `data-faction` is built from the
*translated, lowercased* faction name but compared against a faction *key*, so it only works in
`en_US`. Pre-existing on the live JS path; the now-deleted Blade block happened to hold the correct
`strtolower($faction->key)`, which is how it surfaced.

## Verification

- New tests: `FactionTest` (accessor per faction key + `toArray()` shape), `CharacterClassTest`
  (both class models), and `MapContextStaticDataTest`. The last is the one that actually pins what
  changed: it asserts the **serialized** map-context factions payload carries `icon_url` and no
  `iconfile`, which is precisely the contract `factiondisplaycontrols.js` depends on. (The
  `assertArrayNotHasKey('icon_file_id', ...)` lines are belt-and-braces — `$hidden` already
  guaranteed those on `master`.)
- All four seeders re-run clean against the `NOT NULL` columns (`db:seedone`).
- `composer run fix` (0 files changed) and `composer run analyse` (no errors).
- Full suite green apart from three pre-existing failures that reproduce identically on `master` in
  this worktree, all MDT/Lua-package environment issues:
  `MDTImportStringServiceMDT2AuthoritativeTest`, `MDTNpcMappingCoverageTest`, and
  `ConversionTest` (`vendor/nnoggie/mythicdungeontools/Midnight/KingsRest.lua` missing).

### Visual verification

Admin floor mapping page for The Nexus, which is where `FactionDisplayControls` actually renders
(`dungeonmap.js` only adds it in edit mode for `DUNGEON_THE_NEXUS`). Before, the icons resolve to
`/storage/images/factions/*.png`, which 403s on both the main dev stack and the worktree — those
files only exist in the assets project now. After, they load from the assets host.

### Cold review

Reviewed by a fresh-context agent with no shared context. It independently verified the dead-Blade
claim against `scripts/build/handlebars.mjs`, swept the repo for missed `iconfile` consumers (none
outside `User`/`Team`), confirmed every seeder's remaining `-1` is still reachable given each one's
insert mechanism, and checked the PHPDoc column types against both schema dumps. Its one medium
finding (`isFactionSelectionRequired()` left dangling) and the PHPDoc-placement nit are fixed in
`4c57111cb`; the wording issues it raised are corrected in this body; the locale bug became #3788.

