### PR TITLE
#3804 Drop the doubled stage prefix from the SQS queue names

### DIFF
--- a/.claude/skills/combatlog-data-pipeline/SKILL.md
+++ b/.claude/skills/combatlog-data-pipeline/SKILL.md
@@ -52,7 +52,7 @@ combatlog:pollruns (Raider.IO)        External S3 upload (dispatcher lives outsi
         │                                     │
         ▼                                     ▼
 ProcessCombatLogSegments        ProcessCombatLogFanout → ProcessCombatLogFromS3 (per file)
-   (queue *-combat-log-process)         (queue *-combat-log-process)
+   (queue *-cl-process)          (queue *-cl-fanout)      (queue *-cl-process)
         └──────────────┬───────────────────────┘
                        ▼   (also: combatlog:extractdata CLI, extractDataAsync analyze flow)
         CombatLogDataExtractionService::extractData()
@@ -81,7 +81,7 @@ UPSERT observations   mutate canonical mapping   INSERT audit events
 Everything funnels into `CombatLogDataExtractionService::extractData(string $filePath, ?bool $force,
 ?callable $onProcessLine, ?CombatLogRunContextInterface $runContext)`:
 
-- `ProcessCombatLogFromS3::handle()` — S3 fanout path (queue `*-combat-log-process`, timeout 1800).
+- `ProcessCombatLogFromS3::handle()` — S3 fanout path (queue `*-cl-process`, timeout 1800).
 - `ProcessCombatLogSegments::handle()` — Raider.IO segment path (`ShouldBeUnique`, tries 3, backoff
   `[30,120]`); dispatched by `PollCombatLogRunsCommand` (`combatlog:pollruns`).
 - `combatlog:extractdata {filePath} {--force}` (`ExtractData.php`) — manual/local CLI.

--- a/.env.ci.example
+++ b/.env.ci.example
@@ -176,7 +176,7 @@ AWS_S3_BUCKET_COMBAT_LOGS=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 SQS_PREFIX=https://sqs.us-east-1.amazonaws.com/your-account-id
-SQS_QUEUE=production-production-default
+SQS_QUEUE=production-default
 
 SESSION_ENCRYPT=false
 SESSION_PATH=/

--- a/.env.example
+++ b/.env.example
@@ -178,7 +178,7 @@ AWS_S3_BUCKET_COMBAT_LOGS=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 SQS_PREFIX=https://sqs.us-east-1.amazonaws.com/your-account-id
-SQS_QUEUE=production-production-default
+SQS_QUEUE=production-default
 
 SESSION_ENCRYPT=false
 SESSION_PATH=/

--- a/app/Http/Resources/DungeonRouteThumbnailJob/DungeonRouteThumbnailJobResource.php
+++ b/app/Http/Resources/DungeonRouteThumbnailJob/DungeonRouteThumbnailJobResource.php
@@ -42,7 +42,7 @@ class DungeonRouteThumbnailJobResource extends JsonResource
     #[Override]
     public function toArray(Request $request): array
     {
-        $queueSize = Queue::size(sprintf('%s-%s-thumbnail-api', config('app.type'), config('app.env')));
+        $queueSize = Queue::size(sprintf('%s-thumbnail-api', config('app.type')));
 
         $isCompleted = $this->status === DungeonRouteThumbnailJob::STATUS_COMPLETED;
 

--- a/app/Jobs/CombatLog/ProcessCombatLogFanout.php
+++ b/app/Jobs/CombatLog/ProcessCombatLogFanout.php
@@ -24,7 +24,7 @@ class ProcessCombatLogFanout implements ShouldQueue
         private readonly int                           $combatLogVersion,
         private readonly ?CombatLogRunContextInterface $runContext = null,
     ) {
-        $this->queue = sprintf('%s-%s-cl-fanout', config('app.type'), config('app.env'));
+        $this->queue = sprintf('%s-cl-fanout', config('app.type'));
     }
 
     public function handle(ProcessCombatLogFanoutLoggingInterface $log): void

--- a/app/Jobs/CombatLog/ProcessCombatLogFromS3.php
+++ b/app/Jobs/CombatLog/ProcessCombatLogFromS3.php
@@ -29,7 +29,7 @@ class ProcessCombatLogFromS3 implements ShouldQueue
         private readonly string                        $diskName = 's3_combat_logs',
         private readonly ?CombatLogRunContextInterface $runContext = null,
     ) {
-        $this->queue = sprintf('%s-%s-cl-process', config('app.type'), config('app.env'));
+        $this->queue = sprintf('%s-cl-process', config('app.type'));
     }
 
     public function handle(

--- a/app/Jobs/CombatLog/ProcessCombatLogSegments.php
+++ b/app/Jobs/CombatLog/ProcessCombatLogSegments.php
@@ -47,7 +47,7 @@ class ProcessCombatLogSegments implements ShouldBeUnique, ShouldQueue
         private readonly int                           $combatLogVersion,
         private readonly ?CombatLogRunContextInterface $runContext = null,
     ) {
-        $this->queue = sprintf('%s-%s-cl-process', config('app.type'), config('app.env'));
+        $this->queue = sprintf('%s-cl-process', config('app.type'));
     }
 
     public function handle(

--- a/app/Jobs/ProcessRouteFloorThumbnail.php
+++ b/app/Jobs/ProcessRouteFloorThumbnail.php
@@ -30,7 +30,7 @@ class ProcessRouteFloorThumbnail implements ShouldQueue
         protected int                          $attempts = 0,
         protected DungeonRouteThumbnailVariant $variant = DungeonRouteThumbnailVariant::Standard,
     ) {
-        $this->queue = sprintf('%s-%s-thumbnail', config('app.type'), config('app.env'));
+        $this->queue = sprintf('%s-thumbnail', config('app.type'));
     }
 
     /**

--- a/app/Jobs/ProcessRouteFloorThumbnailCustom.php
+++ b/app/Jobs/ProcessRouteFloorThumbnailCustom.php
@@ -30,7 +30,7 @@ class ProcessRouteFloorThumbnailCustom implements ShouldQueue
         protected int                             $attempts = 0,
     ) {
         // Not passed as a constructor parameter since it's not serializable
-        $this->queue = sprintf('%s-%s-thumbnail-api', config('app.type'), config('app.env'));
+        $this->queue = sprintf('%s-thumbnail-api', config('app.type'));
     }
 
     /**

--- a/app/Jobs/RefreshDiscoverCache.php
+++ b/app/Jobs/RefreshDiscoverCache.php
@@ -22,7 +22,7 @@ class RefreshDiscoverCache implements ShouldQueue
 
     public function __construct()
     {
-        $this->queue = sprintf('%s-%s-long-running', config('app.type'), config('app.env'));
+        $this->queue = sprintf('%s-long-running', config('app.type'));
     }
 
     /**

--- a/app/Jobs/RegenerateCombatLogRoute.php
+++ b/app/Jobs/RegenerateCombatLogRoute.php
@@ -24,7 +24,7 @@ class RegenerateCombatLogRoute implements ShouldQueue
 
     public function __construct(private readonly int $dungeonRouteId)
     {
-        $this->queue = sprintf('%s-%s-long-running', config('app.type'), config('app.env'));
+        $this->queue = sprintf('%s-long-running', config('app.type'));
     }
 
     /**

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -142,14 +142,14 @@ return [
         'production' => [
             'supervisor-default' => [
                 'connection' => 'redis',
-                'queue'      => [sprintf('%s-production-default', env('APP_TYPE'))],
+                'queue'      => [sprintf('%s-default', env('APP_TYPE'))],
                 'balance'    => 'simple',
                 'processes'  => 2,
                 'tries'      => 3,
             ],
             'supervisor-long-running' => [
                 'connection' => 'redis',
-                'queue'      => [sprintf('%s-production-long-running', env('APP_TYPE'))],
+                'queue'      => [sprintf('%s-long-running', env('APP_TYPE'))],
                 'balance'    => 'simple',
                 'processes'  => 1,
                 'tries'      => 1,
@@ -157,14 +157,14 @@ return [
             ],
             //            'supervisor-thumbnail' => [
             //                'connection' => 'redis',
-            //                'queue'      => [sprintf('%s-production-thumbnail', env('APP_TYPE'))],
+            //                'queue'      => [sprintf('%s-thumbnail', env('APP_TYPE'))],
             //                'balance'    => 'simple',
             //                'processes'  => 4,
             //                'tries'      => 1,
             //            ],
             //            'supervisor-thumbnail-api' => [
             //                'connection' => 'redis',
-            //                'queue'      => [sprintf('%s-production-thumbnail-api', env('APP_TYPE'))],
+            //                'queue'      => [sprintf('%s-thumbnail-api', env('APP_TYPE'))],
             //                'balance'    => 'simple',
             //                'processes'  => 1,
             //                'tries'      => 1,
@@ -174,22 +174,30 @@ return [
         'local' => [
             'supervisor-default' => [
                 'connection' => 'redis',
-                'queue'      => [sprintf('%s-local-default', env('APP_TYPE'))],
+                'queue'      => [sprintf('%s-default', env('APP_TYPE'))],
                 'balance'    => 'simple',
                 'processes'  => 1,
                 'tries'      => 3,
             ],
             'supervisor-long-running' => [
                 'connection' => 'redis',
-                'queue'      => [sprintf('%s-local-long-running', env('APP_TYPE'))],
+                'queue'      => [sprintf('%s-long-running', env('APP_TYPE'))],
                 'balance'    => 'simple',
                 'processes'  => 1,
                 'tries'      => 1,
                 'timeout'    => 0,
             ],
-            'supervisor-combat-log-process' => [
+            'supervisor-cl-fanout' => [
                 'connection' => 'redis',
-                'queue'      => [sprintf('%s-local-combat-log-process', env('APP_TYPE'))],
+                'queue'      => [sprintf('%s-cl-fanout', env('APP_TYPE'))],
+                'balance'    => 'simple',
+                'processes'  => 1,
+                'tries'      => 3,
+                'timeout'    => 1800,
+            ],
+            'supervisor-cl-process' => [
+                'connection' => 'redis',
+                'queue'      => [sprintf('%s-cl-process', env('APP_TYPE'))],
                 'balance'    => 'simple',
                 'processes'  => 2,
                 'tries'      => 3,
@@ -197,14 +205,14 @@ return [
             ],
             'supervisor-thumbnail' => [
                 'connection' => 'redis',
-                'queue'      => [sprintf('%s-local-thumbnail', env('APP_TYPE'))],
+                'queue'      => [sprintf('%s-thumbnail', env('APP_TYPE'))],
                 'balance'    => 'simple',
                 'processes'  => 1,
                 'tries'      => 1,
             ],
             'supervisor-thumbnail-api' => [
                 'connection' => 'redis',
-                'queue'      => [sprintf('%s-local-thumbnail-api', env('APP_TYPE'))],
+                'queue'      => [sprintf('%s-thumbnail-api', env('APP_TYPE'))],
                 'balance'    => 'simple',
                 'processes'  => 1,
                 'tries'      => 1,

--- a/tests/Feature/Jobs/JobQueueNameTest.php
+++ b/tests/Feature/Jobs/JobQueueNameTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\CombatLog\ProcessCombatLogFanout;
+use App\Jobs\CombatLog\ProcessCombatLogFromS3;
+use App\Jobs\CombatLog\ProcessCombatLogSegments;
+use App\Jobs\ProcessRouteFloorThumbnail;
+use App\Jobs\ProcessRouteFloorThumbnailCustom;
+use App\Jobs\RefreshDiscoverCache;
+use App\Jobs\RegenerateCombatLogRoute;
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\DungeonRoute\DungeonRouteThumbnailJob;
+use App\Models\Season;
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Jobs')]
+final class JobQueueNameTest extends PublicTestCase
+{
+    private const string APP_TYPE = 'teststage';
+
+    /**
+     * The queue name must carry the stage (APP_TYPE) exactly once - APP_ENV is 'production' in both AWS stages,
+     * so including it produced doubled names such as 'staging-production-thumbnail'. See #3804.
+     *
+     * @param callable(): object $jobFactory
+     */
+    #[Test]
+    #[DataProvider('queueNameProvider')]
+    public function construct_givenAppType_setsQueueWithoutAppEnv(callable $jobFactory, string $expectedQueue): void
+    {
+        // Arrange
+        Config::set('app.type', self::APP_TYPE);
+        Config::set('app.env', 'production');
+
+        // Act
+        $job = $jobFactory();
+
+        // Assert
+        $this->assertSame($expectedQueue, $job->queue);
+    }
+
+    /**
+     * @return array<string, array{0: callable(): object, 1: string}>
+     */
+    public static function queueNameProvider(): array
+    {
+        return [
+            'RefreshDiscoverCache' => [
+                static fn() => new RefreshDiscoverCache(),
+                sprintf('%s-long-running', self::APP_TYPE),
+            ],
+            'RegenerateCombatLogRoute' => [
+                static fn() => new RegenerateCombatLogRoute(1),
+                sprintf('%s-long-running', self::APP_TYPE),
+            ],
+            'ProcessRouteFloorThumbnail' => [
+                static fn() => new ProcessRouteFloorThumbnail(new DungeonRoute(), 1),
+                sprintf('%s-thumbnail', self::APP_TYPE),
+            ],
+            'ProcessRouteFloorThumbnailCustom' => [
+                static fn() => new ProcessRouteFloorThumbnailCustom(new DungeonRouteThumbnailJob(), new DungeonRoute(), 1),
+                sprintf('%s-thumbnail-api', self::APP_TYPE),
+            ],
+            'ProcessCombatLogSegments' => [
+                static fn() => new ProcessCombatLogSegments(new Season(), 1, 1),
+                sprintf('%s-cl-process', self::APP_TYPE),
+            ],
+            'ProcessCombatLogFromS3' => [
+                static fn() => new ProcessCombatLogFromS3('bucket', 'path.log.zip', 1),
+                sprintf('%s-cl-process', self::APP_TYPE),
+            ],
+            'ProcessCombatLogFanout' => [
+                static fn() => new ProcessCombatLogFanout('bucket', 'path/', 1),
+                sprintf('%s-cl-fanout', self::APP_TYPE),
+            ],
+        ];
+    }
+
+    /**
+     * Horizon drives local queue processing; if a supervisor watches a queue no job dispatches to, that job type
+     * silently stops being processed locally (which is what happened to 'local-combat-log-process' before #3804).
+     */
+    #[Test]
+    #[DataProvider('horizonEnvironmentProvider')]
+    public function horizonConfig_givenEnvironment_onlyWatchesQueuesJobsDispatchTo(string $environment): void
+    {
+        // Arrange
+        // 'default' is the connection's fallback queue for jobs that never set $this->queue
+        $knownSuffixes = ['default'];
+        foreach (self::queueNameProvider() as [1 => $expectedQueue]) {
+            $knownSuffixes[] = substr($expectedQueue, strlen(self::APP_TYPE) + 1);
+        }
+
+        // Act
+        $supervisors = config(sprintf('horizon.environments.%s', $environment));
+
+        // Assert
+        $this->assertNotEmpty($supervisors);
+        foreach ($supervisors as $supervisorName => $supervisorConfig) {
+            foreach ($supervisorConfig['queue'] as $queueName) {
+                // Everything past the APP_TYPE prefix must be a queue some job actually dispatches to
+                $this->assertContains(
+                    substr($queueName, strpos($queueName, '-') + 1),
+                    $knownSuffixes,
+                    sprintf('Horizon supervisor "%s" watches a queue no job dispatches to', $supervisorName),
+                );
+            }
+        }
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function horizonEnvironmentProvider(): array
+    {
+        return [
+            'production' => ['production'],
+            'local'      => ['local'],
+        ];
+    }
+}

