### PR TITLE
Pin ext-lua and cli_weakauras_parser CI builds to commit SHAs

### DIFF
--- a/.github/actions/php-ci-setup/action.yml
+++ b/.github/actions/php-ci-setup/action.yml
@@ -10,6 +10,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Pinned commits for third-party toolchain repos with no tagged releases. Bump these
+    # deliberately (not via unpinned HEAD) when an upstream fix/feature is needed - the pin is
+    # baked into the cache keys below so a bump busts the cache correctly.
+    - name: Pin toolchain commit SHAs
+      id: pins
+      run: |
+        echo "php-lua-sha=a76f01149e6132810fe6b3095f2b9bc597d34f9e" >> "$GITHUB_OUTPUT"
+        echo "cli-weakauras-parser-sha=febb57faeaa805a79c9c2e0425c804e441a0e969" >> "$GITHUB_OUTPUT"
+      shell: bash
     - name: Checkout
       uses: actions/checkout@v5
       with:
@@ -47,14 +56,14 @@ runs:
       shell: bash
 
     # Cache the compiled lua.so / bit.so so we skip the ~30-40s phpize/configure/make on every run
-    # (paid per shard once the test job is sharded). Bump the trailing "-v1" to bust the cache if the
-    # Wotuu/php-lua repo (built from HEAD, unpinned) changes and a rebuild is needed.
+    # (paid per shard once the test job is sharded). The pinned php-lua SHA is part of the key so
+    # bumping it above busts the cache and triggers a rebuild.
     - name: Restore Lua extension build cache
       id: cache-lua-ext
       uses: actions/cache@v5
       with:
         path: ~/lua-ext-cache
-        key: lua-ext-php8.4-${{ hashFiles('storage/lua/LuaBitOp-1.0.3.zip') }}-v1
+        key: lua-ext-php8.4-${{ hashFiles('storage/lua/LuaBitOp-1.0.3.zip') }}-${{ steps.pins.outputs.php-lua-sha }}
 
     - name: Build PHP Lua extension
       run: |
@@ -75,6 +84,7 @@ runs:
           echo "==> Building Lua extension from source"
           git clone https://github.com/Wotuu/php-lua.git /tmp/php-lua
           cd /tmp/php-lua
+          git checkout "${{ steps.pins.outputs.php-lua-sha }}"
           phpize
           ./configure
           make -j$(nproc)
@@ -98,14 +108,14 @@ runs:
       uses: actions/cache@v5
       with:
         path: ~/.cargo/bin/cli_weakauras_parser
-        key: cli-weakauras-parser-rust-1.91.1
+        key: cli-weakauras-parser-rust-1.91.1-${{ steps.pins.outputs.cli-weakauras-parser-sha }}
 
     - name: Build cli_weakauras_parser
       if: steps.cache-cli-weakauras-parser.outputs.cache-hit != 'true'
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.91.1 -y
         source "$HOME/.cargo/env"
-        cargo install --git https://codeberg.org/Velithris/cli-weakauras-parser.git --locked
+        cargo install --git https://codeberg.org/Velithris/cli-weakauras-parser.git --rev "${{ steps.pins.outputs.cli-weakauras-parser-sha }}" --locked
       shell: bash
 
     - name: Install cli_weakauras_parser system-wide

--- a/.github/actions/php-ci-setup/action.yml
+++ b/.github/actions/php-ci-setup/action.yml
@@ -10,14 +10,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Pinned commits for third-party toolchain repos with no tagged releases. Bump these
+    # Pinned commits for third-party toolchain repos built straight from git. Bump these
     # deliberately (not via unpinned HEAD) when an upstream fix/feature is needed - the pin is
-    # baked into the cache keys below so a bump busts the cache correctly.
+    # baked into the cache keys below so a bump busts the cache correctly. php-lua has no tagged
+    # releases; cli-weakauras-parser does (the pin below is refs/tags/v0.1.8) but tags are mutable
+    # so the commit SHA is still pinned explicitly rather than the tag name.
     - name: Pin toolchain commit SHAs
       id: pins
       run: |
         echo "php-lua-sha=a76f01149e6132810fe6b3095f2b9bc597d34f9e" >> "$GITHUB_OUTPUT"
