### PR TITLE
Retry combat log parse on a dropped Redis/Valkey connection instead of recording a permanent failure

### DIFF
--- a/app/Jobs/CombatLog/ProcessCombatLogSegments.php
+++ b/app/Jobs/CombatLog/ProcessCombatLogSegments.php
@@ -110,7 +110,11 @@ class ProcessCombatLogSegments implements ShouldBeUnique, ShouldQueue
 
             $result = true;
         } catch (RuntimeException $e) {
-            // Re-throw download failures so the job can be retried with fresh one-time URLs.
+            // Re-throw so the job is retried instead of recording a permanent CombatLogParseFailure: this
+            // covers download failures (fresh one-time URLs on retry) as well as RedisException, which
+            // extends RuntimeException and is rethrown unwrapped by CombatLogService::parseCombatLog() for
+            // the same reason - a dropped Redis/Valkey connection mid-parse is a transient infra blip, not
+            // an unparsable line (see #3791).
             throw $e;
         } catch (Throwable $e) {
             $log->handleParseError($this->runId, $this->combatLogVersion, $e->getMessage(), $e::class);

--- a/app/Service/CombatLog/CombatLogService.php
+++ b/app/Service/CombatLog/CombatLogService.php
@@ -31,6 +31,7 @@ use File;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use RedisException;
 use Throwable;
 use ZipArchive;
 
@@ -399,6 +400,12 @@ readonly class CombatLogService implements CombatLogServiceInterface
                     $this->log->parseCombatLogParseEventsChangedCombatLogVersion($combatLogVersion, $isAdvancedLoggingEnabled);
                 }
             }
