### PR TITLE
#3789 Stop a failed segment download from being parsed as a combat log

### DIFF
--- a/app/Jobs/CombatLog/ProcessCombatLogSegments.php
+++ b/app/Jobs/CombatLog/ProcessCombatLogSegments.php
@@ -94,6 +94,14 @@ class ProcessCombatLogSegments implements ShouldBeUnique, ShouldQueue
                 }
 
                 $tempFiles[] = $tempPath;
+
+                if ($this->isErrorDocument($tempPath)) {
+                    $log->handleSegmentIsErrorDocument($this->runId, $segment->id, $tempPath);
+
+                    throw new RuntimeException(
+                        sprintf('Downloaded segment %d for run %d is not a combat log', $segment->id, $this->runId),
+                    );
+                }
             }
 
             foreach ($tempFiles as $tempFile) {
@@ -142,6 +150,21 @@ class ProcessCombatLogSegments implements ShouldBeUnique, ShouldQueue
         $path = (string)parse_url($downloadUrl, PHP_URL_PATH);
 
         return str_ends_with($path, '.zip') ? 'zip' : 'txt';
+    }
+
+    /**
+     * A second line of defence against a storage error response reaching the parser: `curlSaveToFile()` already
+     * rejects a non-2xx download, but a proxy or CDN in front of S3 may hand back an error document with a 200.
+     * Neither a combat log (a timestamp) nor a zip archive (`PK`) can start with `<`, so an opening angle bracket
+     * means an XML or HTML document rather than the segment we asked for (see #3789).
+     */
+    private function isErrorDocument(string $filePath): bool
+    {
+        if (!is_file($filePath)) {
+            return false;
+        }
+
+        return file_get_contents($filePath, length: 1) === '<';
     }
 
     /**

--- a/app/Jobs/CombatLog/ProcessCombatLogSegments.php
+++ b/app/Jobs/CombatLog/ProcessCombatLogSegments.php
@@ -95,8 +95,8 @@ class ProcessCombatLogSegments implements ShouldBeUnique, ShouldQueue
 
                 $tempFiles[] = $tempPath;
 
-                if ($this->isErrorDocument($tempPath)) {
-                    $log->handleSegmentIsErrorDocument($this->runId, $segment->id, $tempPath);
+                if (!$this->isPlausibleSegment($tempPath)) {
+                    $log->handleSegmentIsNotACombatLog($this->runId, $segment->id, $tempPath);
 
                     throw new RuntimeException(
                         sprintf('Downloaded segment %d for run %d is not a combat log', $segment->id, $this->runId),
@@ -153,18 +153,22 @@ class ProcessCombatLogSegments implements ShouldBeUnique, ShouldQueue
     }
 
     /**
-     * A second line of defence against a storage error response reaching the parser: `curlSaveToFile()` already
-     * rejects a non-2xx download, but a proxy or CDN in front of S3 may hand back an error document with a 200.
-     * Neither a combat log (a timestamp) nor a zip archive (`PK`) can start with `<`, so an opening angle bracket
-     * means an XML or HTML document rather than the segment we asked for (see #3789).
+     * A second line of defence against a bad download reaching the parser: `curlSaveToFile()` already rejects a
+     * non-2xx response, but a proxy or CDN in front of S3 may hand back an error document with a 200, and an
+     * empty body is a successful response by every measure curl reports.
+     *
+     * Neither a combat log (which starts with a timestamp) nor a zip archive (`PK`) can start with `<`, so an
+     * opening angle bracket means an XML or HTML document rather than the segment we asked for. A zero-byte
+     * segment carries nothing to extract either way, and is far more likely a broken download than a real
+     * (empty) part of a run - failing it retries rather than silently reporting a successful ingest (see #3789).
      */
