### PR TITLE
#3806 Route /ajax/ errors to JSON instead of crashing HTML error views

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -97,28 +97,50 @@ class Handler extends ExceptionHandler
     #[Override]
     public function render($request, Throwable $e)
     {
-        if ($request->isJson() || $this->isApiRequest($request)) {
-            if ($e instanceof ModelNotFoundException) {
+        if ($this->shouldReturnJson($request, $e)) {
+            if ($e instanceof ValidationException) {
+                // ValidationException doesn't render an HTML error view (parent::render() either
+                // returns JSON or redirects back with flashed session errors, per
+                // shouldReturnJson() below), so it was never part of the #3806 crash class - leave
+                // its normal expectsJson()-driven behavior alone rather than forcing JSON, since
+                // some /ajax/ forms rely on the redirect+flash for a non-JSON request.
+                return parent::render($request, $e);
+            } elseif ($e instanceof ModelNotFoundException) {
                 return response()->json([
                     'message' => __('exceptions.handler.api_model_not_found', [
                         'ids'   => implode(', ', $e->getIds()),
                         'model' => $e->getModel(),
                     ]),
                 ], StatusCode::NOT_FOUND);
-            } elseif ($e instanceof NotFoundHttpException) {
+            }
+
+            // Normalize the same way parent::render() would (AuthorizationException -> 403,
+            // TokenMismatchException -> 419, ...) before the instanceof checks below, so a
+            // forced-JSON /ajax/ request (which isn't necessarily an HttpException already) gets
+            // the exception's real status instead of collapsing into the generic 500 tail.
+            $normalized = $this->prepareException($this->mapException($e));
+
+            if ($normalized instanceof NotFoundHttpException) {
                 return response()->json(['message' => __('exceptions.handler.api_route_not_found')], StatusCode::NOT_FOUND);
-            } elseif ($e instanceof ThrottleRequestsException) {
+            } elseif ($normalized instanceof ThrottleRequestsException) {
                 return response()->json(['message' => __('exceptions.handler.too_many_requests')], RFC6585::TOO_MANY_REQUESTS);
-            } elseif ($e instanceof HttpExceptionInterface) {
-                // Preserve the real HTTP status (e.g. 405 Method Not Allowed) and any headers (such as
-                // the Allow header on a 405) instead of collapsing every remaining HttpException to a 500.
-                $statusCode = $e->getStatusCode();
+            } elseif ($normalized instanceof MethodNotAllowedHttpException) {
+                // The router's own message here is a verbose "The GET method is not supported for
+                // route ...", not meant for API consumers - use the plain status text instead, but
+                // still preserve the Allow header.
+                $statusCode = $normalized->getStatusCode();
 
                 return response()->json(
                     ['message' => SymfonyResponse::$statusTexts[$statusCode] ?? __('exceptions.handler.internal_server_error')],
                     $statusCode,
-                    $e->getHeaders(),
+                    $normalized->getHeaders(),
                 );
+            } elseif ($normalized instanceof HttpExceptionInterface) {
+                // Any other HttpException (e.g. a policy denial normalized above, or a deliberate
+                // abort($status, $message) elsewhere in the app) carries a message meant to be shown
+                // to the caller - delegate to parent::render() so it's preserved verbatim instead of
+                // being collapsed into a generic status text.
+                return parent::render($request, $e);
             } elseif (!config('app.debug')) {
                 return response()->json(['message' => __('exceptions.handler.internal_server_error')], StatusCode::INTERNAL_SERVER_ERROR);
             } elseif (config('app.type') !== 'local') {
@@ -138,7 +160,7 @@ class Handler extends ExceptionHandler
     #[Override]
     protected function unauthenticated($request, AuthenticationException $exception)
     {
-        if ($request->isJson() || $this->isApiRequest($request)) {
+        if ($this->shouldReturnJson($request, $exception)) {
             return response()->json(['error' => __('exceptions.handler.unauthenticated')], StatusCode::UNAUTHORIZED);
         }
 
@@ -150,10 +172,24 @@ class Handler extends ExceptionHandler
      * ViewService::shouldLoadViewVariables()) - not even for the handful of /ajax/ routes
      * whitelisted there to deliberately render an HTML fragment on success (search/view). So an
      * HTML error view rendered for ANY /ajax/ request is guaranteed to crash on a missing view
-     * variable (#3806); route every /ajax/ error to JSON instead, matching how /api/ is already
-     * treated here. This is shared with unauthenticated() below, so an unauthenticated /ajax/
-     * request now gets a JSON 401 instead of a redirect to the login page too.
+     * variable (#3806). Force JSON for every /ajax/ error (matching how /api/ is already treated
+     * here) except ValidationException, which render() above already carves out since it never
+     * renders an HTML error view in the first place.
      */
+    #[Override]
+    protected function shouldReturnJson($request, Throwable $e): bool
+    {
+        if ($request->isJson()) {
+            return true;
+        }
+
+        if ($e instanceof ValidationException) {
+            return parent::shouldReturnJson($request, $e);
+        }
+
+        return $this->isApiRequest($request) || parent::shouldReturnJson($request, $e);
+    }
+
     private function isApiRequest(Request $request): bool
     {
         $path = $request->decodedPath();

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -145,9 +145,19 @@ class Handler extends ExceptionHandler
         return redirect()->guest('login');
     }
 
+    /**
+     * /ajax/ endpoints only ever render HTML in their success responses (some deliberately, e.g.
+     * the search/view routes whitelisted in ViewService::VIEW_VARIABLES_URL_WHITELIST); no view
+     * composers run for them otherwise (KeystoneGuruServiceProvider::boot(), gated by
+     * ViewService::shouldLoadViewVariables()), so an HTML error view rendered for one of them is
+     * guaranteed to crash on a missing view variable (#3806). Route every /ajax/ error to JSON,
+     * matching how /api/ is already treated here.
+     */
     private function isApiRequest(Request $request): bool
     {
-        return str_starts_with($request->decodedPath(), 'api/');
+        $path = $request->decodedPath();
+
+        return str_starts_with($path, 'api/') || str_starts_with($path, 'ajax/');
     }
 
     /**

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -146,12 +146,13 @@ class Handler extends ExceptionHandler
     }
 
     /**
-     * /ajax/ endpoints only ever render HTML in their success responses (some deliberately, e.g.
-     * the search/view routes whitelisted in ViewService::VIEW_VARIABLES_URL_WHITELIST); no view
-     * composers run for them otherwise (KeystoneGuruServiceProvider::boot(), gated by
-     * ViewService::shouldLoadViewVariables()), so an HTML error view rendered for one of them is
-     * guaranteed to crash on a missing view variable (#3806). Route every /ajax/ error to JSON,
-     * matching how /api/ is already treated here.
+     * No view composers run on /ajax/ (KeystoneGuruServiceProvider::boot(), gated by
+     * ViewService::shouldLoadViewVariables()) - not even for the handful of /ajax/ routes
+     * whitelisted there to deliberately render an HTML fragment on success (search/view). So an
+     * HTML error view rendered for ANY /ajax/ request is guaranteed to crash on a missing view
+     * variable (#3806); route every /ajax/ error to JSON instead, matching how /api/ is already
+     * treated here. This is shared with unauthenticated() below, so an unauthenticated /ajax/
+     * request now gets a JSON 401 instead of a redirect to the login page too.
      */
     private function isApiRequest(Request $request): bool
     {

--- a/resources/views/common/layout/header.blade.php
+++ b/resources/views/common/layout/header.blade.php
@@ -26,11 +26,15 @@ use Illuminate\Support\Str;
  * @var Collection<string, string>   $dungeonContextLinks
  */
 
-$navs                = [];
-$showMore            ??= false;
-$showDungeonContext  ??= true;
-$forceShrink         ??= false;
-$dungeonContextLinks ??= null;
+$navs                   = [];
+$showMore               ??= false;
+$showDungeonContext     ??= true;
+$forceShrink            ??= false;
+$dungeonContextLinks    ??= null;
+// Defense in depth for #3806 - GlobalComposer normally supplies this, but view composers are
+// skipped entirely on paths ViewService::shouldLoadViewVariables() blacklists (e.g. /ajax/),
+// so an HTML error view rendered for one of those paths would otherwise crash here.
+$currentUserGameVersion ??= GameVersion::getUserOrDefaultGameVersion();
 
 if ($currentUserGameVersion->key === GameVersion::GAME_VERSION_RETAIL) {
     if ($nextSeason !== null) {

--- a/tests/Feature/Controller/ErrorResponseTest.php
+++ b/tests/Feature/Controller/ErrorResponseTest.php
@@ -11,15 +11,17 @@ use Tests\TestCases\PublicTestCase;
 final class ErrorResponseTest extends PublicTestCase
 {
     #[Test]
-    public function fallback_givenGetRequestToDeleteOnlyRoute_returns405HtmlPage(): void
+    public function fallback_givenGetRequestToDeleteOnlyAjaxRoute_returns405Json(): void
     {
-        // Act - /ajax/profile/adfree/{user} is registered for POST and DELETE, but not GET
+        // Act - /ajax/profile/adfree/{user} is registered for POST and DELETE, but not GET. No view
+        // composers ever run on /ajax/ (ViewService::shouldLoadViewVariables()), so this must never
+        // render an HTML error view - it would crash on a missing view variable (#3806).
         $response = $this->get('/ajax/profile/adfree/1');
 
         // Assert
         $response->assertStatus(405);
         $response->assertHeader('Allow', 'POST, DELETE');
-        $response->assertSee(__('view_errors.405.title'));
+        $response->assertJson(['message' => 'Method Not Allowed']);
     }
 
     #[Test]

--- a/tests/Feature/Controller/ErrorResponseTest.php
+++ b/tests/Feature/Controller/ErrorResponseTest.php
@@ -59,6 +59,17 @@ final class ErrorResponseTest extends PublicTestCase
     }
 
     #[Test]
+    public function fallback_givenPlainGetRequestToUnmatchedAjaxRoute_returns404Json(): void
+    {
+        // Act - a plain (non-JSON, non-XHR) request is exactly the crawler shape from #3806
+        $response = $this->get('/ajax/this/route/does/not/exist/xyz');
+
+        // Assert
+        $response->assertStatus(404);
+        $response->assertJson(['message' => __('exceptions.handler.api_route_not_found')]);
+    }
+
+    #[Test]
     public function render_givenJsonWrongMethodToExistingRoute_returns405JsonWithAllowHeader(): void
     {
         // Act - the home page is GET only, so a POST is a genuine method mismatch thrown by the router


### PR DESCRIPTION
:robot: Closes #3806

## Summary
- `/ajax/` requests never get view composers registered (`ViewService::shouldLoadViewVariables()` blacklists them), but `Handler::render()` only routed `/api/` and explicit JSON requests to the JSON error branch — so any HTML error view rendered for an `/ajax/` request (e.g. a crawler GET to a POST-only route → 405) crashed on the resulting undefined view variables. This was the highest-volume unresolved Sentry issue in production (PHP-LARAVEL-54, 3k+ occurrences).
- Fix direction 1 from the issue: cover `/ajax/` in `Handler::isApiRequest()` so its errors always render JSON, matching how `/ajax/` already behaves in the success case.
- Fix direction 2 from the issue (defense in depth): `header.blade.php` now falls back `$currentUserGameVersion ??= GameVersion::getUserOrDefaultGameVersion();`, mirroring the existing pattern in `home/sections/featured.blade.php`.
- Updated `ErrorResponseTest` — the existing `fallback_givenGetRequestToDeleteOnlyRoute_returns405HtmlPage` test encoded the buggy behavior (a plain GET to an `/ajax/` POST-only route returning an HTML 405 page); it now asserts the JSON response instead.

Fix direction 3 (registering `GlobalComposer` unconditionally) was not taken — it re-opens the performance concern #2767 was closing, and isn't needed once `/ajax/` errors never try to render HTML at all.

## Test plan
- [x] `php artisan test --compact tests/Feature/Controller/ErrorResponseTest.php` — 5 passed
- [x] `composer run fix` — no changes
- [x] `composer run analyse` — no errors
- [x] Reproduced the exact issue scenario against the running worktree stack:
  ```
  curl -A "Mozilla/5.0 (compatible; bingbot)" -H "Accept: text/html,application/xhtml+xml" http://localhost:8102/ajax/heatmap/data
  → 405 {"message":"Method Not Allowed"}
  ```