+        } catch (RedisException $exception) {
+            // A dropped Redis/Valkey connection is a transient infrastructure failure, not a malformed
+            // combat log line - the line the reader happened to be on when it hit is not the cause. Let it
+            // propagate unwrapped so the caller's retry logic (queue tries/backoff) applies instead of it
+            // being recorded as a permanent CombatLogParseFailure.
+            throw $exception;
         } catch (Exception $exception) {
             $this->log->parseCombatLogParseEventsException(sprintf('%d: %s', $lineNr, $rawEvent), $exception);
 

--- a/tests/Feature/Jobs/CombatLog/ProcessCombatLogSegmentsTest.php
+++ b/tests/Feature/Jobs/CombatLog/ProcessCombatLogSegmentsTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\MockObject\Exception;
+use RedisException;
 use RuntimeException;
 use Tests\TestCases\PublicTestCase;
 
@@ -347,6 +348,46 @@ final class ProcessCombatLogSegmentsTest extends PublicTestCase
 
         // Assert + Act
         $this->expectException(RuntimeException::class);
+        app()->call([$job, 'handle']);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_givenRedisExceptionDuringExtraction_throwsForRetryInsteadOfRecordingParseFailure(): void
+    {
+        // Arrange — a dropped Redis/Valkey connection mid-parse (#3791) is a transient infra failure, not an
+        // unparsable line: it must be retried by the queue rather than permanently recorded as a parse failure.
+        $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
+        $raiderIOApiService->method('getCombatLogSegmentsForRun')
+            ->willReturn(new CombatLogSegmentsResponse(
+                sourceUserId: 1,
+                segments:     [new CombatLogSegment(id: 1, type: 'combat_log', downloadUrl: self::DOWNLOAD_URL_1)],
+            ));
+        app()->instance(RaiderIOApiServiceInterface::class, $raiderIOApiService);
+
+        $extractionService = $this->createMockPublic(CombatLogDataExtractionServiceInterface::class);
+        $extractionService->method('extractData')
+            ->willThrowException(new RedisException('read error on connection to tcp://ksg-valkey:6379'));
+        app()->instance(CombatLogDataExtractionServiceInterface::class, $extractionService);
+
+        $parseFailureRepository = $this->createMockPublic(CombatLogParseFailureRepositoryInterface::class);
+        $parseFailureRepository->expects($this->never())->method('recordFailure');
+        app()->instance(CombatLogParseFailureRepositoryInterface::class, $parseFailureRepository);
+
+        $log = $this->createMockPublic(ProcessCombatLogSegmentsLoggingInterface::class);
+        $log->expects($this->never())->method('handleParseError');
+        app()->instance(ProcessCombatLogSegmentsLoggingInterface::class, $log);
+
+        $job = $this->getMockBuilder(ProcessCombatLogSegments::class)
+            ->setConstructorArgs([new Season(), self::RUN_ID, self::COMBAT_LOG_VERSION])
+            ->onlyMethods(['curlSaveToFile'])
+            ->getMock();
+        $job->method('curlSaveToFile')->willReturnCallback($this->writeSegmentContents(...));
+
+        // Assert + Act
+        $this->expectException(RedisException::class);
         app()->call([$job, 'handle']);
     }
 

--- a/tests/Unit/App/Service/CombatLog/CombatLogServiceTest.php
+++ b/tests/Unit/App/Service/CombatLog/CombatLogServiceTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Unit\App\Service\CombatLog;
 
 use App\Service\CombatLog\CombatLogServiceInterface;
+use App\Service\CombatLog\Exceptions\CombatLogParseException;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use RedisException;
 use Tests\TestCases\PublicTestCase;
 use ZipArchive;
 
@@ -68,6 +71,59 @@ final class CombatLogServiceTest extends PublicTestCase
         } finally {
             if (file_exists($txtFilePath)) {
                 unlink($txtFilePath);
+            }
+        }
+    }
+
+    #[Test]
+    public function parseCombatLog_givenCallbackThrowsRedisException_rethrowsUnwrapped(): void
+    {
+        // Arrange — a dropped Redis/Valkey connection mid-parse (#3791) is a transient infra failure, not an
+        // unparsable line. It must propagate as-is (not wrapped in CombatLogParseException) so the caller's
+        // retry logic applies instead of the blip being recorded as a permanent parse failure.
+        $filePath = sprintf('%s/keystone_test_combatlog_%d.txt', sys_get_temp_dir(), random_int(1, PHP_INT_MAX));
+        file_put_contents($filePath, "COMBAT_LOG_VERSION,21\nZONE_CHANGE,1234\n");
+
+        try {
+            /** @var CombatLogServiceInterface $combatLogService */
+            $combatLogService = app(CombatLogServiceInterface::class);
+
+            // Assert
+            $this->expectException(RedisException::class);
+            $this->expectExceptionMessage('read error on connection to tcp://ksg-valkey:6379');
+
+            // Act
+            $combatLogService->parseCombatLog($filePath, function (): void {
+                throw new RedisException('read error on connection to tcp://ksg-valkey:6379');
+            });
+        } finally {
+            if (file_exists($filePath)) {
+                unlink($filePath);
+            }
+        }
+    }
+
+    #[Test]
+    public function parseCombatLog_givenCallbackThrowsOtherException_wrapsInCombatLogParseException(): void
+    {
+        // Arrange — genuine parse errors are still wrapped so the failing line/number can be recorded.
+        $filePath = sprintf('%s/keystone_test_combatlog_%d.txt', sys_get_temp_dir(), random_int(1, PHP_INT_MAX));
+        file_put_contents($filePath, "COMBAT_LOG_VERSION,21\nZONE_CHANGE,1234\n");
+
+        try {
+            /** @var CombatLogServiceInterface $combatLogService */
+            $combatLogService = app(CombatLogServiceInterface::class);
+
+            // Assert
+            $this->expectException(CombatLogParseException::class);
+
+            // Act
+            $combatLogService->parseCombatLog($filePath, function (): void {
+                throw new InvalidArgumentException('Unbalanced quotes');
+            });
+        } finally {
+            if (file_exists($filePath)) {
+                unlink($filePath);
             }
         }
     }


### PR DESCRIPTION
:robot: Closes #3791

