### PR TITLE
Make structured errors usable in Sentry: fingerprint, tag and throttle them

### DIFF
--- a/.claude/skills/structured-logging/SKILL.md
+++ b/.claude/skills/structured-logging/SKILL.md
@@ -101,6 +101,37 @@ the context/extras. This is the granularity you want, so:
   (an array). `SkipsExceptionMirrorsHandler` uses this to split `HandlerLogging::uncaughtException`
   by exception class.
 
+### Fingerprinting, tags and throttling (#3820)
+
+"One issue per log site" is right for most sites but wrong for the ones that report a *failure*: a
+hundred distinct combat log parse failures collapsing into one issue is not triageable. Three taps
+on the `sentry` channel handle that, and the array order in `config/logging.php` **reads backwards** —
+each tap wraps the handlers the previous one produced, so the last entry is outermost and runs first.
+Execution order is `SkipsExceptionMirrors` → `FingerprintsStructuredErrors` → `ThrottlesRepeatedEvents`
+→ `SentryHandler`.
+
+- **`FingerprintsStructuredErrorsHandler`** sets `context['fingerprint']` to
+  `[$logSite, $exceptionClass, $normalizedMessage]` (digit runs collapsed to `#`) and promotes
+  `runId`, `seasonId`, `combatLogVersion`, `lineNumber`, `exceptionClass` into `context['tags']`.
+  It never overwrites a fingerprint another handler already set.
+- **Context key names are load-bearing.** The tap keys on the literal keys `exceptionClass` and
+  `message`, and `StructuredLogging` builds its context from `get_defined_vars()` — so **renaming a
+  Logging method's parameter silently changes grouping**. Both `handleParseError` methods carry a
+  docblock saying so.
+- **`rawLine` is deliberately not a tag.** Tags are capped at 200 characters and indexed; a raw
+  combat log line is long and carries player names and GUIDs. It stays in the context, which the SDK
+  files as extra data.
+- **`ThrottlesRepeatedEventsHandler`** caps events per fingerprint per hour. Sentry meters every
+  event even though it groups them, so an unthrottled failure loop burns the account's budget and
+  starts dropping novel errors. Consequence to remember when triaging: **a throttled issue's event
+  count is a lower bound, not the true occurrence count** — read real volume off the file logs.
+
+**Test taps end to end, never by calling the handler directly.** #3792 shipped three silent failures
+past tests that asserted on configuration shape or invoked the handler in isolation — the one path
+production never takes. `SentryLogChannelTest` resolves the real DSN-shaped channel against
+`CapturingTransport` and asserts an event actually arrives; extend that, and check your new test
+fails when the tap is removed.
+
 ### Traps, all of which fail silently
 
 These were found by review on #3792 after the tests went green; each one produced a channel that

--- a/app/Jobs/CombatLog/ProcessCombatLogSegments.php
+++ b/app/Jobs/CombatLog/ProcessCombatLogSegments.php
@@ -117,16 +117,31 @@ class ProcessCombatLogSegments implements ShouldBeUnique, ShouldQueue
             // an unparsable line (see #3791).
             throw $e;
         } catch (Throwable $e) {
-            $log->handleParseError($this->runId, $this->combatLogVersion, $e->getMessage(), $e::class);
+            // CombatLogParseException only wraps the real failure, so the class worth grouping and reporting on is
+            // the one it wrapped. Resolved once here because the log line used to report the wrapper while the
+            // recorded failure reported the cause, which made the two impossible to correlate.
+            $exceptionClass = $e instanceof CombatLogParseException ? $e->getOriginalExceptionClass() : $e::class;
+            $lineNumber     = $e instanceof CombatLogParseException ? $e->lineNumber : null;
+            $rawLine        = $e instanceof CombatLogParseException ? $e->rawLine : null;
+
+            $log->handleParseError(
+                $this->runId,
+                $this->season->id,
+                $this->combatLogVersion,
+                $lineNumber,
+                $exceptionClass,
+                $e->getMessage(),
+                $rawLine,
+            );
 
             $parseFailureRepository->recordFailure(
                 $this->runId,
                 $this->season->id,
                 $this->combatLogVersion,
-                $e instanceof CombatLogParseException ? $e->lineNumber : null,
-                $e instanceof CombatLogParseException ? $e->rawLine : null,
+                $lineNumber,
+                $rawLine,
                 $e->getMessage(),
-                $e instanceof CombatLogParseException ? $e->getOriginalExceptionClass() : $e::class,
+                $exceptionClass,
             );
         } finally {
             foreach ($tempFiles as $tempFile) {

--- a/app/Jobs/Logging/ProcessCombatLogPartLogging.php
+++ b/app/Jobs/Logging/ProcessCombatLogPartLogging.php
@@ -21,8 +21,12 @@ class ProcessCombatLogPartLogging extends StructuredLogging implements ProcessCo
         $this->error(__METHOD__, get_defined_vars());
     }
 
-    public function handleParseError(int $combatLogVersion, string $offendingLine, string $reason, string $filePath): void
-    {
+    public function handleParseError(
+        int    $combatLogVersion,
+        string $message,
+        string $exceptionClass,
+        string $filePath,
+    ): void {
         $this->error(__METHOD__, get_defined_vars());
     }
 

--- a/app/Jobs/Logging/ProcessCombatLogPartLoggingInterface.php
+++ b/app/Jobs/Logging/ProcessCombatLogPartLoggingInterface.php
@@ -10,7 +10,19 @@ interface ProcessCombatLogPartLoggingInterface
 
     public function handleFileWriteFailed(string $tempPath): void;
 
-    public function handleParseError(int $combatLogVersion, string $offendingLine, string $reason, string $filePath): void;
+    /**
+     * The parameter names become the log context keys the error tracker fingerprints and tags on, so `exceptionClass`
+     * and `message` must keep exactly those names - see {@see \App\Logging\Handlers\FingerprintsStructuredErrorsHandler}.
+     *
+     * They were previously `$offendingLine` and `$reason`, which did not describe what the only caller actually passes
+     * (`$e->getMessage()` then `$e::class`), so every logged context had those two values under misleading keys.
+     */
+    public function handleParseError(
+        int    $combatLogVersion,
+        string $message,
+        string $exceptionClass,
+        string $filePath,
+    ): void;
 
     public function handleEnd(bool $result): void;
 }

--- a/app/Jobs/Logging/ProcessCombatLogSegmentsLogging.php
+++ b/app/Jobs/Logging/ProcessCombatLogSegmentsLogging.php
@@ -31,8 +31,15 @@ class ProcessCombatLogSegmentsLogging extends StructuredLogging implements Proce
         $this->error(__METHOD__, get_defined_vars());
     }
 