-    private function isErrorDocument(string $filePath): bool
+    private function isPlausibleSegment(string $filePath): bool
     {
-        if (!is_file($filePath)) {
+        if (!is_file($filePath) || filesize($filePath) === 0) {
             return false;
         }
 
-        return file_get_contents($filePath, length: 1) === '<';
+        return file_get_contents($filePath, length: 1) !== '<';
     }
 
     /**

--- a/app/Jobs/Logging/ProcessCombatLogSegmentsLogging.php
+++ b/app/Jobs/Logging/ProcessCombatLogSegmentsLogging.php
@@ -26,6 +26,11 @@ class ProcessCombatLogSegmentsLogging extends StructuredLogging implements Proce
         $this->error(__METHOD__, get_defined_vars());
     }
 
+    public function handleSegmentIsErrorDocument(int $runId, int $segmentId, string $tempPath): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
+    }
+
     public function handleParseError(int $runId, int $combatLogVersion, string $message, string $class): void
     {
         $this->error(__METHOD__, get_defined_vars());

--- a/app/Jobs/Logging/ProcessCombatLogSegmentsLogging.php
+++ b/app/Jobs/Logging/ProcessCombatLogSegmentsLogging.php
@@ -26,7 +26,7 @@ class ProcessCombatLogSegmentsLogging extends StructuredLogging implements Proce
         $this->error(__METHOD__, get_defined_vars());
     }
 
-    public function handleSegmentIsErrorDocument(int $runId, int $segmentId, string $tempPath): void
+    public function handleSegmentIsNotACombatLog(int $runId, int $segmentId, string $tempPath): void
     {
         $this->error(__METHOD__, get_defined_vars());
     }

--- a/app/Jobs/Logging/ProcessCombatLogSegmentsLoggingInterface.php
+++ b/app/Jobs/Logging/ProcessCombatLogSegmentsLoggingInterface.php
@@ -12,6 +12,8 @@ interface ProcessCombatLogSegmentsLoggingInterface
 
     public function handleSegmentDownloadFailed(int $runId, int $segmentId, string $tempPath): void;
 
+    public function handleSegmentIsErrorDocument(int $runId, int $segmentId, string $tempPath): void;
+
     public function handleParseError(int $runId, int $combatLogVersion, string $message, string $class): void;
 
     public function handleEnd(int $runId, bool $result): void;

--- a/app/Jobs/Logging/ProcessCombatLogSegmentsLoggingInterface.php
+++ b/app/Jobs/Logging/ProcessCombatLogSegmentsLoggingInterface.php
@@ -12,7 +12,7 @@ interface ProcessCombatLogSegmentsLoggingInterface
 
     public function handleSegmentDownloadFailed(int $runId, int $segmentId, string $tempPath): void;
 
-    public function handleSegmentIsErrorDocument(int $runId, int $segmentId, string $tempPath): void;
+    public function handleSegmentIsNotACombatLog(int $runId, int $segmentId, string $tempPath): void;
 
     public function handleParseError(int $runId, int $combatLogVersion, string $message, string $class): void;
 

--- a/app/Service/Traits/Curl.php
+++ b/app/Service/Traits/Curl.php
@@ -9,37 +9,7 @@ trait Curl
      */
     public function curlGet(string $url, array $options = []): string
     {
-        $ch = curl_init();
-
-        curl_setopt_array($ch, $options + [
-            CURLOPT_RETURNTRANSFER => true,
-            // return web page
-            CURLOPT_HEADER => false,
-            // don't return headers
-            CURLOPT_FOLLOWLOCATION => true,
-            // follow redirects
-            CURLOPT_MAXREDIRS => 10,
-            // stop after 10 redirects
-            CURLOPT_ENCODING => '',
-            // handle compressed
-            CURLOPT_USERAGENT => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36',
-            // name of client
-            CURLOPT_AUTOREFERER => true,
-            // set referrer on redirect
-            CURLOPT_CONNECTTIMEOUT => 120,
-            // time-out on connect
-            CURLOPT_TIMEOUT => 120,
-            // time-out on response
-            CURLOPT_URL => $url,
-        ]);
-
-        try {
-            $response = curl_exec($ch);
-        } finally {
-            curl_close($ch);
-        }
-
-        return $response;
+        return $this->curlGetResponse($url, $options)['body'];
     }
 
     /**
@@ -49,9 +19,17 @@ trait Curl
      */
     public function curlSaveToFile(string $url, string $filePath): bool
     {
-        $rawImage = $this->curlGet($url);
+        $response = $this->curlGetResponse($url);
 
-        return file_put_contents($filePath, $rawImage) !== false;
+        // A failed HTTP request still has a body - S3, for example, answers an expired or denied presigned URL
+        // with an XML `Error` document. Saving that body would hand a bogus file to whatever consumes it, so
+        // treat any error response as a download failure instead (see #3789).
+        if ($response['body'] === false || $response['errorNumber'] !== CURLE_OK
+            || $response['httpCode'] < 200 || $response['httpCode'] >= 300) {
+            return false;
+        }
+
+        return file_put_contents($filePath, $response['body']) !== false;
     }
 
     /**
@@ -85,5 +63,51 @@ trait Curl
         }
 
         return $response;
+    }
+
+    /**
+     * Perform the GET and report the transport outcome alongside the body.
+     *
+     * Note `httpCode` is 0 for non-HTTP protocols, and when the request never got a response at all, so callers
+     * should judge failure on `errorNumber` first.
+     *
+     * @param  array<string, mixed>                                      $options
+     * @return array{body: string|bool, httpCode: int, errorNumber: int}
+     */
+    protected function curlGetResponse(string $url, array $options = []): array
+    {
+        $ch = curl_init();
+
+        curl_setopt_array($ch, $options + [
+            CURLOPT_RETURNTRANSFER => true,
+            // return web page
+            CURLOPT_HEADER => false,
+            // don't return headers
+            CURLOPT_FOLLOWLOCATION => true,
+            // follow redirects
+            CURLOPT_MAXREDIRS => 10,
+            // stop after 10 redirects
+            CURLOPT_ENCODING => '',
+            // handle compressed
+            CURLOPT_USERAGENT => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36',
+            // name of client
+            CURLOPT_AUTOREFERER => true,
+            // set referrer on redirect
+            CURLOPT_CONNECTTIMEOUT => 120,
+            // time-out on connect
+            CURLOPT_TIMEOUT => 120,
+            // time-out on response
+            CURLOPT_URL => $url,
+        ]);
+
+        try {
+            $response    = curl_exec($ch);
+            $httpCode    = (int)curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+            $errorNumber = curl_errno($ch);
+        } finally {
+            curl_close($ch);
+        }
+
+        return ['body' => $response, 'httpCode' => $httpCode, 'errorNumber' => $errorNumber];
     }
 }

