### PR TITLE
#3789 Validate HTTP status before writing curlSaveToFile() output

### DIFF
--- a/app/Service/Traits/Curl.php
+++ b/app/Service/Traits/Curl.php
@@ -9,6 +9,36 @@ trait Curl
      */
     public function curlGet(string $url, array $options = []): string
     {
+        return $this->curlExec($url, $options)['body'];
+    }
+
+    /**
+     * Downloads $url to $filePath, refusing to write the response body unless the request actually
+     * succeeded (transport-level success and a 2xx status). Without this, an S3/HTTP error body (e.g.
+     * an XML error document from an expired presigned URL) gets written to disk and silently treated
+     * as a valid combat log segment by the caller.
+     *
+     * @param  string $url
+     * @param  string $filePath
+     * @return bool
+     */
+    public function curlSaveToFile(string $url, string $filePath): bool
+    {
+        $result = $this->curlExec($url);
+
+        if ($result['errno'] !== 0 || $result['httpCode'] < 200 || $result['httpCode'] >= 300) {
+            return false;
+        }
+
+        return file_put_contents($filePath, $result['body']) !== false;
+    }
+
+    /**
+     * @param  array<string, mixed>                           $options
+     * @return array{body: string, httpCode: int, errno: int}
+     */
+    private function curlExec(string $url, array $options = []): array
+    {
         $ch = curl_init();
 
         curl_setopt_array($ch, $options + [
@@ -35,23 +65,17 @@ trait Curl
 
         try {
             $response = curl_exec($ch);
+            $errno    = curl_errno($ch);
+            $httpCode = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
         } finally {
             curl_close($ch);
         }
 
-        return $response;
-    }
-
-    /**
-     * @param  string $url
-     * @param  string $filePath
-     * @return bool
-     */
-    public function curlSaveToFile(string $url, string $filePath): bool
-    {
-        $rawImage = $this->curlGet($url);
-
-        return file_put_contents($filePath, $rawImage) !== false;
+        return [
+            'body'     => $response !== false ? $response : '',
+            'httpCode' => $httpCode,
+            'errno'    => $errno,
+        ];
     }
 
     /**

--- a/tests/Feature/Service/Traits/CurlTest.php
+++ b/tests/Feature/Service/Traits/CurlTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\Service\Traits;
+
+use App\Service\Traits\Curl;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Exercises the real curl transport (via a local PHP built-in server) rather than mocking it, since the
+ * bug this covers (#3789) is specifically about curlSaveToFile() failing to notice a non-2xx response.
+ */
+#[Group('Service')]
+final class CurlTest extends PublicTestCase
+{
+    private static int $port;
+
+    /** @var resource|null */
+    private static $serverProcess = null;
+
+    private static string $routerPath;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$port       = random_int(20000, 29999);
+        self::$routerPath = sprintf('%s/curl_test_router_%s.php', sys_get_temp_dir(), uniqid());
+
+        file_put_contents(
+            self::$routerPath,
+            <<<'PHP'
+<?php
+$status = (int)($_GET['status'] ?? 200);
+http_response_code($status);
+echo $status >= 200 && $status < 300 ? 'OK-BODY' : '<?xml version="1.0" encoding="UTF-8"?><Error/>';
+PHP,
+        );
+
+        self::$serverProcess = proc_open(
+            sprintf('exec php -S 127.0.0.1:%d %s', self::$port, escapeshellarg(self::$routerPath)),
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+        );
+
+        $deadline = microtime(true) + 5;
+        while (microtime(true) < $deadline) {
+            $connection = @fsockopen('127.0.0.1', self::$port, $errno, $errstr, 0.1);
+
+            if ($connection !== false) {
+                fclose($connection);
+
+                return;
+            }
+
+            usleep(50000);
+        }
+
+        self::fail('Local test HTTP server did not start in time.');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$serverProcess !== null) {
+            proc_terminate(self::$serverProcess);
+            proc_close(self::$serverProcess);
+        }
+
+        if (file_exists(self::$routerPath)) {
+            unlink(self::$routerPath);
+        }
+
+        parent::tearDownAfterClass();
+    }
+
+    private function url(int $status): string
+    {
+        return sprintf('http://127.0.0.1:%d/?status=%d', self::$port, $status);
+    }
+
+    private function subject(): object
+    {
+        return new class {
+            use Curl;
+        };
+    }
+
+    #[Test]
+    public function curlSaveToFile_given200Response_writesBodyAndReturnsTrue(): void
+    {
+        // Arrange
+        $tempPath = tempnam(sys_get_temp_dir(), 'curl_test_');
+
+        try {
+            // Act
+            $result = $this->subject()->curlSaveToFile($this->url(200), $tempPath);
+
+            // Assert
+            $this->assertTrue($result);
+            $this->assertSame('OK-BODY', file_get_contents($tempPath));
+        } finally {
+            @unlink($tempPath);
+        }
+    }
+
+    #[Test]
+    public function curlSaveToFile_given500Response_doesNotWriteFileAndReturnsFalse(): void
+    {
+        // Arrange
+        $tempPath = tempnam(sys_get_temp_dir(), 'curl_test_');
+        unlink($tempPath);
+
+        // Act
+        $result = $this->subject()->curlSaveToFile($this->url(500), $tempPath);
+
+        // Assert
+        $this->assertFalse($result);
+        $this->assertFileDoesNotExist($tempPath);
+    }
+
+    #[Test]
+    public function curlSaveToFile_given403Response_doesNotWriteFileAndReturnsFalse(): void
+    {
+        // Arrange — mirrors an expired/invalid presigned S3 URL, the real-world trigger for #3789.
+        $tempPath = tempnam(sys_get_temp_dir(), 'curl_test_');
+        unlink($tempPath);
+
+        // Act
+        $result = $this->subject()->curlSaveToFile($this->url(403), $tempPath);
+
+        // Assert
+        $this->assertFalse($result);
+        $this->assertFileDoesNotExist($tempPath);
+    }
+
+    #[Test]
+    public function curlSaveToFile_givenConnectionFailure_returnsFalseWithoutWritingFile(): void
+    {
+        // Arrange
+        $tempPath = tempnam(sys_get_temp_dir(), 'curl_test_');
+        unlink($tempPath);
+
+        // Act — nothing listens on this port, so curl fails at the transport level.
+        $result = $this->subject()->curlSaveToFile('http://127.0.0.1:1/', $tempPath);
+
+        // Assert
+        $this->assertFalse($result);
+        $this->assertFileDoesNotExist($tempPath);
+    }
+
+    #[Test]
+    public function curlGet_given500Response_stillReturnsRawBody(): void
+    {
+        // curlGet() keeps returning whatever the server sent regardless of status, unlike
+        // curlSaveToFile() — existing callers already handle/ignore malformed bodies themselves.
+
+        // Act
+        $result = $this->subject()->curlGet($this->url(500));
+
+        // Assert
+        $this->assertStringContainsString('<?xml', $result);
+    }
+}