-    public function handleParseError(int $runId, int $combatLogVersion, string $message, string $class): void
-    {
+    public function handleParseError(
+        int     $runId,
+        ?int    $seasonId,
+        int     $combatLogVersion,
+        ?int    $lineNumber,
+        string  $exceptionClass,
+        string  $message,
+        ?string $rawLine,
+    ): void {
         $this->error(__METHOD__, get_defined_vars());
     }
 

--- a/app/Jobs/Logging/ProcessCombatLogSegmentsLoggingInterface.php
+++ b/app/Jobs/Logging/ProcessCombatLogSegmentsLoggingInterface.php
@@ -14,7 +14,19 @@ interface ProcessCombatLogSegmentsLoggingInterface
 
     public function handleSegmentIsNotACombatLog(int $runId, int $segmentId, string $tempPath): void;
 
-    public function handleParseError(int $runId, int $combatLogVersion, string $message, string $class): void;
+    /**
+     * The parameter names become the log context keys the error tracker fingerprints and tags on, so `exceptionClass`
+     * and `message` must keep exactly those names - see {@see \App\Logging\Handlers\FingerprintsStructuredErrorsHandler}.
+     */
+    public function handleParseError(
+        int     $runId,
+        ?int    $seasonId,
+        int     $combatLogVersion,
+        ?int    $lineNumber,
+        string  $exceptionClass,
+        string  $message,
+        ?string $rawLine,
+    ): void;
 
     public function handleEnd(int $runId, bool $result): void;
 }

--- a/app/Logging/Handlers/FingerprintsStructuredErrors.php
+++ b/app/Logging/Handlers/FingerprintsStructuredErrors.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Logging\Handlers;
+
+use Illuminate\Log\Logger;
+
+/**
+ * Log channel tap that wraps every handler of the channel in a {@see FingerprintsStructuredErrorsHandler}, so
+ * error-level structured records arrive at the error tracker grouped by root cause and tagged with the identifiers a
+ * triage pass searches on.
+ *
+ * Only ever applied to the `sentry` channel - the file logs and Discord already carry the full context inline and
+ * have no concept of tags or fingerprints.
+ */
+class FingerprintsStructuredErrors
+{
+    /**
+     * Customize the given logger instance.
+     */
+    public function __invoke(Logger $logger): void
+    {
+        $handlers = [];
+        foreach ($logger->getHandlers() as $handler) {
+            $handlers[] = new FingerprintsStructuredErrorsHandler($handler);
+        }
+
+        $logger->setHandlers($handlers);
+    }
+}