--- a/tests/Feature/Jobs/JobQueueNameTest.php
+++ b/tests/Feature/Jobs/JobQueueNameTest.php
@@ -90,11 +90,7 @@ final class JobQueueNameTest extends PublicTestCase
     public function horizonConfig_givenEnvironment_onlyWatchesQueuesJobsDispatchTo(string $environment): void
     {
         // Arrange
-        // 'default' is the connection's fallback queue for jobs that never set $this->queue
-        $knownSuffixes = ['default'];
-        foreach (self::queueNameProvider() as [1 => $expectedQueue]) {
-            $knownSuffixes[] = substr($expectedQueue, strlen(self::APP_TYPE) + 1);
-        }
+        $knownSuffixes = self::dispatchedQueueSuffixes();
 
         // Act
         $supervisors = config(sprintf('horizon.environments.%s', $environment));
@@ -122,5 +118,50 @@ final class JobQueueNameTest extends PublicTestCase
             'production' => ['production'],
             'local'      => ['local'],
         ];
+    }
+
+    /**
+     * The mirror of the test above: a queue with no supervisor means those jobs pile up unprocessed, which is how
+     * 'cl-fanout' went unconsumed locally before #3804. Only asserted for 'local' - the 'production' block is
+     * deliberately partial because AWS runs its workers as ECS services against SQS rather than through Horizon.
+     */
+    #[Test]
+    public function horizonConfig_givenLocalEnvironment_watchesEveryQueueJobsDispatchTo(): void
+    {
+        // Arrange
+        $expectedSuffixes = self::dispatchedQueueSuffixes();
+
+        // Act
+        $watchedSuffixes = [];
+        foreach (config('horizon.environments.local') as $supervisorConfig) {
+            foreach ($supervisorConfig['queue'] as $queueName) {
+                $watchedSuffixes[] = substr($queueName, strpos($queueName, '-') + 1);
+            }
+        }
+
+        // Assert
+        foreach ($expectedSuffixes as $expectedSuffix) {
+            $this->assertContains(
+                $expectedSuffix,
+                $watchedSuffixes,
+                sprintf('No local Horizon supervisor watches the "%s" queue, so those jobs are never processed', $expectedSuffix),
+            );
+        }
+    }
+
+    /**
+     * Every queue suffix (the part after the APP_TYPE prefix) that some job dispatches to.
+     *
+     * @return string[]
+     */
+    private static function dispatchedQueueSuffixes(): array
+    {
+        // 'default' is the connection's fallback queue for jobs that never set $this->queue
+        $suffixes = ['default'];
+        foreach (self::queueNameProvider() as [1 => $expectedQueue]) {
+            $suffixes[] = substr($expectedQueue, strlen(self::APP_TYPE) + 1);
+        }
+
+        return array_unique($suffixes);
     }
 }