## Root cause

`CombatLogService::parseCombatLog()` (`app/Service/CombatLog/CombatLogService.php:402-405`) catches
`Exception` around the per-line parse callback and wraps *everything* into a `CombatLogParseException`
— including a `RedisException` thrown when the Redis/Valkey connection drops mid-parse (the exact
failure reported in #3791: a connection blip, not a malformed line — the `raw_line` recorded is
wherever the reader happened to be, not the actual cause).

`ProcessCombatLogSegments::handle()` (`app/Jobs/CombatLog/ProcessCombatLogSegments.php:107-126`) then
catches that wrapped exception in its generic `catch (Throwable $e)` clause, records a permanent
`CombatLogParseFailure` row, and lets the job complete **without rethrowing** — so `tries=3` /
`backoff([30,120])` never engage. A transient infra blip permanently and silently leaves the run
partially ingested.

**Answering the issue's own follow-up question directly**: run `41910839` was never retried — the
exception was caught, recorded, and the job returned normally (no rethrow), per the code path above.

## Fix

`RedisException` (which extends `RuntimeException`) is now rethrown unwrapped from
`parseCombatLog()` instead of being wrapped in `CombatLogParseException`. The job's existing
`catch (RuntimeException $e) { throw $e; }` clause — already used to retry download failures with
fresh presigned URLs — now also catches it (since it extends `RuntimeException`) and retries the job
instead of recording a permanent failure. No new catch clause was needed in the job; only its comment
was updated to document the shared path.

Scoped to `RedisException` specifically because that's the observed failure in #3791; the same
pattern would extend to other transient infra exceptions (e.g. DB connection drops) if those show up
too, but that's out of scope here.

**Retry safety**: `CombatLogDataExtractionService::extractData()` only writes the `ParsedCombatLog`
idempotency-guard row *after* a fully successful parse (`app/Service/CombatLog/CombatLogDataExtractionService.php:141-148`,
past the point where `parseCombatLog()`'s try/catch lives) — so a segment that died mid-parse leaves
no guard row, and a retry correctly re-parses just that segment. Already-successful segments in the
same run are skipped via the existing guard, and re-parsing a partially-processed segment is safe
regardless (observations are upserts; events only fire when canonical state actually changes).

**Observability trade**: after this change, a sustained Valkey outage means 3 failed attempts and
*no* `CombatLogParseFailure` row — the failures table stays a signal for genuine parser defects only,
not infra flakiness. Full outages are already visible via the job's own failure/retry-exhaustion
signals (Horizon).

The real-data reproduction step from the triage skill doesn't apply here — there is no failing input
line to reproduce (the raw_line in the issue is just parser position, not a parse defect), so this MR
is a code-path fix verified with unit/feature tests instead.

## Tests

- `CombatLogServiceTest::parseCombatLog_givenCallbackThrowsRedisException_rethrowsUnwrapped` — asserts
  a `RedisException` from the callback propagates unwrapped (not `CombatLogParseException`).
- `CombatLogServiceTest::parseCombatLog_givenCallbackThrowsOtherException_wrapsInCombatLogParseException` —
  regression guard that genuine parse errors are still wrapped so line/number info is preserved.
- `ProcessCombatLogSegmentsTest::handle_givenRedisExceptionDuringExtraction_throwsForRetryInsteadOfRecordingParseFailure` —
  asserts the job rethrows (for queue retry) and never calls `recordFailure`/`handleParseError`.

`--group=CombatLog` (225 tests) green; `composer run fix` / `composer run analyse` clean.

## Test plan

- [x] Unit test: `RedisException` rethrown unwrapped from `parseCombatLog()`
- [x] Unit test: other exceptions still wrapped in `CombatLogParseException`
- [x] Feature test: job rethrows on `RedisException` from `extractData()`, no parse failure recorded
- [x] Full `--group=CombatLog` suite green
- [x] `composer run fix` / `composer run analyse` clean