--- a/app/Logging/Handlers/FingerprintsStructuredErrorsHandler.php
+++ b/app/Logging/Handlers/FingerprintsStructuredErrorsHandler.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Logging\Handlers;
+
+use Monolog\Handler\HandlerWrapper;
+use Monolog\LogRecord;
+use Override;
+
+/**
+ * Makes error-level {@see \App\Logging\StructuredLogging} records triageable once they reach the error tracker.
+ *
+ * These records are messages, not exceptions, and the error tracker groups message events by their message. Since
+ * StructuredLogging logs under a constant `ClassLogging::method`, every failure of a given log site collapses into a
+ * single issue no matter how many distinct root causes it represents - a hundred different combat log parse failures
+ * look like one problem. All the distinguishing detail sits in the context, where nothing can search or group on it.
+ *
+ * This handler fixes both halves:
+ *
+ * 1. It derives an explicit fingerprint from the log site plus the failure's exception class and the shape of its
+ *    message, so one root cause becomes one issue.
+ * 2. It promotes the short domain identifiers to tags, which are the only searchable and aggregatable surface the
+ *    error tracker offers. That is what lets a triage pass answer "which runs does this affect" without opening
+ *    events one by one.
+ *
+ * Everything not promoted stays in the context and is filed as extra data by the SDK's handler.
+ *
+ * Deliberately done as a channel tap rather than at the call sites: adding `tags`/`fingerprint` keys to a
+ * StructuredLogging context would leak them into the file, stderr and Discord output, which are the human-facing
+ * narrative, and would have to be repeated at every log site that ever wants them.
+ */
+class FingerprintsStructuredErrorsHandler extends HandlerWrapper
+{
+    /**
+     * Context keys promoted to tags, in the order they should appear. Restricted to short, bounded identifiers -
+     * tags are capped at 200 characters and a high-cardinality free-text tag is worse than useless.
+     *
+     * Notably absent: `rawLine`. It is long, and it is the field carrying player names and GUIDs, so it stays in the
+     * context where it is readable during triage but never indexed.
+     */
+    private const array TAG_CONTEXT_KEYS = [
+        'runId',
+        'seasonId',
+        'combatLogVersion',
+        'lineNumber',
+        'exceptionClass',
+    ];
+
+    /** Context key holding the class of the exception the record describes. */
+    private const string EXCEPTION_CLASS_KEY = 'exceptionClass';
+
+    /** Context key holding the failure's message, whose digit-stripped shape is the second fingerprint component. */
+    private const string MESSAGE_KEY = 'message';
+
+    /** Hard cap the error tracker applies to tag values; a longer value is dropped rather than truncated. */
+    private const int MAX_TAG_LENGTH = 200;
+
+    #[Override]
+    public function handle(LogRecord $record): bool
+    {
+        return parent::handle($this->fingerprint($this->promoteTags($record)));
+    }
+
+    /**
+     * Records are forwarded in batches when a buffering handler sits in front of this one, which would otherwise
+     * bypass the enrichment entirely.
+     *
+     * @param array<int, LogRecord> $records
+     */
+    #[Override]
+    public function handleBatch(array $records): void
+    {
+        foreach ($records as $record) {
+            $this->handle($record);
+        }
+    }
+
+    /**
+     * Copies the recognised identifiers into the `tags` context key, which the SDK's handler reads out and applies to
+     * the scope. Values that cannot be expressed as a short string are skipped rather than truncated - a silently
+     * cut-off identifier is a wrong identifier.
+     */
+    private function promoteTags(LogRecord $record): LogRecord
+    {
+        $tags = [];
+        foreach (self::TAG_CONTEXT_KEYS as $key) {
+            $value = $record->context[$key] ?? null;
+
+            if ($value === null || is_array($value) || is_object($value)) {
+                continue;
+            }
+
+            $value = (string)$value;
+            if ($value === '' || strlen($value) > self::MAX_TAG_LENGTH) {
+                continue;
+            }
+
+            $tags[$key] = $value;
+        }
+
+        if ($tags === []) {
+            return $record;
+        }
+
+        // Merge rather than replace - a caller that set its own tags keeps them, and wins on a key collision
+        return $record->with(context: array_merge($record->context, [
+            'tags' => array_merge($tags, is_array($record->context['tags'] ?? null) ? $record->context['tags'] : []),
+        ]));
+    }
+
+    /**
+     * Splits a log site's single issue into one issue per root cause.
+     *
+     * The log site itself stays the first component, so two different log sites that happen to hit the same exception
+     * class never merge. A record carrying neither an exception class nor a message is left alone: there is nothing to
+     * distinguish causes by, and the error tracker's default message grouping is already the right answer.
+     *
+     * A fingerprint set by another handler is never overwritten - {@see SkipsExceptionMirrorsHandler} sets its own for
+     * uncaught-exception mirrors, and it has better information about those than this handler does.
+     */
+    private function fingerprint(LogRecord $record): LogRecord
+    {
+        if (isset($record->context['fingerprint'])) {
+            return $record;
+        }
+
+        $exceptionClass = $record->context[self::EXCEPTION_CLASS_KEY] ?? null;
+        $message        = $record->context[self::MESSAGE_KEY] ?? null;
+
+        $components = array_values(array_filter([
+            is_string($exceptionClass) ? $exceptionClass : null,
+            is_string($message) ? self::normalizeMessage($message) : null,
+        ]));
+
+        if ($components === []) {
+            return $record;
+        }
+
+        return $record->with(context: array_merge($record->context, [
+            'fingerprint' => [$record->message, ...$components],
+        ]));
+    }
+
+    /**
+     * Reduces a failure message to its stable shape by collapsing every digit run to a `#`, so
+     * "Unable to find combat log version 21" and "... version 22" group together.
+     *
+     * Known limitation, inherited from the manual clustering this replaces: two genuinely different root causes that
+     * happen to share a normalised shape merge into one issue. That is acceptable for a triage feed - re-cluster by
+     * hand once the dominant cause is fixed.
+     */
+    private static function normalizeMessage(string $message): string
+    {
+        return trim((string)preg_replace('/\d+/', '#', $message));
+    }
+}

--- a/app/Logging/Handlers/FingerprintsStructuredErrorsHandler.php
+++ b/app/Logging/Handlers/FingerprintsStructuredErrorsHandler.php
@@ -54,6 +54,12 @@ class FingerprintsStructuredErrorsHandler extends HandlerWrapper
     /** Hard cap the error tracker applies to tag values; a longer value is dropped rather than truncated. */
     private const int MAX_TAG_LENGTH = 200;
 
+    /**
+     * How much of the normalised message contributes to the fingerprint. Long enough to tell failure shapes apart,
+     * short enough that a message with an entire combat log line appended cannot make every event unique.
+     */
+    private const int MAX_FINGERPRINT_MESSAGE_LENGTH = 120;
+
     #[Override]
     public function handle(LogRecord $record): bool
     {
@@ -141,8 +147,15 @@ class FingerprintsStructuredErrorsHandler extends HandlerWrapper
     }
 
     /**
-     * Reduces a failure message to its stable shape by collapsing every digit run to a `#`, so
-     * "Unable to find combat log version 21" and "... version 22" group together.
+     * Reduces a failure message to its stable shape, so "Unable to find combat log version 21" and "... version 22"
+     * group together.
+     *
+     * Collapsing digit runs alone is not enough here. Parsing exceptions routinely interpolate the offending combat
+     * log line into their message - `CombatLogStringParser` throws "Unbalanced quotes in string <line>", and
+     * `CombatLogService` wraps that as the message - and such a line carries character names and hex GUIDs. Left
+     * alone those make every single failing line its own fingerprint, which would defeat both the grouping and the
+     * throttle that keys on it. Quoted segments and GUID-shaped tokens are therefore flattened first, and the result
+     * is capped so a very long line cannot reintroduce uniqueness past the cap.
      *
      * Known limitation, inherited from the manual clustering this replaces: two genuinely different root causes that
      * happen to share a normalised shape merge into one issue. That is acceptable for a triage feed - re-cluster by
@@ -150,6 +163,19 @@ class FingerprintsStructuredErrorsHandler extends HandlerWrapper
      */
     private static function normalizeMessage(string $message): string
     {
-        return trim((string)preg_replace('/\d+/', '#', $message));
+        // Quoted segments in a combat log line are names and free text; the failure shape does not depend on them
+        $normalized = (string)preg_replace('/"[^"]*"/', '""', $message);
+
+        // An unbalanced quote - the single most common parse failure - leaves a dangling `"Somebody-Realm` that the
+        // pass above cannot match, and that trailing name is per-player. Flatten it the same way.
+        $normalized = (string)preg_replace('/"[^"]*$/', '""', $normalized);
+
+        // WoW GUIDs (Player-1234-0A1B2C3D, Creature-0-3886-2291-16093-208862-00003EDB78) are per-entity by design
+        $normalized = (string)preg_replace('/\b[A-Za-z]+(?:-[0-9A-Fa-f]+)+\b/', '#', $normalized);
+
+        $normalized = (string)preg_replace('/\d+/', '#', $normalized);
+        $normalized = (string)preg_replace('/\s+/', ' ', $normalized);
+
+        return mb_substr(trim($normalized), 0, self::MAX_FINGERPRINT_MESSAGE_LENGTH);
     }
 }