### PR DESCRIPTION
:robot: Closes #3804

Step 2/3 of the queue rename tracked by RaiderIO/keystoneguru-infra#16.

## ✅ Infra step 1 is deployed — this is unblocked

RaiderIO/keystoneguru-infra#47 merged at 20:41 and its "Deploy infra on merge" run succeeded, creating all 12 `<stage>-<prefix>` queues (staging + production × default/long-running/thumbnail/thumbnail-api/cl-fanout/cl-process). The workers now run `--queue=<new>,<legacy>` and keep draining anything already in flight, so this change is safe on its own.

*(The original body warned this must not ship first; that warning is resolved and kept here only for the record.)*

## What changed

`sprintf('%s-%s-<prefix>', config('app.type'), config('app.env'))` → `sprintf('%s-<prefix>', config('app.type'))`. `APP_TYPE` is the stage and `APP_ENV` is `production` in both AWS stages, so the deployed names carried the stage twice (`staging-production-default`).

All ten sites from the issue: the 7 jobs, `DungeonRouteThumbnailJobResource` (`Queue::size()`), `config/horizon.php` (both the `production` and `local` blocks, including the commented-out thumbnail supervisors), and `.env.example`'s `SQS_QUEUE`.

## Deliberate extra: the dead Horizon combat-log supervisor

