### PR TITLE
#3790 Fold surplus EMOTE parameters back into the emote text

### DIFF
--- a/app/Logic/CombatLog/SpecialEvents/Emote.php
+++ b/app/Logic/CombatLog/SpecialEvents/Emote.php
@@ -23,9 +23,10 @@ class Emote extends SpecialEvent
 
     /**
      * Skips the four leading fields - each either a quoted string, which may itself contain commas, or an
-     * unquoted one - to recover the emote text from the raw line exactly as it was logged.
+     * unquoted one - to recover the emote text from the raw line exactly as it was logged. Deliberately
+     * without the /s modifier, to match CombatLogEntry's own line regex in never running past a newline.
      */
-    private const string EMOTE_TEXT_REGEX = '/(?:^|\s)EMOTE,(?:(?:"[^"]*"|[^,]*),){4}(.*)$/s';
+    private const string EMOTE_TEXT_REGEX = '/(?:^|\s)EMOTE,(?:(?:"[^"]*"|[^,]*),){4}(.*)$/';
 
     private string $sourceGuid;
 
@@ -79,7 +80,7 @@ class Emote extends SpecialEvent
         $this->sourceName = (string)$foldedParameters[1];
         $this->destGuid   = (string)$foldedParameters[2];
         $this->destName   = (string)$foldedParameters[3];
-        $this->emoteText  = $this->parseEmoteTextFromRawEvent() ?? (string)$foldedParameters[4];
+        $this->emoteText  = $this->resolveEmoteText((string)$foldedParameters[4]);
 
         return $this;
     }
@@ -109,18 +110,26 @@ class Emote extends SpecialEvent
     }
 
     /**
-     * @return string|null Null if the raw event did not have the expected shape, in which case the caller must
-     *                     fall back to the re-joined parameters, which lose any whitespace directly following
-     *                     a comma in the emote text.
+     * Re-joining the folded parameters loses any whitespace that directly followed a comma in the emote text,
+     * so the text is preferably recovered from the raw line instead. That recovery has to find the field
+     * boundaries with a regex, which - unlike CombatLogStringParser - cannot account for escaped quotes, so
+     * it is only trusted when both agree on everything but whitespace. Otherwise the parameters win: losing
+     * a space beats silently returning a differently-delimited string.
+     *
+     * @param string $foldedEmoteText The emote text as recovered from the folded parameters.
      */
-    private function parseEmoteTextFromRawEvent(): ?string
+    private function resolveEmoteText(string $foldedEmoteText): string
     {
         $matches = [];
 
         if (preg_match(self::EMOTE_TEXT_REGEX, $this->getRawEvent(), $matches) !== 1) {
-            return null;
+            return $foldedEmoteText;
         }
 
-        return trim($matches[1]);
+        $rawEmoteText = trim($matches[1]);
+
+        return str_replace(' ', '', $rawEmoteText) === str_replace(' ', '', $foldedEmoteText)
+            ? $rawEmoteText
+            : $foldedEmoteText;
     }
 }