--- a/app/Logging/Handlers/ThrottlesRepeatedEvents.php
+++ b/app/Logging/Handlers/ThrottlesRepeatedEvents.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Logging\Handlers;
+
+use Illuminate\Log\Logger;
+
+/**
+ * Log channel tap that wraps every handler of the channel in a {@see ThrottlesRepeatedEventsHandler}, bounding how
+ * much of a single repeating failure reaches the error tracker.
+ *
+ * Only ever applied to the `sentry` channel - the file logs are the complete record and must stay complete.
+ */
+class ThrottlesRepeatedEvents
+{
+    /**
+     * Customize the given logger instance.
+     */
+    public function __invoke(Logger $logger): void
+    {
+        $handlers = [];
+        foreach ($logger->getHandlers() as $handler) {
+            $handlers[] = new ThrottlesRepeatedEventsHandler($handler);
+        }
+
+        $logger->setHandlers($handlers);
+    }
+}

--- a/app/Logging/Handlers/ThrottlesRepeatedEventsHandler.php
+++ b/app/Logging/Handlers/ThrottlesRepeatedEventsHandler.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Logging\Handlers;
+
+use Illuminate\Support\Facades\Cache;
+use Monolog\Handler\HandlerWrapper;
+use Monolog\LogRecord;
+use Override;
+
+/**
+ * Caps how many times the same failure is forwarded to the error tracker within a window.
+ *
+ * The error tracker groups events, but it still meters every one of them. A single bad WoW patch can fail every
+ * combat log line of every run, and unthrottled that burns the account's whole event budget in hours - at which point
+ * events are dropped indiscriminately and genuinely novel errors are lost precisely when the site is least healthy.
+ *
+ * The file and stderr channels are untouched and keep the complete record, so nothing is actually lost; this only
+ * bounds the mirror. The trade is that a throttled issue's event count becomes a lower bound rather than the true
+ * occurrence count - read volume off the logs, not off the tracker.
+ *
+ * Deliberately not built on Monolog's DeduplicationHandler: that one buffers and forwards through handleBatch(), and
+ * the SDK's handler compares a Monolog 3 Level enum against an integer there, so the batch filters itself empty and
+ * every record is silently discarded (#3792). This handler makes its decision inline and never buffers.
+ */
+class ThrottlesRepeatedEventsHandler extends HandlerWrapper
+{
+    /** How many events of the same signature are forwarded per window before the rest are dropped. */
+    private const int MAX_EVENTS_PER_WINDOW = 10;
+
+    private const int WINDOW_SECONDS = 3600;
+
+    /** Cache key prefix, kept distinct so a cache sweep can target throttle state alone. */
+    private const string CACHE_KEY_PREFIX = 'logging:error-tracker-throttle';
+
+    #[Override]
+    public function handle(LogRecord $record): bool
+    {
+        if (!$this->shouldForward($record)) {
+            // Returning false rather than true so the record still bubbles to the other handlers of a stack
+            return false;
+        }
+
+        return parent::handle($record);
+    }
+
+    /**
+     * Records are forwarded in batches when a buffering handler sits in front of this one, which would otherwise
+     * bypass the throttle entirely.
+     *
+     * @param array<int, LogRecord> $records
+     */
+    #[Override]
+    public function handleBatch(array $records): void
+    {
+        foreach ($records as $record) {
+            $this->handle($record);
+        }
+    }
+
+    /**
+     * Counts this record against its signature's window and reports whether it is still within the allowance.
+     *
+     * A cache failure must never cost us an error report, so anything unexpected forwards the record.
+     */
+    private function shouldForward(LogRecord $record): bool
+    {
+        $key = sprintf('%s:%s', self::CACHE_KEY_PREFIX, sha1($this->signature($record)));
+
+        // add() only succeeds when the key is absent, which both starts the window and counts the first event
+        if (Cache::add($key, 1, self::WINDOW_SECONDS)) {
+            return true;
+        }
+
+        $count = Cache::increment($key);
+
+        // Stores that cannot increment (or a key that expired between the two calls) return false/null - forward it
+        if (!is_int($count)) {
+            return true;
+        }
+
+        return $count <= self::MAX_EVENTS_PER_WINDOW;
+    }
+
+    /**
+     * The throttling key. Prefers the fingerprint, so the throttle bounds exactly what the tracker will group into
+     * one issue; falls back to the message, which is what the tracker groups on when no fingerprint is set.
+     */
+    private function signature(LogRecord $record): string
+    {
+        $fingerprint = $record->context['fingerprint'] ?? null;
+
+        if (is_array($fingerprint) && $fingerprint !== []) {
+            return implode('|', array_map(static fn(mixed $part): string => (string)$part, $fingerprint));
+        }
+
+        return $record->message;
+    }
+}

--- a/app/Logging/Handlers/ThrottlesRepeatedEventsHandler.php
+++ b/app/Logging/Handlers/ThrottlesRepeatedEventsHandler.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Cache;
 use Monolog\Handler\HandlerWrapper;
 use Monolog\LogRecord;
 use Override;