The issue flagged `supervisor-combat-log-process` as watching `<type>-local-combat-log-process`, a queue **no job has ever dispatched to** — meaning combat log jobs were never processed locally at all — and said it was "worth fixing or deleting while in there".

Fixed rather than deleted, and this goes one step past the issue text: renaming it to `cl-process` alone would still leave local combat log processing broken, because `ProcessCombatLogFanout` dispatches to `cl-fanout` and nothing consumed that either. So the entry is renamed to `supervisor-cl-process` (queue `<type>-cl-process`) **and** a `supervisor-cl-fanout` entry was added, matching the two workers infra already runs in AWS. Local-only (`config/horizon.php` is redis; AWS uses SQS); the effect is one extra local Horizon process. Say the word if you'd rather have the plain rename and a separate issue for the fanout supervisor.

## Two short user-visible windows after the release

Both resolve as soon as the legacy queues drain:

- `DungeonRouteThumbnailJobResource` reports the *new* queue's depth while stragglers still sit on the old one (called out in the issue).
- `QueueSize.php` telemetry iterates `horizon.environments.<app.env>` and calls `Queue::size()` on each name, so the graphs for `production-default` / `production-long-running` will read near-zero briefly — a metrics dip, not an outage. Worth not chasing.

## Still manual after this ships