--- a/tests/Feature/Service/Traits/CurlTest.php
+++ b/tests/Feature/Service/Traits/CurlTest.php
@@ -25,7 +25,7 @@ final class CurlTest extends PublicTestCase
     {
         parent::setUpBeforeClass();
 
-        self::$port       = random_int(20000, 29999);
+        self::$port       = self::findFreePort();
         self::$routerPath = sprintf('%s/curl_test_router_%s.php', sys_get_temp_dir(), uniqid());
 
         file_put_contents(
@@ -58,6 +58,24 @@ PHP,
         }
 
         self::fail('Local test HTTP server did not start in time.');
+    }
+
+    /**
+     * Binding to port 0 asks the OS to hand back an ephemeral free port, avoiding collisions with
+     * whatever else happens to be listening (a fixed/random port range is a CI flake waiting to happen).
+     */
+    private static function findFreePort(): int
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+
+        if ($socket === false) {
+            self::fail(sprintf('Could not allocate a free port: %s', $errstr));
+        }
+
+        $name = stream_socket_get_name($socket, false);
+        fclose($socket);
+
+        return (int)substr((string)strrchr($name, ':'), 1);
     }
 
     public static function tearDownAfterClass(): void


### PR DESCRIPTION
:robot: Closes #3789

## Diagnosis

Pulled the real S3 segments for the three unresolved failure rows in the issue's cluster (#745, #21,
and the equivalent for #744) via the `combatlog-parse-failure-triage` skill. **All 9 segments for both
sampled runs (`41746652`, `40280113`) now download and parse cleanly with zero failures** — the
artifact that originally triggered `Unable to parse event <?xml version="1.0" ...` is no longer
reproducible from the stored S3 object, meaning the bad body was transient (an S3/HTTP error response
captured at ingestion time), not a stable, re-downloadable artifact. So this is diagnosed by
elimination from the code path rather than from a captured bad body.

Root cause: `Curl::curlSaveToFile()` (`app/Service/Traits/Curl.php`) wrote the raw curl response body
to disk **unconditionally** — no check of the HTTP status code or `curl_errno()`. `ProcessCombatLogSegments`
(the job that downloads combat log segments from their presigned S3 URLs) only treats a download as
failed when `file_put_contents()` itself fails, which it essentially never does. So an expired/invalid
presigned URL returning an S3 `<Error>` XML document (line 1) was written to the temp file as if it
were a valid segment and handed straight to the parser — producing a permanent
`InvalidArgumentException` `CombatLogParseFailure` row instead of tripping the job's existing
retry-with-fresh-URL path (`tries=3`, `backoff() = [30, 120]`, re-thrown `RuntimeException`).

## Fix

`curlSaveToFile()` now inspects the transport error (`curl_errno()`) and HTTP status
(`CURLINFO_HTTP_CODE`) before writing anything to disk, returning `false` on any non-2xx/transport
failure — which flows into the existing `RuntimeException`-retry path unchanged.
`curlGet()` keeps its prior behavior (returns whatever body it gets, even on non-2xx) since its ~8
other call sites already handle/ignore malformed bodies themselves and none of them were part of this
bug.

**Side effect worth flagging:** `WowheadService::downloadSpellIcon()` is the other `curlSaveToFile()`
caller. It previously always returned `true` (a 404 HTML page got silently written to the icon file
and reported as success); it will now correctly report `false` for a missing icon. This looks like a
pre-existing latent bug this fix also corrects, not a regression — noting it here for review.

**Consequence to be aware of:** a segment whose presigned URL still 403s after all 3 job attempts now
fails the job outright rather than ever reaching the parser/recording a `CombatLogParseFailure` row.
That's the intended behavior (nothing valid was ever parseable in that case).

## Testing

- New `tests/Feature/Service/Traits/CurlTest.php` exercises the real curl transport against a local
  PHP built-in server (started in `setUpBeforeClass`) rather than mocking curl, since the bug is
  specifically about status-code handling: 200 writes+returns true, 500/403 leave no file and return
  false, a refused connection returns false, and `curlGet()` still returns the raw body on 500 for
  backward compatibility.
- `php artisan test --group=CombatLog`: 221 passed.
- `composer run fix` / `composer run analyse`: clean.
- Real-data verification: `run_41746652` (9/9 segments) and `run_40280113` (9/9 segments) both
  re-parse with 0 failures via `CombatLogDataExtractionServiceInterface::extractData()`.