### PR TITLE
#3801 Drop stale phpunit.xml exclude and stopOnFailure

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,6 @@
          bootstrap="bootstrap/autoload.php"
          colors="true"
          processIsolation="false"
-         stopOnFailure="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          cacheDirectory=".phpunit.cache"
          backupStaticProperties="false">
@@ -16,7 +15,6 @@
             <directory suffix="Test.php">./tests/Unit</directory>
             <exclude>./tests/Unit/App/Service/CombatLog/CombatLogDungeonRouteServiceTest.php</exclude>
             <exclude>./tests/Unit/App/Service/CombatLog/CombatLogServiceTest.php</exclude>
-            <exclude>./tests/Unit/App/Service/Season/SeasonServiceTest.php</exclude>
         </testsuite>
     </testsuites>
     <php>


### PR DESCRIPTION
:robot: Closes #3801

## Summary
- Removed the `SeasonServiceTest` exclude — `tests/Unit/App/Service/Season/` no longer exists, so the entry was dead config.
- Removed `stopOnFailure="true"` — it worked against the CI matrix's `fail-fast: false` (intended to surface every shard's full result), causing a red shard to stop at its first failure and hide the rest.
- Left the two `CombatLog*Test.php` excludes as-is: both files' test bodies are entirely commented out, so they're legitimately excluded, not stale.
- No local `--stop-on-failure` replacement added — there's no dedicated composer test script to attach it to; a dev who wants stop-on-first-failure locally can pass `--stop-on-failure` to `php artisan test` / `vendor/bin/phpunit` directly.

Cold review skipped under the trivial-change rule (2-line phpunit.xml change, no schema/UI/auth impact, no test-coverage change needed for a config-only fix).

## Test plan
- [x] `php artisan test --testsuite "Unit Tests" --exclude-group=MapTiles` green (matches CI's `unit` shard)
- [x] Full `php artisan test --compact` green except the pre-existing, CI-excluded `MapTilesExistenceTest` env-noise failure
- [x] `composer run analyse` clean