--- a/tests/Feature/Jobs/CombatLog/ProcessCombatLogSegmentsTest.php
+++ b/tests/Feature/Jobs/CombatLog/ProcessCombatLogSegmentsTest.php
@@ -299,4 +299,51 @@ final class ProcessCombatLogSegmentsTest extends PublicTestCase
         $this->expectException(RuntimeException::class);
         app()->call([$job, 'handle']);
     }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_givenSegmentIsAnXmlErrorDocument_throwsRuntimeExceptionInsteadOfRecordingParseFailure(): void
+    {
+        // Arrange — a storage error response that still arrives with a 2xx status, so the download itself "succeeds".
+        $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
+        $raiderIOApiService->method('getCombatLogSegmentsForRun')
+            ->willReturn(new CombatLogSegmentsResponse(
+                sourceUserId: 1,
+                segments:     [new CombatLogSegment(id: 1, type: 'combat_log', downloadUrl: self::DOWNLOAD_URL_1)],
+            ));
+        app()->instance(RaiderIOApiServiceInterface::class, $raiderIOApiService);
+
+        $extractionService = $this->createMockPublic(CombatLogDataExtractionServiceInterface::class);
+        $extractionService->expects($this->never())->method('extractData');
+        app()->instance(CombatLogDataExtractionServiceInterface::class, $extractionService);
+
+        // The download is retryable, so it must not leave behind a parse failure blaming the parser.
+        $parseFailureRepository = $this->createMockPublic(CombatLogParseFailureRepositoryInterface::class);
+        $parseFailureRepository->expects($this->never())->method('recordFailure');
+        app()->instance(CombatLogParseFailureRepositoryInterface::class, $parseFailureRepository);
+
+        $log = $this->createMockPublic(ProcessCombatLogSegmentsLoggingInterface::class);
+        $log->expects($this->once())->method('handleSegmentIsErrorDocument');
+        $log->expects($this->never())->method('handleParseError');
+        $log->expects($this->once())->method('handleEnd')->with(self::RUN_ID, false);
+        app()->instance(ProcessCombatLogSegmentsLoggingInterface::class, $log);
+
+        $job = $this->getMockBuilder(ProcessCombatLogSegments::class)
+            ->setConstructorArgs([new Season(), self::RUN_ID, self::COMBAT_LOG_VERSION])
+            ->onlyMethods(['curlSaveToFile'])
+            ->getMock();
+
+        $job->method('curlSaveToFile')
+            ->willReturnCallback(function (string $url, string $tempPath): bool {
+                file_put_contents($tempPath, '<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code></Error>');
+
+                return true;
+            });
+
+        // Assert + Act
+        $this->expectException(RuntimeException::class);
+        app()->call([$job, 'handle']);
+    }
 }