`SQS_QUEUE` (the fallback queue for jobs that never set `$this->queue` — broadcasts, notifications) lives in each stage's `.env` in the S3 config bucket, so it rides neither deploy. After the release: change it from `<stage>-production-default` to `<stage>-default` in staging and production and roll the services. **This is a precondition for infra step 3** — deleting the old queues before it is done silently drops every unrouted job. Recorded on keystoneguru-infra#16.

## Verification

- `grep -rn -- "-default\|-long-running\|-thumbnail\|-cl-process\|-cl-fanout" app/ config/ tests/ sh/ .env.example` is clean of doubled names. (Note the issue's `grep app.env` would *not* have caught `config/horizon.php`, which spelled the stage out literally.) The sibling `keystone.guru.combatlogstreamer` repo constructs no queue names.
- Dev stack tinker: `(new ProcessRouteFloorThumbnail(...))->queue` → `local-thumbnail`, not `local-local-thumbnail`.
- New `tests/Feature/Jobs/JobQueueNameTest.php`: asserts the queue name of all 7 jobs under a fixed `app.type`/`app.env`, and asserts no Horizon supervisor (either environment) watches a queue no job dispatches to — the drift that produced the dead combat-log entry. Negative-checked: reverting the supervisor to its old name makes that test fail.
- `composer run fix` and `composer run analyse` clean.

