### PR TITLE
Fix faction display control filtering only working in en_US

### DIFF
--- a/resources/assets/js/custom/mapcontrols/factiondisplaycontrols.js
+++ b/resources/assets/js/custom/mapcontrols/factiondisplaycontrols.js
@@ -10,19 +10,8 @@ class FactionDisplayControls extends MapControl {
             onAdd: function (leafletMap) {
                 let template = Handlebars.templates['map_faction_display_controls_template'];
 
-                let factionsData = [];
                 let stateFactions = getState().getMapContext().getStaticFactions();
-                for (let index in stateFactions) {
-                    if (stateFactions.hasOwnProperty(index)) {
-                        let faction = stateFactions[index];
-                        factionsData.push({
-                            name: lang.get(faction.name),
-                            name_lc: lang.get(faction.name).toLowerCase(),
-                            icon_url: faction.icon_url,
-                            fa_class: parseInt(index) === 0 ? 'fas' : 'far'
-                        });
-                    }
-                }
+                let factionsData = self._buildFactionsData(stateFactions);
 
                 let data = $.extend({}, getHandlebarsDefaultVariables(), {factions: factionsData});
 
@@ -65,6 +54,31 @@ class FactionDisplayControls extends MapControl {
             self._visibilityToggled('horde', true);
             self._visibilityToggled('alliance', false);
         });
+    }
+
+    /**
+     * Builds the per-faction data passed to the Handlebars template.
+     * @param stateFactions
+     * @return {Array}
+     * @private
+     */
+    _buildFactionsData(stateFactions) {
+        console.assert(this instanceof FactionDisplayControls, 'this is not FactionDisplayControls', this);
+
+        let factionsData = [];
+        for (let index in stateFactions) {
+            if (stateFactions.hasOwnProperty(index)) {
+                let faction = stateFactions[index];
+                factionsData.push({
+                    name: lang.get(faction.name),
+                    key: faction.key,
+                    icon_url: faction.icon_url,
+                    fa_class: parseInt(index) === 0 ? 'fas' : 'far'
+                });
+            }
+        }
+
+        return factionsData;
     }
 
     /**
@@ -117,4 +131,8 @@ class FactionDisplayControls extends MapControl {
 
         this.map.unregister('map:mapobjectgroupsloaded', this);
     }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = FactionDisplayControls;
 }

--- a/resources/assets/js/custom/mapcontrols/factiondisplaycontrols.test.js
+++ b/resources/assets/js/custom/mapcontrols/factiondisplaycontrols.test.js
@@ -1,0 +1,51 @@
+// FactionDisplayControls is a global-script class extending MapControl (another global-script
+// class). Stub that at module-load time and exercise _buildFactionsData on a bare prototype
+// instance (Object.create), same recipe as enemyforcesmanager.test.js.
+
+global.MapControl = class MapControl {
+    constructor(map) {
+        this.map = map;
+    }
+};
+
+// A non-en_US locale where the translated faction name does not match the faction key (in this
+// project's real de_DE/es_ES/ru_RU lang files these translations are currently empty strings).
+global.lang = {
+    get: (key) => ({
+        'factions.horde': 'Nicht Horde',
+        'factions.alliance': 'Nicht Allianz',
+    }[key] ?? ''),
+};
+
+const FactionDisplayControls = require('./factiondisplaycontrols');
+
+function createControls() {
+    return Object.create(FactionDisplayControls.prototype);
+}
+
+describe('FactionDisplayControls._buildFactionsData', () => {
+    it('_buildFactionsData_givenFactions_usesFactionKeyNotTranslatedName', () => {
+        const controls = createControls();
+
+        const result = controls._buildFactionsData([
+            {name: 'factions.horde', key: 'horde', icon_url: 'horde.png'},
+            {name: 'factions.alliance', key: 'alliance', icon_url: 'alliance.png'},
+        ]);
+
+        // Before the fix, `key` was derived from `lang.get(faction.name).toLowerCase()` - here
+        // that would yield 'nicht horde' / 'nicht allianz', which never matches the
+        // `mapObject.faction` values ('horde'/'alliance') the click handler compares against.
+        expect(result.map((faction) => faction.key)).toEqual(['horde', 'alliance']);
+    });
+
+    it('_buildFactionsData_givenTranslationDoesNotMatchKey_stillReturnsTheKey', () => {
+        const controls = createControls();
+
+        const result = controls._buildFactionsData([
+            {name: 'factions.horde', key: 'horde', icon_url: 'horde.png'},
+        ]);
+
+        expect(result[0].key).toBe('horde');
+        expect(result[0].name).toBe('Nicht Horde');
+    });
+});

--- a/resources/assets/js/handlebars/map_faction_display_controls_template.handlebars
+++ b/resources/assets/js/handlebars/map_faction_display_controls_template.handlebars
@@ -2,7 +2,7 @@
     <div class="leaflet-draw-toolbar leaflet-bar leaflet-draw-toolbar-top">
         {{#factions}}
             <a class="map_faction_display_control map_controls_custom" href="#"
-               data-faction="{{ name_lc }}" title="{{ name }}">
+               data-faction="{{ key }}" title="{{ name }}">
                 <i class="{{ fa_class }} fa-circle radiobutton" style="width: 15px"></i>
                 <img src="{{ icon_url }}" class="select_icon faction_icon"
                      data-bs-toggle="tooltip" title="{{ name }}"/>


### PR DESCRIPTION
:robot: Closes #3788

## Summary
- `factiondisplaycontrols.js` built the faction data passed to the map control's Handlebars
  template with `name_lc` derived from `lang.get(faction.name).toLowerCase()` — the *translated*
  faction name — while the click handler compares that value against `mapObject.faction`, which
  holds the faction **key** (`horde`/`alliance`). This only worked in `en_US` by coincidence
  (`lang.get('factions.horde')` happens to equal `'horde'` lowercased); in other locales the
  faction translations are empty strings, so the filter silently matched nothing.
- Extracted the per-faction data transform into `FactionDisplayControls._buildFactionsData()` and
  changed it to use `faction.key` directly, renaming `name_lc` to `key` throughout (JS + the
  handlebars template's `data-faction` attribute), per the issue's suggested fix.

## Test plan
- [x] Added `factiondisplaycontrols.test.js`, asserting `_buildFactionsData` uses the faction key
  even when the mocked translation differs from it (simulating a non-en_US locale) — this test
  would have failed before the fix.
- [x] `npx vitest run` — all 352 JS tests pass.