+use Throwable;
 
 /**
  * Caps how many times the same failure is forwarded to the error tracker within a window.
@@ -60,25 +61,47 @@ class ThrottlesRepeatedEventsHandler extends HandlerWrapper
     /**
      * Counts this record against its signature's window and reports whether it is still within the allowance.
      *
-     * A cache failure must never cost us an error report, so anything unexpected forwards the record.
+     * The whole body is guarded: this runs inside Monolog's handler loop, which rethrows (Logger::handleException),
+     * and the `sentry` channel is a member of every stack this application declares. An unreachable cache must
+     * therefore never turn a Log::error() call into a thrown exception - that would break error logging itself, and
+     * Handler::report() logs through exactly this path. Failing open costs at worst a burst of duplicate events.
      */
     private function shouldForward(LogRecord $record): bool
     {
-        $key = sprintf('%s:%s', self::CACHE_KEY_PREFIX, sha1($this->signature($record)));
+        try {
+            $key = $this->cacheKey($record);
 
-        // add() only succeeds when the key is absent, which both starts the window and counts the first event
-        if (Cache::add($key, 1, self::WINDOW_SECONDS)) {
+            $count = Cache::increment($key);
+
+            // A store that cannot increment returns false/null - nothing to count against, so forward the record
+            if (!is_int($count)) {
+                return true;
+            }
+
+            if ($count === 1) {
+                // increment() creates the key without a lifetime (Redis INCRBY does not set one), so the counter has
+                // to be given its window here or it would never expire and the signature would be silenced forever
+                Cache::put($key, 1, self::WINDOW_SECONDS);
+            }
+
+            return $count <= self::MAX_EVENTS_PER_WINDOW;
+        } catch (Throwable) {
             return true;
         }
+    }
 
-        $count = Cache::increment($key);
-
-        // Stores that cannot increment (or a key that expired between the two calls) return false/null - forward it
-        if (!is_int($count)) {
-            return true;
-        }
-
-        return $count <= self::MAX_EVENTS_PER_WINDOW;
+    /**
+     * Bucketing the key by wall-clock window rather than relying purely on the entry's lifetime means a counter that
+     * somehow outlives its window still cannot silence the next one - the next window simply uses a different key.
+     */
+    private function cacheKey(LogRecord $record): string
+    {
+        return sprintf(
+            '%s:%d:%s',
+            self::CACHE_KEY_PREFIX,
+            intdiv(time(), self::WINDOW_SECONDS),
+            sha1($this->signature($record)),
+        );
     }
 
     /**

--- a/config/logging.php
+++ b/config/logging.php
@@ -2,7 +2,9 @@
 
 use App\Logging\Handlers\ColoredLineFormatter;
 use App\Logging\Handlers\DeduplicateHandlers;
+use App\Logging\Handlers\FingerprintsStructuredErrors;
 use App\Logging\Handlers\SkipsExceptionMirrors;
+use App\Logging\Handlers\ThrottlesRepeatedEvents;
 use Monolog\Handler\NoopHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
@@ -108,8 +110,20 @@ return [
             'report_exceptions' => false,
             // Deliberately not deduplicated the way discord is: DeduplicationHandler forwards through handleBatch(),
             // and SentryHandler::handleBatch() still compares a Monolog 3 Level enum as an integer, so every record
-            // would be filtered out and silently never reach Sentry. Sentry groups and rate-limits server-side anyway.
-            'tap' => [SkipsExceptionMirrors::class],
+            // would be filtered out and silently never reach Sentry. ThrottlesRepeatedEvents below bounds the volume
+            // instead, without buffering.
+            //
+            // Order matters, and reads backwards: each tap wraps the handlers the previous one produced, so the LAST
+            // entry ends up outermost and runs FIRST. Execution is therefore
+            //   SkipsExceptionMirrors -> FingerprintsStructuredErrors -> ThrottlesRepeatedEvents -> SentryHandler
+            // which is the order these have to run in: drop the exception mirrors before doing any work on them, then
+            // derive the fingerprint, then throttle on that fingerprint so the throttle bounds exactly what Sentry
+            // will group into one issue.
+            'tap' => [
+                ThrottlesRepeatedEvents::class,
+                FingerprintsStructuredErrors::class,
+                SkipsExceptionMirrors::class,
+            ],
         ],
     ],
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -34,8 +34,10 @@
              resolves the 'sentry' channel by name, or triggers the SDK directly, sends to whichever project the
              developer's .env points at. Both keys are pinned because config/sentry.php falls back from the first to
              the second. Tests that need the DSN branch build it themselves against a stub transport. -->
-        <env name="SENTRY_LARAVEL_DSN" value=""/>
-        <env name="SENTRY_DSN" value=""/>
+        <!-- force="true" matters: PHPUnit skips an <env> entry when the variable already exists in the environment
+             (PhpHandler: `if ($force || getenv($name) === false)`), so without it an exported DSN would still win. -->
+        <env name="SENTRY_LARAVEL_DSN" value="" force="true"/>
+        <env name="SENTRY_DSN" value="" force="true"/>
         <env name="APP_SERVICES_CACHE" value="/tmp/phpunit_services.php"/>
         <!-- The 'tmp_file' store (RemembersToFile, used by ViewService among others) is a file cache that
              CACHE_STORE does not cover. Without this the tests read, write and flush the cache of the

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,12 +30,7 @@
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="PENNANT_STORE" value="array"/>
         <env name="LOG_CHANNEL" value="daily"/>
-        <!-- No test may ever reach the real error tracker. LOG_CHANNEL=daily is not enough on its own: any test that
-             resolves the 'sentry' channel by name, or triggers the SDK directly, sends to whichever project the
-             developer's .env points at. Both keys are pinned because config/sentry.php falls back from the first to
-             the second. Tests that need the DSN branch build it themselves against a stub transport. -->
-        <!-- force="true" matters: PHPUnit skips an <env> entry when the variable already exists in the environment
-             (PhpHandler: `if ($force || getenv($name) === false)`), so without it an exported DSN would still win. -->
+        <!-- No test may ever reach the real error tracker, full stop. -->
         <env name="SENTRY_LARAVEL_DSN" value="" force="true"/>
         <env name="SENTRY_DSN" value="" force="true"/>
         <env name="APP_SERVICES_CACHE" value="/tmp/phpunit_services.php"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,6 +30,12 @@
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="PENNANT_STORE" value="array"/>
         <env name="LOG_CHANNEL" value="daily"/>
+        <!-- No test may ever reach the real error tracker. LOG_CHANNEL=daily is not enough on its own: any test that
+             resolves the 'sentry' channel by name, or triggers the SDK directly, sends to whichever project the
+             developer's .env points at. Both keys are pinned because config/sentry.php falls back from the first to
+             the second. Tests that need the DSN branch build it themselves against a stub transport. -->
+        <env name="SENTRY_LARAVEL_DSN" value=""/>
+        <env name="SENTRY_DSN" value=""/>
         <env name="APP_SERVICES_CACHE" value="/tmp/phpunit_services.php"/>
         <!-- The 'tmp_file' store (RemembersToFile, used by ViewService among others) is a file cache that
              CACHE_STORE does not cover. Without this the tests read, write and flush the cache of the

--- a/tests/Feature/Jobs/CombatLog/ProcessCombatLogSegmentsTest.php
+++ b/tests/Feature/Jobs/CombatLog/ProcessCombatLogSegmentsTest.php
@@ -180,7 +180,20 @@ final class ProcessCombatLogSegmentsTest extends PublicTestCase
         app()->instance(CombatLogParseFailureRepositoryInterface::class, $parseFailureRepository);
 
         $log = $this->createMockPublic(ProcessCombatLogSegmentsLoggingInterface::class);
-        $log->expects($this->once())->method('handleParseError');
+        // Asserted in full, and deliberately mirroring the recordFailure expectation above: the log line used to
+        // report the CombatLogParseException wrapper while the recorded failure reported the cause, so the two could
+        // never be correlated. Both must now name InvalidArgumentException.
+        $log->expects($this->once())
+            ->method('handleParseError')
+            ->with(
+                self::RUN_ID,
+                $this->isNull(),
+                self::COMBAT_LOG_VERSION,
+                257080,
+                InvalidArgumentException::class,
+                'Unbalanced quotes in string SPELL_DAMAGE,Player-1084-0B4087DE,"Pa',
+                'SPELL_DAMAGE,Player-1084-0B4087DE,"Pa',
+            );
         $log->expects($this->once())->method('handleEnd')->with(self::RUN_ID, false);
         app()->instance(ProcessCombatLogSegmentsLoggingInterface::class, $log);
 

--- a/tests/Unit/App/Logging/SentryLogChannelTest.php
+++ b/tests/Unit/App/Logging/SentryLogChannelTest.php
@@ -51,7 +51,15 @@ final class SentryLogChannelTest extends PublicTestCase
     #[Test]
     public function sentryChannel_givenEmptyDsn_logsWithoutEmittingPhpErrors(): void
     {
-        // Arrange - force a fresh resolution so channel resolution (and any warning) actually happens
+        // Arrange - a configured DSN selects the real driver, and unlike the other tests here this one logs for real
+        // rather than against a stub transport. Without this guard the record is delivered to whichever project the
+        // developer's .env points at, which is how this suite ended up filing its own assertion string as a
+        // production issue. phpunit.xml pins the DSN empty as well; this keeps the test honest on its own terms.
+        if (!empty(config('sentry.dsn'))) {
+            self::markTestSkipped('A Sentry DSN is configured; this test covers the empty-DSN default.');
+        }
+
+        // Force a fresh resolution so channel resolution (and any warning) actually happens
         Log::forgetChannel('sentry');
 
         $capturedErrors = [];
@@ -148,6 +156,161 @@ final class SentryLogChannelTest extends PublicTestCase
 
         // Assert
         self::assertCount(1, $transport->capturedEvents);
+    }
+
+    /**
+     * Without a fingerprint every record of a given log site collapses into one Sentry issue, because Sentry groups
+     * message events by their message and StructuredLogging logs under a constant `ClassLogging::method`. Two
+     * different root causes must therefore end up with two different fingerprints.
+     */
+    #[Test]
+    public function sentryChannel_givenParseErrorsOfDifferentExceptionClasses_fingerprintsThemApart(): void
+    {
+        // Arrange
+        $transport = $this->bindStubHub();
+        $channel   = $this->sentryChannel();
+
+        // Act
+        $channel->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+            'exceptionClass' => 'InvalidArgumentException',
+            'message'        => 'Invalid parameter count, wanted 30-32, got 29',
+        ]);
+        $channel->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+            'exceptionClass' => 'OutOfBoundsException',
+            'message'        => 'Invalid parameter count, wanted 30-32, got 29',
+        ]);
+
+        // Assert
+        self::assertCount(2, $transport->capturedEvents);
+        self::assertNotSame(
+            $transport->capturedEvents[0]->getFingerprint(),
+            $transport->capturedEvents[1]->getFingerprint(),
+            'Two distinct root causes at one log site must not group into a single Sentry issue.',
+        );
+    }
+
+    /**
+     * The other half of the grouping contract: the same cause differing only in the numbers embedded in its message
+     * must stay one issue, or a single bad WoW patch becomes thousands of one-event issues.
+     */
+    #[Test]
+    public function sentryChannel_givenParseErrorsDifferingOnlyInDigits_fingerprintsThemTogether(): void
+    {
+        // Arrange
+        $transport = $this->bindStubHub();
+        $channel   = $this->sentryChannel();
+
+        // Act
+        $channel->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+            'exceptionClass' => 'InvalidArgumentException',
+            'message'        => 'Unable to find combat log version 21',
+        ]);
+        $channel->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+            'exceptionClass' => 'InvalidArgumentException',
+            'message'        => 'Unable to find combat log version 1337',
+        ]);
+
+        // Assert
+        self::assertCount(2, $transport->capturedEvents);
+        self::assertSame(
+            $transport->capturedEvents[0]->getFingerprint(),
+            $transport->capturedEvents[1]->getFingerprint(),
+        );
+    }
+
+    /**
+     * Tags are the only searchable and aggregatable surface Sentry offers, and they are what lets a triage pass pick
+     * two distinct runs to reproduce against without opening events one by one.
+     */
+    #[Test]
+    public function sentryChannel_givenParseErrorRecord_promotesIdentifiersToTagsButNotTheRawLine(): void
+    {
+        // Arrange
+        $transport = $this->bindStubHub();
+
+        // Act
+        $this->sentryChannel()->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+            'runId'            => 42015954,
+            'seasonId'         => 15,
+            'combatLogVersion' => 21,
+            'lineNumber'       => 8842,
+            'exceptionClass'   => 'InvalidArgumentException',
+            'message'          => 'Invalid parameter count',
+            'rawLine'          => '8/3 21:15:02.123  SPELL_AURA_APPLIED,Player-1234-ABCDEF,"Somebody-Realm",...',
+        ]);
+
+        // Assert
+        self::assertCount(1, $transport->capturedEvents);
+
+        $tags = $transport->capturedEvents[0]->getTags();
+        self::assertSame('42015954', $tags['runId'] ?? null);
+        self::assertSame('15', $tags['seasonId'] ?? null);
+        self::assertSame('21', $tags['combatLogVersion'] ?? null);
+        self::assertSame('8842', $tags['lineNumber'] ?? null);
+        self::assertSame('InvalidArgumentException', $tags['exceptionClass'] ?? null);
+
+        self::assertArrayNotHasKey(
+            'rawLine',
+            $tags,
+            'The raw line carries player names and GUIDs and must never become an indexed tag.',
+        );
+    }
+
+    /**
+     * Sentry meters every event even though it groups them, so an unthrottled failure loop can burn the whole event
+     * budget and start dropping genuinely novel errors. The file and stderr channels keep the complete record.
+     */
+    #[Test]
+    public function sentryChannel_givenTheSameFailureRepeatedly_stopsForwardingAfterTheAllowance(): void
+    {
+        // Arrange
+        $transport = $this->bindStubHub();
+        $channel   = $this->sentryChannel();
+
+        // Act - well past any sane per-window allowance
+        for ($i = 0; $i < 50; $i++) {
+            $channel->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+                'exceptionClass' => 'InvalidArgumentException',
+                'message'        => 'Invalid parameter count',
+            ]);
+        }
+
+        // Assert
+        self::assertGreaterThan(0, count($transport->capturedEvents), 'The first occurrences must still be reported.');
+        self::assertLessThan(
+            50,
+            count($transport->capturedEvents),
+            'A repeating failure must be throttled rather than metered in full.',
+        );
+    }
+
+    /**
+     * Distinct failures must not throttle each other - the allowance is per fingerprint, not per channel, or one noisy
+     * error would silence every other error on the site.
+     */
+    #[Test]
+    public function sentryChannel_givenDistinctFailures_throttlesThemIndependently(): void
+    {
+        // Arrange
+        $transport = $this->bindStubHub();
+        $channel   = $this->sentryChannel();
+
+        for ($i = 0; $i < 50; $i++) {
+            $channel->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+                'exceptionClass' => 'InvalidArgumentException',
+                'message'        => 'The noisy one',
+            ]);
+        }
+        $throttled = count($transport->capturedEvents);
+
+        // Act
+        $channel->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+            'exceptionClass' => 'OutOfBoundsException',
+            'message'        => 'The rare one that actually matters',
+        ]);
+
+        // Assert
+        self::assertCount($throttled + 1, $transport->capturedEvents);
     }
 
     #[Test]