-        echo "cli-weakauras-parser-sha=febb57faeaa805a79c9c2e0425c804e441a0e969" >> "$GITHUB_OUTPUT"
+        echo "cli-weakauras-parser-sha=febb57faeaa805a79c9c2e0425c804e441a0e969" >> "$GITHUB_OUTPUT" # = v0.1.8
+        echo "rust-toolchain=1.91.1" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Checkout
       uses: actions/checkout@v5
@@ -108,12 +111,12 @@ runs:
       uses: actions/cache@v5
       with:
         path: ~/.cargo/bin/cli_weakauras_parser
-        key: cli-weakauras-parser-rust-1.91.1-${{ steps.pins.outputs.cli-weakauras-parser-sha }}
+        key: cli-weakauras-parser-rust-${{ steps.pins.outputs.rust-toolchain }}-${{ steps.pins.outputs.cli-weakauras-parser-sha }}
 
     - name: Build cli_weakauras_parser
       if: steps.cache-cli-weakauras-parser.outputs.cache-hit != 'true'
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.91.1 -y
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain "${{ steps.pins.outputs.rust-toolchain }}" -y
         source "$HOME/.cargo/env"
         cargo install --git https://codeberg.org/Velithris/cli-weakauras-parser.git --rev "${{ steps.pins.outputs.cli-weakauras-parser-sha }}" --locked
       shell: bash

--- a/docker-compose/app/Dockerfile
+++ b/docker-compose/app/Dockerfile
@@ -6,7 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 RUN cargo --version && rustc --version
-RUN cargo install --git https://codeberg.org/Velithris/cli-weakauras-parser.git --locked
+# Pinned to the same commit as .github/actions/php-ci-setup/action.yml (= v0.1.8) so CI and this
+# image stay in lockstep - see #3802.
+RUN cargo install --git https://codeberg.org/Velithris/cli-weakauras-parser.git --rev febb57faeaa805a79c9c2e0425c804e441a0e969 --locked
 
 ### ---- PHP extension builder ----
 # Compiles every PHP extension (and the Lua modules) with the full toolchain and
@@ -40,10 +42,12 @@ RUN ln -s /usr/include/lua5.3/ /usr/include/lua \
  && ln /usr/include/lua5.3/lua.h /usr/include/lua.h || true \
  && ln /usr/include/lua5.3/lua.h /usr/include/luaconf.h || true
 
-# Build & enable the PHP Lua extension
+# Build & enable the PHP Lua extension. Pinned to the same commit as
+# .github/actions/php-ci-setup/action.yml so CI and this image stay in lockstep - see #3802.
 RUN mkdir -p /tmp/php-lua \
  && cd /tmp/php-lua \
  && git clone https://github.com/Wotuu/php-lua.git . \
+ && git checkout a76f01149e6132810fe6b3095f2b9bc597d34f9e \
  && phpize \
  && ./configure \
  && make -j"$(nproc)" \


### PR DESCRIPTION
:robot: Closes #3802

## Summary
- `.github/actions/php-ci-setup/action.yml` built `Wotuu/php-lua` and `codeberg.org/Velithris/cli-weakauras-parser` from unpinned HEAD — an upstream commit to either repo could turn CI red across every PR with no change on this side, and since both builds are cache-hidden the failure would surface late and look uncorrelated with the actual cause.
- Pin both to explicit commit SHAs (`a76f01149e6132810fe6b3095f2b9bc597d34f9e` for php-lua, `febb57faeaa805a79c9c2e0425c804e441a0e969` for cli_weakauras_parser), matching the existing `composer.json` convention of pinning `reference` SHAs for the `nnoggie/mythicdungeontools`/`mdt-legacy` packages.
- Fold both pins into their respective `actions/cache@v5` keys so a deliberate bump busts the cache and triggers a rebuild.

## Test plan
- [ ] `php-tests` CI run goes green from a cold cache (new cache keys guarantee this on first run of this PR)