--- a/app/Logic/CombatLog/SpecialEvents/Emote.php
+++ b/app/Logic/CombatLog/SpecialEvents/Emote.php
@@ -6,8 +6,12 @@ use Override;
 
 /**
  * EMOTE,Creature-0-4242-1841-14566-131318-00006285EA,"Elder Leaxa",0000000000000000,nil,|TINTERFACE\ICONS\INV_TikiMan2_Bloodtroll.blp:20|t Elder Leaxa begins to cast |cFFF00000|Hspell:264603|h[Blood Mirror]|h|r
- * This line causes an issue because the entry is not escaped properly and its name contains a comma, doh
+ * The emote text is emitted unquoted, so any comma inside it is indistinguishable from a field separator and
+ * the generic comma split yields more parameters than the event has fields:
  * EMOTE,Creature-0-3019-2519-13090-189340-00005D7992,"Chargath, Bane of Scales",Player-3684-0D90C5CC,"Novakk",|TInterface\Icons\Spell_Nature_Slow.blp:20|tChargath, Bane of Scales targets you with |cFFFF0000|Hspell:373424|h[Grounding Spear]|h|r!
+ * EMOTE,Player-1427-0E8EA11C,"Baifrosth",Player-1427-0E8EA11C,"Baifrosth",Esto es patético, antiguo maestro, ni siquiera ese sucio demonio eredar recibe tantos golpes.
+ * There is no upper bound on the amount of commas the text may contain, so the surplus parameters are folded
+ * back into the emote text rather than the accepted parameter count being widened to fit.
  *
  * @author Wouter
  *
@@ -15,24 +19,108 @@ use Override;
  */
 class Emote extends SpecialEvent
 {
-    #[Override]
+    private const int PARAMETER_COUNT = 5;
+
+    /**
+     * Skips the four leading fields - each either a quoted string, which may itself contain commas, or an
+     * unquoted one - to recover the emote text from the raw line exactly as it was logged.
+     */
+    private const string EMOTE_TEXT_REGEX = '/(?:^|\s)EMOTE,(?:(?:"[^"]*"|[^,]*),){4}(.*)$/s';
+
+    private string $sourceGuid;
+
+    private string $sourceName;
+
+    private string $destGuid;
+
+    private string $destName;
+
+    private string $emoteText;
+
+    public function getSourceGuid(): string
+    {
+        return $this->sourceGuid;
+    }
+
+    public function getSourceName(): string
+    {
+        return $this->sourceName;
+    }
+
+    public function getDestGuid(): string
+    {
+        return $this->destGuid;
+    }
+
+    /**
+     * @return string The name of the target of the emote, or the literal 'nil' if the emote had no target.
+     */
+    public function getDestName(): string
+    {
+        return $this->destName;
+    }
+
+    public function getEmoteText(): string
+    {
+        return $this->emoteText;
+    }
+
     /**
      * @param array<int, mixed> $parameters
      */
+    #[Override]
     public function setParameters(array $parameters): self
     {
-        parent::setParameters($parameters);
+        $foldedParameters = $this->foldSurplusParametersIntoEmoteText($parameters);
+
+        parent::setParameters($foldedParameters);
+
+        $this->sourceGuid = (string)$foldedParameters[0];
+        $this->sourceName = (string)$foldedParameters[1];
+        $this->destGuid   = (string)$foldedParameters[2];
+        $this->destName   = (string)$foldedParameters[3];
+        $this->emoteText  = $this->parseEmoteTextFromRawEvent() ?? (string)$foldedParameters[4];
 
         return $this;
     }
 
-    public function getOptionalParameterCount(): int
-    {
-        return 1;
-    }
-
     public function getParameterCount(): int
     {
-        return 6;
+        return self::PARAMETER_COUNT;
+    }
+
+    /**
+     * The generic comma split cannot know where the unquoted emote text starts, so any parameters beyond the
+     * expected count are surplus pieces of that text - fold them back into one so that the count validates.
+     *
+     * @param  array<int, mixed> $parameters
+     * @return array<int, mixed>
+     */
+    private function foldSurplusParametersIntoEmoteText(array $parameters): array
+    {
+        if (count($parameters) <= self::PARAMETER_COUNT) {
+            return $parameters;
+        }
+
+        return [
+            ...array_slice($parameters, 0, self::PARAMETER_COUNT - 1),
+            implode(',', array_map(strval(...), array_slice($parameters, self::PARAMETER_COUNT - 1))),
+        ];
+    }
+
+    /**
+     * @return string|null Null if the raw event did not have the expected shape, in which case the caller must
+     *                     fall back to the re-joined parameters, which lose any whitespace directly following
+     *                     a comma in the emote text.
+     */
+    private function parseEmoteTextFromRawEvent(): ?string
+    {
+        $matches = [];
+
+        if (preg_match(self::EMOTE_TEXT_REGEX, $this->getRawEvent(), $matches) !== 1) {
+            return null;
+        }
+
+        return trim($matches[1]);
     }
 }