--- a/tests/Feature/Jobs/CombatLog/ProcessCombatLogSegmentsTest.php
+++ b/tests/Feature/Jobs/CombatLog/ProcessCombatLogSegmentsTest.php
@@ -14,6 +14,7 @@ use App\Service\RaiderIO\Dtos\CombatLogSegmentsResponse;
 use App\Service\RaiderIO\RaiderIOApiServiceInterface;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Constraint\IsType;
@@ -125,7 +126,7 @@ final class ProcessCombatLogSegmentsTest extends PublicTestCase
             ->setConstructorArgs([new Season(), self::RUN_ID, self::COMBAT_LOG_VERSION])
             ->onlyMethods(['curlSaveToFile'])
             ->getMock();
-        $job->method('curlSaveToFile')->willReturn(true);
+        $job->method('curlSaveToFile')->willReturnCallback($this->writeSegmentContents(...));
 
         // Act
         app()->call([$job, 'handle']);
@@ -186,7 +187,7 @@ final class ProcessCombatLogSegmentsTest extends PublicTestCase
             ->setConstructorArgs([new Season(), self::RUN_ID, self::COMBAT_LOG_VERSION])
             ->onlyMethods(['curlSaveToFile'])
             ->getMock();
-        $job->method('curlSaveToFile')->willReturn(true);
+        $job->method('curlSaveToFile')->willReturnCallback($this->writeSegmentContents(...));
 
         // Act
         app()->call([$job, 'handle']);
@@ -304,9 +305,11 @@ final class ProcessCombatLogSegmentsTest extends PublicTestCase
      * @throws Exception
      */
     #[Test]
