### PR TITLE
Exempt heatmap embed data endpoint from CSRF verification

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -48,10 +48,17 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->redirectGuestsTo(fn() => route('login'));
         $middleware->redirectUsersTo('/home');
 
-        // Only the external webhook endpoints (called by GitHub / Wowhead without a session)
-        // are exempt from CSRF verification; every other route sends a token.
+        // Only the external webhook endpoints (called by GitHub / Wowhead without a session), and
+        // the heatmap embed data endpoint, are exempt from CSRF verification; every other route
+        // sends a token. The heatmap embed page is designed to be loaded in an <iframe> on
+        // third-party sites, where SameSite=Lax session/XSRF cookies aren't sent on the
+        // same-origin XHR issued from inside that cross-site iframe, so the token never arrives.
+        // ajax.heatmap.data is a read-only, unauthenticated data fetch (see
+        // AjaxHeatmapController::getData()), so exempting it from CSRF carries no state-changing
+        // risk (see #3836).
         $middleware->validateCsrfTokens(except: [
             'webhook/*',
+            'ajax/heatmap/data',
         ]);
 
         // Prepend so every log line of the request - including those of other global middleware - carries the trace_id

--- a/tests/Unit/App/Http/Middleware/CsrfExemptRoutesTest.php
+++ b/tests/Unit/App/Http/Middleware/CsrfExemptRoutesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit\App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Middleware')]
+#[Group('CsrfExemptRoutes')]
+class CsrfExemptRoutesTest extends PublicTestCase
+{
+    #[Test]
+    public function getExcludedPaths_givenBootedApplication_includesHeatmapEmbedDataRoute(): void
+    {
+        // Arrange
+        /** @var ValidateCsrfToken $middleware */
+        $middleware = $this->app->make(ValidateCsrfToken::class);
+
+        // Act
+        $excludedPaths = $middleware->getExcludedPaths();
+
+        // Assert
+        self::assertContains('ajax/heatmap/data', $excludedPaths);
+    }
+
+    #[Test]
+    public function getExcludedPaths_givenBootedApplication_stillIncludesWebhookRoutes(): void
+    {
+        // Arrange
+        /** @var ValidateCsrfToken $middleware */
+        $middleware = $this->app->make(ValidateCsrfToken::class);
+
+        // Act
+        $excludedPaths = $middleware->getExcludedPaths();
+
+        // Assert
+        self::assertContains('webhook/*', $excludedPaths);
+    }
+}


### PR DESCRIPTION
:robot:

Closes #3836

## Problem

`POST /ajax/heatmap/data` returns `419 CSRF token mismatch` when called from a heatmap embed page, because the embed is designed to be loaded in a cross-site `<iframe>`. `SESSION_SAME_SITE=lax` (the default) means the session/`XSRF-TOKEN` cookies are sent on the initial top-level iframe navigation, but not on the subsequent same-origin XHR issued from *inside* that cross-site iframe — so the token the page renders never reaches the server.

## Fix

Add `ajax/heatmap/data` to the CSRF exemption list in `bootstrap/app.php`, alongside the existing `webhook/*` exemption. `AjaxHeatmapController::getData()` is a read-only, unauthenticated data fetch (no state mutation, no auth), so exempting it from CSRF carries no meaningful risk — same reasoning as the `pr cold reviewed` exceptions applied elsewhere for genuinely side-effect-free endpoints.

## Note: this has already been hotfixed to production (v15.9.1)

Given the severity (heatmap embeds are broken for all viewers) this was pushed out via the `hotfix` skill ahead of this PR landing, with explicit go-ahead in-conversation. This PR lands the same change permanently on `master` so the next release includes it and the hotfix key doesn't need to be re-applied.

- RED baseline confirmed against production before the hotfix: `POST /ajax/heatmap/data` → `419 {"message":"CSRF token mismatch."}`
- Uploaded surgically via `--file=bootstrap/app.php` (verified via `Storage::disk('s3_hotfixes')->allFiles('v15.9.1')`)
- Production container restart being done manually by @Wotuu; GREEN re-verification against production pending that restart.

## Testing

- Added `tests/Unit/App/Http/Middleware/CsrfExemptRoutesTest.php` asserting `ajax/heatmap/data` (and the pre-existing `webhook/*`) are present in `ValidateCsrfToken::getExcludedPaths()` after boot.
- Existing `tests/Feature/Controller/Ajax/AjaxHeatmapControllerTest.php` still green (CSRF is bypassed for feature tests regardless, so it only confirms no regression to the endpoint itself).

Cold review not yet done — @Wotuu asked for Fable to review this one given it's a security-relevant middleware change. Left as draft until that happens.