--- a/tests/Unit/App/Logging/SentryLogChannelTest.php
+++ b/tests/Unit/App/Logging/SentryLogChannelTest.php
@@ -3,11 +3,13 @@
 namespace Tests\Unit\App\Logging;
 
 use App\Logging\Handlers\SkipsExceptionMirrorsHandler;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Monolog\Handler\NoopHandler;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Sentry\ClientBuilder;
 use Sentry\Options;
 use Sentry\State\Hub;
@@ -216,6 +218,63 @@ final class SentryLogChannelTest extends PublicTestCase
             $transport->capturedEvents[0]->getFingerprint(),
             $transport->capturedEvents[1]->getFingerprint(),
         );
+    }
+
+    /**
+     * The real shape of a parse failure, and the one that matters most: CombatLogStringParser interpolates the
+     * offending line into its message, so the `message` context key carries character names and hex GUIDs. Collapsing
+     * digit runs alone leaves those intact, which would give every failing line its own issue and stop the throttle
+     * (which keys on the fingerprint) from ever engaging.
+     */
+    #[Test]
+    public function sentryChannel_givenParseErrorsCarryingDifferentCombatLogLines_fingerprintsThemTogether(): void
+    {
+        // Arrange
+        $transport = $this->bindStubHub();
+        $channel   = $this->sentryChannel();
+
+        // Act - the same failure on two different lines, from two different players
+        $channel->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+            'exceptionClass' => 'InvalidArgumentException',
+            'message'        => 'Unbalanced quotes in string SPELL_DAMAGE,Player-1084-0B4087DE,"Rhaellyn-Ravencrest',
+        ]);
+        $channel->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+            'exceptionClass' => 'InvalidArgumentException',
+            'message'        => 'Unbalanced quotes in string SPELL_DAMAGE,Player-3676-0A1B2C3D,"Someoneelse-Kazzak',
+        ]);
+
+        // Assert
+        self::assertCount(2, $transport->capturedEvents);
+        self::assertSame(
+            $transport->capturedEvents[0]->getFingerprint(),
+            $transport->capturedEvents[1]->getFingerprint(),
+            'Two occurrences of one parse failure must group, even though each quotes a different combat log line.',
+        );
+    }
+
+    /**
+     * This handler runs inside Monolog's handler loop, which rethrows, and the sentry channel is a member of every
+     * stack this application declares - including the one Handler::report() logs through. A Redis outage must
+     * therefore never turn Log::error() into a thrown exception.
+     */
+    #[Test]
+    public function sentryChannel_givenAnUnreachableCache_stillLogsWithoutThrowing(): void
+    {
+        // Arrange
+        $transport = $this->bindStubHub();
+        $channel   = $this->sentryChannel();
+
+        Cache::shouldReceive('increment')->andThrow(new RuntimeException('Connection refused'));
+        Cache::shouldReceive('put')->andThrow(new RuntimeException('Connection refused'));
+
+        // Act
+        $channel->error('ProcessCombatLogSegmentsLogging::handleParseError', [
+            'exceptionClass' => 'InvalidArgumentException',
+            'message'        => 'Invalid parameter count',
+        ]);
+
+        // Assert - failing open: the record is still reported rather than lost or rethrown
+        self::assertCount(1, $transport->capturedEvents);
     }
 
     /**


### PR DESCRIPTION
:robot: Closes #3820

Stage 1/5 of moving combat log parse failures onto Sentry (#3820 → #3821 → #3822 → #3823 → #3824). **This must deploy before #3821 removes the DB fallback.**

#3794 wired `StructuredLogging` errors into Sentry, but the resulting feed cannot be triaged:

- Sentry groups message events by their message, and `StructuredLogging` logs under a constant `ClassLogging::method`. **Every combat log parse failure ever recorded collapses into one issue**, no matter how many distinct root causes it represents.
- `rawLine`, `lineNumber` and `seasonId` never left the database, so an issue carried nothing you could reproduce from.
- Nothing bounded the volume. Sentry meters every event even though it groups them, so a bad WoW patch failing every line of every run would burn the account's event budget and start dropping genuinely novel errors.

## What changed

Three taps on the `sentry` channel. Their order in `config/logging.php` **reads backwards** — each tap wraps the handlers the previous one produced, so the last entry is outermost and runs first. Execution is `SkipsExceptionMirrors` → `FingerprintsStructuredErrors` → `ThrottlesRepeatedEvents` → `SentryHandler`.

| Handler | Does |
|---|---|
| `FingerprintsStructuredErrorsHandler` | Fingerprints as `[logSite, exceptionClass, normalizedMessage]` (digit runs → `#`), and promotes `runId`/`seasonId`/`combatLogVersion`/`lineNumber`/`exceptionClass` to tags |
| `ThrottlesRepeatedEventsHandler` | Caps events per fingerprint per hour |

Done as **taps rather than at the call sites**, so the `tags`/`fingerprint` keys never leak into the file, stderr and Discord output — and so every future `{Service}Logging` error benefits without further work. That also covers the second parse-failure log site (`ProcessCombatLogPartLogging`, S3-sourced), which has no `runId` and would otherwise have stayed unfingerprinted.

`rawLine` is **deliberately not a tag**: tags are capped at 200 characters and indexed, and a raw combat log line is long and carries player character names and GUIDs. It stays in the context, which the SDK files as extra data.

The normalisation is a direct port of the clustering `combatlog-parse-failure-poll` does by hand today, and **inherits its known limitation**: two genuinely different root causes sharing a normalised shape merge into one issue. Documented, not claimed solved.

## Two inconsistencies found while wiring this up

Both are pre-existing and fixed here, because the tap keys on exactly these names:

1. `ProcessCombatLogSegments` logged `$e::class` — the `CombatLogParseException` **wrapper** — while `recordFailure()` one line below stored the unwrapped cause. The log line and the DB row could not be correlated. Now resolved once and shared.
2. `ProcessCombatLogPartLogging::handleParseError` declared `($combatLogVersion, $offendingLine, $reason, $filePath)`, but its only caller passes `($combatLogVersion, $e->getMessage(), $e::class, $filePath)`. **Every logged context had the message under `offendingLine` and the exception class under `reason`.** Renamed to match reality.

Because `StructuredLogging` builds context from `get_defined_vars()`, renaming a Logging method's parameter silently changes Sentry grouping. Both methods now carry a docblock saying so.

## Test-suite leak

`sentryChannel_givenEmptyDsn_logsWithoutEmittingPhpErrors` logs for real rather than against a stub transport and — unlike its sibling four lines above — had **no guard for a configured DSN**. On any machine whose `.env` holds a real DSN it delivered straight to that project. That is `PHP-LARAVEL-R9`, a PHPUnit assertion string sitting in the production issue list.

Diagnosed before suppressing, per the issue: `phpunit.xml` already pins `LOG_CHANNEL=daily` (which contains no `sentry`), so the channel stack was never the leak. Fixed the test, and pinned both DSN keys empty in `phpunit.xml` as a suite-wide backstop so no future test can reach the real transport either.

Over the last 7 days `local` accounted for 108 events and `testing` 41, against 204 from production — 42% of volume was non-production noise. The remaining `local` share comes from a developer `.env` holding a real DSN, which is not this repo's to change; that is tracked in #3824.

## Verification

- `php artisan test --compact tests/Unit/App/Logging/ tests/Feature/Jobs/CombatLog/` → **65 passed**.
- `composer run fix` → 0 of 3804 files changed. `composer run analyse` → no errors.
- **Each new test was verified to fail with its tap removed** — asserting on configuration shape or calling the handler directly is exactly how #3792 shipped three silent failures past a green suite, so the tests resolve the real DSN-shaped channel against `CapturingTransport` instead.

Backend-only; no visual verification applies.