-    public function handle_givenSegmentIsAnXmlErrorDocument_throwsRuntimeExceptionInsteadOfRecordingParseFailure(): void
-    {
-        // Arrange — a storage error response that still arrives with a 2xx status, so the download itself "succeeds".
+    #[DataProvider('implausibleSegmentBodyProvider')]
+    public function handle_givenSegmentIsNotACombatLog_throwsRuntimeExceptionInsteadOfRecordingParseFailure(
+        string $body,
+    ): void {
+        // Arrange — a bad download that still arrives with a 2xx status, so the download itself "succeeds".
         $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
         $raiderIOApiService->method('getCombatLogSegmentsForRun')
             ->willReturn(new CombatLogSegmentsResponse(
@@ -325,7 +328,7 @@ final class ProcessCombatLogSegmentsTest extends PublicTestCase
         app()->instance(CombatLogParseFailureRepositoryInterface::class, $parseFailureRepository);
 
         $log = $this->createMockPublic(ProcessCombatLogSegmentsLoggingInterface::class);
-        $log->expects($this->once())->method('handleSegmentIsErrorDocument');
+        $log->expects($this->once())->method('handleSegmentIsNotACombatLog');
         $log->expects($this->never())->method('handleParseError');
         $log->expects($this->once())->method('handleEnd')->with(self::RUN_ID, false);
         app()->instance(ProcessCombatLogSegmentsLoggingInterface::class, $log);
@@ -336,8 +339,8 @@ final class ProcessCombatLogSegmentsTest extends PublicTestCase
             ->getMock();
 
         $job->method('curlSaveToFile')
-            ->willReturnCallback(function (string $url, string $tempPath): bool {
-                file_put_contents($tempPath, '<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code></Error>');
+            ->willReturnCallback(function (string $url, string $tempPath) use ($body): bool {
+                file_put_contents($tempPath, $body);
 
                 return true;
             });
@@ -345,5 +348,27 @@ final class ProcessCombatLogSegmentsTest extends PublicTestCase
         // Assert + Act
         $this->expectException(RuntimeException::class);
         app()->call([$job, 'handle']);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function implausibleSegmentBodyProvider(): array
+    {
+        return [
+            'xml error document' => ['<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code></Error>'],
+            'html error page'    => ['<html><body>403 Forbidden</body></html>'],
+            'empty body'         => [''],
+        ];
+    }
+
+    /**
+     * Stand-in for a successful download: writes plausible combat log content to the segment's temp path.
+     */
+    private function writeSegmentContents(string $url, string $tempPath): bool
+    {
+        file_put_contents($tempPath, sprintf('8/2/2026 20:15:01.123-4  ENCOUNTER_START,from %s', $url));
+
+        return true;
     }
 }

--- a/tests/Fixtures/CurlTraitConsumer.php
+++ b/tests/Fixtures/CurlTraitConsumer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use App\Service\Traits\Curl;
+
+/**
+ * The Curl trait is only ever used from a class; this is a minimal host for it so its behaviour can be tested
+ * without dragging in one of the real consuming services.
+ */
+class CurlTraitConsumer
+{
+    use Curl;
+}

--- a/tests/Unit/App/Service/Traits/CurlTest.php
+++ b/tests/Unit/App/Service/Traits/CurlTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit\App\Service\Traits;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use Tests\Fixtures\CurlTraitConsumer;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Curl')]
+final class CurlTest extends PublicTestCase
+{
+    private const string URL          = 'https://s3.example.com/02_boss.txt.gz?X-Amz-Signature=abc';
+    private const string ERROR_BODY   = '<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code></Error>';
+    private const string SUCCESS_BODY = "8/2/2026 20:15:01.123-4  SPELL_CAST_SUCCESS,Player-1084-0B4087DE\n";
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function curlSaveToFile_givenSuccessfulResponse_writesBodyAndReturnsTrue(): void
+    {
+        // Arrange
+        $filePath = $this->getTempFilePath();
+        $consumer = $this->getConsumerWithResponse(self::SUCCESS_BODY, 200, CURLE_OK);
+
+        try {
+            // Act
+            $result = $consumer->curlSaveToFile(self::URL, $filePath);
+
+            // Assert
+            $this->assertTrue($result);
+            $this->assertSame(self::SUCCESS_BODY, file_get_contents($filePath));
+        } finally {
+            if (is_file($filePath)) {
+                unlink($filePath);
+            }
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[DataProvider('failedResponseProvider')]
+    public function curlSaveToFile_givenFailedResponse_writesNothingAndReturnsFalse(
+        string|bool $body,
+        int         $httpCode,
+        int         $errorNumber,
+    ): void {
+        // Arrange
+        $filePath = $this->getTempFilePath();
+        $consumer = $this->getConsumerWithResponse($body, $httpCode, $errorNumber);
+
+        try {
+            // Act
+            $result = $consumer->curlSaveToFile(self::URL, $filePath);
+
+            // Assert — the error body must not end up on disk, or it gets handed to the combat log parser (#3789)
+            $this->assertFalse($result);
+            $this->assertFileDoesNotExist($filePath);
+        } finally {
+            if (is_file($filePath)) {
+                unlink($filePath);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, array{string|bool, int, int}>
+     */
+    public static function failedResponseProvider(): array
+    {
+        return [
+            'expired presigned url (403)' => [self::ERROR_BODY, 403, CURLE_OK],
+            'missing object (404)'        => [self::ERROR_BODY, 404, CURLE_OK],
+            'storage error (500)'         => [self::ERROR_BODY, 500, CURLE_OK],
+            'unfollowed redirect (302)'   => ['', 302, CURLE_OK],
+            'transport failure'           => [false, 0, CURLE_COULDNT_CONNECT],
+        ];
+    }
+
+    private function getTempFilePath(): string
+    {
+        return sprintf('%s/curl_test_%s.txt', sys_get_temp_dir(), uniqid());
+    }
+
+    /**
+     * Build a trait consumer with its single network-touching method stubbed out.
+     *
+     * @throws Exception
+     * @return CurlTraitConsumer&MockObject
+     */
+    private function getConsumerWithResponse(string|bool $body, int $httpCode, int $errorNumber): MockObject
+    {
+        $consumer = $this->getMockBuilder(CurlTraitConsumer::class)
+            ->onlyMethods(['curlGetResponse'])
+            ->getMock();
+
+        $consumer->method('curlGetResponse')
+            ->willReturn(['body' => $body, 'httpCode' => $httpCode, 'errorNumber' => $errorNumber]);
+
+        return $consumer;
+    }
+}


### PR DESCRIPTION
:robot: Closes #3789

## The bug

`Curl::curlSaveToFile()` wrote whatever body came back from the request without ever inspecting the HTTP status. When a presigned S3 URL is expired or denied, S3 answers with an XML `Error` document — and that document was saved as the segment's `.txt` file and handed straight to the combat log parser.

It then failed on line 1 with `InvalidArgumentException: Unable to parse event <?xml version="1.0" encoding="UTF-8"?>` and was recorded as a `CombatLogParseFailure`. That is doubly wrong: it reads like a parser bug when it is really a download failure, and the run is never retried even though `ProcessCombatLogSegments` already re-throws `RuntimeException` precisely so the job can retry with fresh presigned URLs.

This matches all three failure rows in #3789 exactly — line 1, `rawLine` = the XML declaration, three different runs and two different `combatLogVersion` values.

## The fix

1. **`app/Service/Traits/Curl.php`** — `curlSaveToFile()` now returns `false` unless the request succeeded at the transport level (`curl_errno`) *and* answered 2xx. Nothing is written to disk otherwise, so the existing `RuntimeException` at `ProcessCombatLogSegments.php:88` fires and the job retries.
2. **`app/Jobs/CombatLog/ProcessCombatLogSegments.php`** — a second line of defence, `isPlausibleSegment()`: a downloaded segment is rejected if its first byte is `<`, or if it is zero bytes. Neither a combat log line (a timestamp) nor a zip archive (`PK`) can start with `<`, so an opening angle bracket means an error document — which covers the variant where a proxy or CDN in front of S3 returns an error body with a `200`, invisible to a status check. The zero-byte case is the same class of hole: an empty 200 body is a "successful" response by every measure curl reports, and would otherwise have been extracted as a silent no-op run reporting success. (A transfer truncated mid-flight is already covered — curl reports `CURLE_PARTIAL_FILE`.) Both throw `RuntimeException`, so they land on the retry path rather than recording a parse failure.

`curlGet()`'s public contract is deliberately unchanged — it has 14 other call sites (Wowhead, Cloudflare, Archon, Raider.IO, localization downloads) and widening this into a general HTTP-error overhaul is out of scope here.

### Consequences for the other `curlSaveToFile()` caller

`WowheadService::downloadSpellIcon()` (`WowheadService.php:126`) downloads spell icons through the same method. Previously a 404 HTML page from zamimg was silently saved as a `.jpg`; now nothing is written and the call returns `false`. Two knock-on effects worth stating plainly rather than calling this a pure improvement:

- `downloadMissingSpellIcons()` accumulates via `$result = $result && ...`, so `wowhead:fetchmissingspellicons` now exits non-zero if *any single* icon 404s, where before it exited 0.
- Because no garbage file is written, the `file_exists($targetFile)` skip no longer permanently short-circuits an icon that does not exist upstream — each such icon is re-requested (with its `sleep()`) on every invocation.

Both are the correct behaviour — a corrupt HTML-as-JPEG on disk being served to users is worse than either — and the command is manual, not scheduled, so the cost is bounded. Left as-is deliberately; widening this PR into a Wowhead retry/negative-cache change would be scope creep.

### Where this failure surfaces now

Worth being explicit, since the bogus `CombatLogParseFailure` row is exactly what surfaced #3789 in the first place via `combatlog-parse-failure-poll`. After this change the same failure no longer appears in the parse-failure admin panel or that poll — correctly, since it was never a parse failure. It surfaces instead as an `error`-level structured log (`handleSegmentDownloadFailed` / `handleSegmentIsNotACombatLog`), which `config/logging.php` routes to the Discord and Sentry channels at `level => error`, plus a `failed_jobs` row once the 3 retries are exhausted. So recurrence is still visible, just in error alerting rather than in the parse-failure tooling.

## Verification

- `tests/Unit/App/Service/Traits/CurlTest.php` (new) — asserts a 2xx response is written, and that a 403/404/500/302 response and a transport failure all return `false` **and leave no file on disk**.
- `tests/Feature/Jobs/CombatLog/ProcessCombatLogSegmentsTest.php` — new data-provider case asserting that an XML error document, an HTML error page, and an empty body downloaded with a "successful" status throws `RuntimeException`, never calls `extractData()`, and never records a `CombatLogParseFailure`.
- 16 tests / 79 assertions green (plus the full `--group=CombatLog` suite: 224 tests / 1095 assertions); `composer run fix` and `composer run analyse` clean.

**Why there is no real-data reproduction here**, unlike the usual `combatlog-parse-failure-triage` step 4: this failure is transient by nature. Pulling `/segments` for one of the three affected runs today issues *fresh* presigned URLs, which return 200 with real log data — the bug cannot be reproduced on demand against live segments. The tests above stub the error response directly, which is a stronger proof for this particular failure mode than a real-data run could be.