--- a/tests/Unit/App/Logic/CombatLog/SpecialEvents/Emote/EmoteTest.php
+++ b/tests/Unit/App/Logic/CombatLog/SpecialEvents/Emote/EmoteTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Unit\App\Logic\CombatLog\SpecialEvents\Emote;
+
+use App\Logic\CombatLog\CombatLogEntry;
+use App\Logic\CombatLog\CombatLogVersion;
+use App\Logic\CombatLog\SpecialEvents\Emote;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+final class EmoteTest extends PublicTestCase
+{
+    #[Test]
+    #[Group('CombatLog')]
+    #[Group('Emote')]
+    #[DataProvider('parseEvent_givenEmoteEvent_returnsCorrectValues_DataProvider')]
+    public function parseEvent_givenEmoteEvent_returnsCorrectValues(
+        string $emoteEvent,
+        string $expectedSourceGuid,
+        string $expectedSourceName,
+        string $expectedDestGuid,
+        string $expectedDestName,
+        string $expectedEmoteText,
+    ): void {
+        // Arrange
+        $combatLogEntry = new CombatLogEntry($emoteEvent);
+
+        // Act
+        /** @var Emote $result */
+        $result = $combatLogEntry->parseEvent([], CombatLogVersion::RETAIL_12_0_1);
+
+        // Assert
+        Assert::assertInstanceOf(Emote::class, $combatLogEntry->getParsedEvent());
+        Assert::assertEquals($expectedSourceGuid, $result->getSourceGuid());
+        Assert::assertEquals($expectedSourceName, $result->getSourceName());
+        Assert::assertEquals($expectedDestGuid, $result->getDestGuid());
+        Assert::assertEquals($expectedDestName, $result->getDestName());
+        Assert::assertEquals($expectedEmoteText, $result->getEmoteText());
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public static function parseEvent_givenEmoteEvent_returnsCorrectValues_DataProvider(): array
+    {
+        return [
+            // The emote text is unquoted, so every comma in it produces a surplus parameter that must be
+            // folded back into the text - see #3790.
+            'unquoted-text-with-two-commas' => [
+                '7/23/2026 21:16:11.380-5  EMOTE,Player-1427-0E8EA11C,"Baifrosth",Player-1427-0E8EA11C,"Baifrosth",Esto es patético, antiguo maestro, ni siquiera ese sucio demonio eredar recibe tantos golpes.',
+                'Player-1427-0E8EA11C',
+                'Baifrosth',
+                'Player-1427-0E8EA11C',
+                'Baifrosth',
+                'Esto es patético, antiguo maestro, ni siquiera ese sucio demonio eredar recibe tantos golpes.',
+            ],
+            'unquoted-text-with-three-commas' => [
+                '7/23/2026 21:16:12.376-5  EMOTE,Player-1427-0E8EA11C,"Baifrosth",Player-1427-0E8EA11C,"Baifrosth",¡¡¡Atrápenlo, atrápenlo, atrápenlo, atrápenlo!!!',
+                'Player-1427-0E8EA11C',
+                'Baifrosth',
+                'Player-1427-0E8EA11C',
+                'Baifrosth',
+                '¡¡¡Atrápenlo, atrápenlo, atrápenlo, atrápenlo!!!',
+            ],
+            'unquoted-text-without-commas' => [
+                '7/23/2026 21:16:30.882-5  EMOTE,Player-1427-0E8EA11C,"Baifrosth",Player-1427-0E8EA11C,"Baifrosth",Daglop agita la cabeza.',
+                'Player-1427-0E8EA11C',
+                'Baifrosth',
+                'Player-1427-0E8EA11C',
+                'Baifrosth',
+                'Daglop agita la cabeza.',
+            ],
+            'untargeted-emote-with-nil-dest-name' => [
+                '3/25/2026 10:36:28.9051  EMOTE,Creature-0-4242-1841-14566-131318-00006285EA,"Elder Leaxa",0000000000000000,nil,|TINTERFACE\ICONS\INV_TikiMan2_Bloodtroll.blp:20|t Elder Leaxa begins to cast |cFFF00000|Hspell:264603|h[Blood Mirror]|h|r',
+                'Creature-0-4242-1841-14566-131318-00006285EA',
+                'Elder Leaxa',
+                '0000000000000000',
+                'nil',
+                '|TINTERFACE\ICONS\INV_TikiMan2_Bloodtroll.blp:20|t Elder Leaxa begins to cast |cFFF00000|Hspell:264603|h[Blood Mirror]|h|r',
+            ],
+            // A comma inside the quoted source name must not be mistaken for a field separator, and the
+            // bracketed spell link in the text must survive intact.
+            'quoted-source-name-containing-a-comma' => [
+                '3/25/2026 10:16:13.2761  EMOTE,Creature-0-3019-2519-13090-189340-00005D7992,"Chargath, Bane of Scales",Player-3684-0D90C5CC,"Novakk",|TInterface\Icons\Spell_Nature_Slow.blp:20|tChargath, Bane of Scales targets you with |cFFFF0000|Hspell:373424|h[Grounding Spear]|h|r!',
+                'Creature-0-3019-2519-13090-189340-00005D7992',
+                'Chargath, Bane of Scales',
+                'Player-3684-0D90C5CC',
+                'Novakk',
+                '|TInterface\Icons\Spell_Nature_Slow.blp:20|tChargath, Bane of Scales targets you with |cFFFF0000|Hspell:373424|h[Grounding Spear]|h|r!',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/App/Logic/CombatLog/SpecialEvents/Emote/EmoteTest.php
+++ b/tests/Unit/App/Logic/CombatLog/SpecialEvents/Emote/EmoteTest.php
@@ -5,17 +5,20 @@ namespace Tests\Unit\App\Logic\CombatLog\SpecialEvents\Emote;
 use App\Logic\CombatLog\CombatLogEntry;
 use App\Logic\CombatLog\CombatLogVersion;
 use App\Logic\CombatLog\SpecialEvents\Emote;
+use App\Logic\CombatLog\SpecialEvents\SpecialEvent;
+use Illuminate\Support\Carbon;
+use InvalidArgumentException;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
 
+#[Group('CombatLog')]
+#[Group('Emote')]
 final class EmoteTest extends PublicTestCase
 {
     #[Test]
-    #[Group('CombatLog')]
-    #[Group('Emote')]
     #[DataProvider('parseEvent_givenEmoteEvent_returnsCorrectValues_DataProvider')]
     public function parseEvent_givenEmoteEvent_returnsCorrectValues(
         string $emoteEvent,
@@ -33,7 +36,8 @@ final class EmoteTest extends PublicTestCase
         $result = $combatLogEntry->parseEvent([], CombatLogVersion::RETAIL_12_0_1);
 
         // Assert
-        Assert::assertInstanceOf(Emote::class, $combatLogEntry->getParsedEvent());
+        Assert::assertInstanceOf(Emote::class, $result);
+        Assert::assertSame($result, $combatLogEntry->getParsedEvent());
         Assert::assertEquals($expectedSourceGuid, $result->getSourceGuid());
         Assert::assertEquals($expectedSourceName, $result->getSourceName());
         Assert::assertEquals($expectedDestGuid, $result->getDestGuid());
@@ -91,6 +95,46 @@ final class EmoteTest extends PublicTestCase
                 'Novakk',
                 '|TInterface\Icons\Spell_Nature_Slow.blp:20|tChargath, Bane of Scales targets you with |cFFFF0000|Hspell:373424|h[Grounding Spear]|h|r!',
             ],
+            // A quoted emote text is split as a single parameter, so it must be unquoted like any other field
+            // rather than kept verbatim from the raw line.
+            'fully-quoted-emote-text' => [
+                '3/25/2026 10:16:13.2761  EMOTE,Player-1427-0E8EA11C,"Baifrosth",Player-1427-0E8EA11C,"Baifrosth","Esto es patético, antiguo maestro."',
+                'Player-1427-0E8EA11C',
+                'Baifrosth',
+                'Player-1427-0E8EA11C',
+                'Baifrosth',
+                'Esto es patético, antiguo maestro.',
+            ],
+            // An escaped quote inside a name is understood by CombatLogStringParser but not by the regex that
+            // recovers the text from the raw line, so the two disagree and the parameters must win - at the
+            // cost of the space that followed the comma.
+            'escaped-quote-in-source-name-falls-back-to-parameters' => [
+                '3/25/2026 10:16:13.2761  EMOTE,Creature-0-3019-2519-13090-189340-00005D7992,"Na\"me, X",Player-3684-0D90C5CC,"Novakk",Hello, there',
+                'Creature-0-3019-2519-13090-189340-00005D7992',
+                'Na\"me, X',
+                'Player-3684-0D90C5CC',
+                'Novakk',
+                'Hello,there',
+            ],
         ];
+    }
+
+    #[Test]
+    public function setParameters_givenFewerParametersThanTheEventHasFields_throwsInvalidArgumentException(): void
+    {
+        // Arrange
+        $rawEvent = '3/25/2026 10:16:13.2761  EMOTE,Player-1427-0E8EA11C,"Baifrosth",Player-1427-0E8EA11C';
+
+        // Assert
+        $this->expectException(InvalidArgumentException::class);
+
+        // Act
+        new Emote(
+            CombatLogVersion::RETAIL_12_0_1,
+            Carbon::parse('2026-03-25 10:16:13'),
+            SpecialEvent::SPECIAL_EVENT_EMOTE,
+            ['Player-1427-0E8EA11C', 'Baifrosth', 'Player-1427-0E8EA11C'],
+            $rawEvent,
+        );
     }
 }


### PR DESCRIPTION
:robot: Closes #3790

## Problem

`EMOTE` emits its emote text **unquoted**, so every comma inside the text is
indistinguishable from a field separator to the generic comma split. The count
was previously widened to `6` with `1` optional, which absorbs exactly one comma
and no more — the Staging failure has two:

```
Invalid parameter count for App\Logic\CombatLog\SpecialEvents\Emote - wanted 6, got 7
7/23/2026 21:16:11.380-5  EMOTE,Player-1427-0E8EA11C,"Baifrosth",Player-1427-0E8EA11C,"Baifrosth",Esto es patético, antiguo maestro, ni siquiera ese sucio demonio eredar recibe tantos golpes.
```

There is no upper bound on the amount of commas an emote may contain, so raising
the limit again would only move the failure rather than remove it.

## Fix

`Emote` now folds every parameter past the fourth field back into a single one
before the count is validated. Re-joining those parameters loses the whitespace
that directly followed each comma, so the text is preferably recovered from the
raw line instead — but that recovery has to find the field boundaries with a
regex, which (unlike `CombatLogStringParser`) cannot account for escaped quotes.
It is therefore trusted **only when both agree on everything but whitespace**;
otherwise the parameters win. Losing a space beats silently returning a
differently-delimited string, and it keeps the parameter path load-bearing
rather than unreachable.

The accepted parameter count goes `6` (1 optional) → `5` (0 optional). The
**minimum is unchanged at 5**, so no line that parsed before stops parsing.

Source/dest GUID and name are exposed as getters alongside `getEmoteText()` —
nothing consumed `Emote` before, and without them the fix is only assertable as
"did not throw". `CombatLogStringParser` is deliberately untouched: an unquoted
trailing-text mode there would change behaviour for every event type, and this
is EMOTE-specific.

## Verification against real Staging data

Segments pulled for run `41076792` (the run behind failure row `id=743`) per the
`combatlog-parse-failure-triage` skill and re-parsed with
`parseCombatLogToEvents()`:

| | before | after |
|---|---|---|
| segments parsed OK | 8 / 9 | **9 / 9** |
| events | 240,084 | **309,968** |
| failures | 1 (`01_trash.txt` line 10802) | **0** |

All 14 EMOTE lines in the run now parse, and each reconstructed
`getEmoteText()` matches its raw line verbatim — including the three
`|TInterface\...|Hspell:...|h[...]|h|r` creature emotes with a `nil` dest name.

The cluster is a single row, so **the skill's "reproduce against two distinct
failing runs" step could not be met** — no second failing run exists. As a
broader regression check the segments for run `41910839` (from #3791, a
different cluster) were parsed too: 446,111 events, 0 failures. That run
contains no EMOTE lines, so it exercises the change only as a no-regression
check, not as a second reproduction.

## Tests

New `EmoteTest` data provider covers the discriminating cases: the #3790 line
(2 commas), a 3-comma variant, a comma-free emote, the untargeted `nil`
dest-name form, the quoted source name containing a comma
(`"Chargath, Bane of Scales"`), a fully quoted emote text, and an escaped quote
in a name that forces the parameter fallback — asserting the reconstructed text,
not merely that parsing succeeded. A separate test pins the below-minimum
boundary still throwing.

- `EmoteTest` — 8 passed (50 assertions)
- `--group=CombatLog` — 221 passed (1077 assertions)
- `composer run fix` / `composer run analyse` — clean

Note this MR does **not** mark failure row `id=743` resolved; per the triage
skill that needs an explicit go-ahead and should follow the fix actually
shipping.
