### PR TITLE
#3837 Keep non-filter query params in the URL when the heatmap sidebar syncs its search

### DIFF
--- a/resources/assets/js/custom/inline/base/searchinlinebase.js
+++ b/resources/assets/js/custom/inline/base/searchinlinebase.js
@@ -7,6 +7,8 @@ class SearchInlineBase extends InlineCode {
         this.searchHandler = searchHandler;
         // Previous search params are used to prevent searching for the same thing multiple times for no reason
         this._previousSearchParams = null;
+        // Every query param name we've written into the URL ourselves - see _updateUrl()
+        this._writtenUrlParamNames = [];
         this.filters = {};
     }
 
@@ -142,9 +144,12 @@ class SearchInlineBase extends InlineCode {
     /**
      * Updates the URL according to the passed searchParams (so users can press F5 and be where they left off, ish)
      *
-     * Query parameters that none of the filters own (embed display options such as defaultZoom or showHeader) are
-     * carried over untouched - rebuilding the query string from the filters alone silently truncated shared embed
-     * URLs (#3837).
+     * Query parameters that we don't own (embed display options such as defaultZoom or showHeader) are carried over
+     * untouched - rebuilding the query string from the filters alone silently truncated shared embed URLs (#3837).
+     *
+     * "Ours" is everything the filters claim plus everything a previous call wrote: a param the caller injected
+     * through `queryParameters` (npc_id on the enemy failures search) would otherwise be preserved forever once it
+     * had been written, even after the search stopped sending it.
      *
      * @param searchParams {SearchParams}
      * @param blacklist {Array}
@@ -159,18 +164,23 @@ class SearchInlineBase extends InlineCode {
         blacklist.push('limit');
 
         // Everything we're not responsible for stays exactly as it was
-        let ownedParams = this._getFilterParamNames().concat(blacklist);
+        let ownedParams = this._getFilterParamNames().concat(blacklist).concat(this._writtenUrlParamNames);
         let existingParams = getQueryParams();
         for (let index in existingParams) {
             if (existingParams.hasOwnProperty(index) && !ownedParams.includes(index) &&
                 !searchParams.params.hasOwnProperty(index)) {
-                urlParams.push(`${index}=${encodeURIComponent(existingParams[index])}`);
+                // The key came out of getQueryParams() decoded, so it needs re-encoding just like the value
+                urlParams.push(`${encodeURIComponent(index)}=${encodeURIComponent(existingParams[index])}`);
             }
         }
 
         for (let index in searchParams.params) {
             if (searchParams.params.hasOwnProperty(index) && !blacklist.includes(index)) {
                 urlParams.push(`${index}=${encodeURIComponent(searchParams.params[index])}`);
+
+                if (!this._writtenUrlParamNames.includes(index)) {
+                    this._writtenUrlParamNames.push(index);
+                }
             }
         }
 

--- a/resources/assets/js/custom/inline/base/searchinlinebase.js
+++ b/resources/assets/js/custom/inline/base/searchinlinebase.js
@@ -50,6 +50,9 @@ class SearchInlineBase extends InlineCode {
                     if (paramsOverride !== null && filter.getParamsOverride().hasOwnProperty(filtersKey)) {
                         // It does! Set the value
                         filter.setValueOverride(filtersKey, queryParams[key]);
+                        // The URL asked for this value explicitly, so it must survive a round trip even when it
+                        // happens to equal the filter's default (#3837)
+                        filter.markValueOverrideExplicit(filtersKey);
                         valueAssigned = true;
                         break;
                     }
@@ -106,7 +109,42 @@ class SearchInlineBase extends InlineCode {
     }
 
     /**
+     * All query parameter names the filters of this search own - anything else in the URL belongs to someone else
+     * and must be left alone by _updateUrl().
+     *
+     * Disabled filters are included on purpose: their params must be dropped from the URL, not preserved.
+     *
+     * @returns {String[]}
+     * @protected
+     */
+    _getFilterParamNames() {
+        console.assert(this instanceof SearchInlineBase, 'this is not a SearchInlineBase!', this);
+
+        let names = [];
+
+        for (let name in this.filters) {
+            if (!this.filters.hasOwnProperty(name)) {
+                continue;
+            }
+
+            let paramsOverride = this.filters[name].getParamsOverride();
+            if (paramsOverride !== null) {
+                names = names.concat(Object.keys(paramsOverride));
+            } else {
+                names.push(name);
+                names.push(`${name}[]`);
+            }
+        }
+
+        return names;
+    }
+
+    /**
      * Updates the URL according to the passed searchParams (so users can press F5 and be where they left off, ish)
+     *
+     * Query parameters that none of the filters own (embed display options such as defaultZoom or showHeader) are
+     * carried over untouched - rebuilding the query string from the filters alone silently truncated shared embed
+     * URLs (#3837).
      *
      * @param searchParams {SearchParams}
      * @param blacklist {Array}
@@ -119,6 +157,16 @@ class SearchInlineBase extends InlineCode {
 
         blacklist.push('offset');
         blacklist.push('limit');
+
+        // Everything we're not responsible for stays exactly as it was
+        let ownedParams = this._getFilterParamNames().concat(blacklist);
+        let existingParams = getQueryParams();
+        for (let index in existingParams) {
+            if (existingParams.hasOwnProperty(index) && !ownedParams.includes(index) &&
+                !searchParams.params.hasOwnProperty(index)) {
+                urlParams.push(`${index}=${encodeURIComponent(existingParams[index])}`);
+            }
+        }
 
         for (let index in searchParams.params) {
             if (searchParams.params.hasOwnProperty(index) && !blacklist.includes(index)) {

--- a/resources/assets/js/custom/inline/base/searchinlinebase.urlsync.test.js
+++ b/resources/assets/js/custom/inline/base/searchinlinebase.urlsync.test.js
@@ -1,0 +1,132 @@
+// ---------------------------------------------------------------------------
+// SearchInlineBase._updateUrl() keeps the address bar in sync with the search, and #3837 made it preserve the
+// query params it doesn't own instead of dropping them. These tests pin the boundary of "doesn't own" on the base
+// class itself, where all four search inlines share it - the heatmap sidebar's own behaviour is covered by
+// custom/inline/common/maps/heatmapsearchsidebar.urlrestore.test.js.
+//
+// The interesting case is a param the caller injects through _search()'s `queryParameters` (npc_id on the enemy
+// failures search): it is not a filter, yet it is ours - so it must not be resurrected from the URL once the
+// search stops sending it.
+// ---------------------------------------------------------------------------
+
+globalThis.$ = globalThis.jQuery = require('jquery');
+
+const {InlineCode} = require('../inlinecode');
+globalThis.InlineCode = InlineCode;
+
+const {getQueryParams} = require('../../util');
+globalThis.getQueryParams = getQueryParams;
+
+const {SearchFilter} = require('../common/search/filters/filter');
+globalThis.SearchFilter = SearchFilter;
+globalThis.SearchParams = require('../common/search/searchparams').SearchParams;
+
+const {SearchInlineBase} = require('./searchinlinebase');
+
+/**
+ * A filter whose value the test drives directly, standing in for a DOM-backed one.
+ */
+class FixedValueFilter extends SearchFilter {
+    constructor(value) {
+        super(null, null, {});
+
+        this.value = value;
+    }
+
+    getValue() {
+        return this.value;
+    }
+
+    setValue(value) {
+        this.value = value;
+    }
+}
+
+/**
+ * @param {String} queryString
+ * @param {Object<string, SearchFilter>} filters
+ * @returns {SearchInlineBase}
+ */
+function buildSearch(queryString, filters) {
+    // jsdom doesn't allow assigning document.location.search - see custom/util.test.js for the same approach.
+    window.history.replaceState({}, '', `/routes${queryString}`);
+
+    const search = new SearchInlineBase({search: () => undefined}, 'search', 'base/search', {});
+    search.filters = filters;
+
+    return search;
+}
+
+/**
+ * @returns {Object<string, string>}
+ */
+function writtenParams() {
+    return Object.fromEntries(new URLSearchParams(window.location.search));
+}
+
+describe('SearchInlineBase - keeping the URL in sync with the search', () => {
+    test('search_givenAParamNoFilterOwns_leavesItInTheUrl', () => {
+        // Arrange
+        const search = buildSearch('?title=abc&defaultZoom=1.4', {title: new FixedValueFilter('abc')});
+
+        // Act
+        search._search();
+
+        // Assert
+        expect(writtenParams()).toEqual({title: 'abc', defaultZoom: '1.4'});
+    });
+
+    test('search_givenAFiltersParamIsNoLongerSent_dropsItFromTheUrl', () => {
+        // Arrange
+        const title = new FixedValueFilter('abc');
+        const search = buildSearch('?title=abc&expansion=midnight', {
+            title: title,
+            expansion: new FixedValueFilter('midnight'),
+        });
+        search._search();
+
+        // Act - clearing a filter must clear it from the URL, not preserve it as someone else's param
+        title.setValue('');
+        search._search();
+
+        // Assert
+        expect(writtenParams()).toEqual({expansion: 'midnight'});
+    });
+
+    test('search_givenAnInjectedParamIsNoLongerSent_dropsItFromTheUrl', () => {
+        // Arrange - mirrors CommonMapsCombatlogrouteenemyfailures, which only injects npc_id while an npc is selected
+        const search = buildSearch('', {title: new FixedValueFilter('abc')});
+        search._search({}, {npc_id: 123});
+        expect(writtenParams().npc_id).toBe('123');
+
+        // Act
+        search._search({}, {});
+
+        // Assert - nothing restores npc_id on F5, so leaving it behind would make the URL lie about the page state
+        expect(writtenParams()).toEqual({title: 'abc'});
+    });
+
+    test('search_givenABlacklistedParam_keepsItOutOfTheUrl', () => {
+        // Arrange
+        const search = buildSearch('', {title: new FixedValueFilter('abc')});
+
+        // Act
+        search._search({}, {dungeonId: 42}, ['dungeonId']);
+
+        // Assert
+        expect(writtenParams()).toEqual({title: 'abc'});
+    });
+
+    test('search_givenAPreservedParamWithReservedCharacters_writesItBackEncoded', () => {
+        // Arrange
+        const search = buildSearch(`?title=abc&${encodeURIComponent('a&b')}=${encodeURIComponent('c&d')}`, {
+            title: new FixedValueFilter('abc'),
+        });
+
+        // Act
+        search._search();
+
+        // Assert - re-emitting the key raw would split it into a different param set than it came in as
+        expect(writtenParams()).toEqual({title: 'abc', 'a&b': 'c&d'});
+    });
+});

--- a/resources/assets/js/custom/inline/common/maps/heatmapsearchsidebar.urlrestore.test.js
+++ b/resources/assets/js/custom/inline/common/maps/heatmapsearchsidebar.urlrestore.test.js
@@ -54,6 +54,11 @@ globalThis.SearchFilterRadioDataType = require('../../common/search/filters/filt
 globalThis.SearchFilterRadioRegion = require('../../common/search/filters/filterradioregion').SearchFilterRadioRegion;
 globalThis.SearchFilterPlayerSpells = require('../../common/search/filters/filterselectplayerspells').SearchFilterPlayerSpells;
 globalThis.SearchFilterPassThrough = require('../../common/search/filters/filterpassthrough').SearchFilterPassThrough;
+const {SearchFilterKeyLevel} = require('../../common/search/filters/filterinputkeylevel');
+globalThis.SearchFilterKeyLevel = SearchFilterKeyLevel;
+// The real key level filter is kept (rather than stubbed like its siblings) because it is the one filter here that
+// claims its URL params through getParamsOverride() - which is where #3837's minMythicLevel truncation lived.
+globalThis.SearchFilterMythicLevel = require('../../common/search/filters/filterinputmythiclevel').SearchFilterMythicLevel;
 
 globalThis.SearchParams = require('../../common/search/searchparams').SearchParams;
 const {SearchInlineBase} = require('../../base/searchinlinebase');
@@ -67,7 +72,6 @@ class StubFilter extends SearchFilter {
 }
 
 for (const name of [
-    'SearchFilterMythicLevel',
     'SearchFilterItemLevel',
     'SearchFilterPlayerDeaths',
     'SearchFilterAffixes',
@@ -82,6 +86,7 @@ for (const name of [
 }
 
 for (const name of [
+    'KeyLevelHandler',
     'HeatOptionMinOpacityHandler',
     'HeatOptionMaxZoomHandler',
     'HeatOptionMaxHandler',
@@ -129,6 +134,9 @@ const BLOODLUST_SPELL_ID = 2825;
 const HEROISM_SPELL_ID = 32182;
 const TIME_WARP_SPELL_ID = 80353;
 const SPELL_IDS = [BLOODLUST_SPELL_ID, HEROISM_SPELL_ID, TIME_WARP_SPELL_ID];
+// The season's own key level bounds - #3837 is about an explicit ?minMythicLevel that happens to equal this minimum.
+const KEY_LEVEL_MIN = 2;
+const KEY_LEVEL_MAX = 99;
 
 const OPTIONS = {
     defaultState: 0,
@@ -146,6 +154,9 @@ const OPTIONS = {
     filterClassesPlayerDeathsSelector: '#filter_classes_player_deaths',
     filterSpecializationsPlayerDeathsContainerSelector: '#filter_specializations_player_deaths_container',
     filterSpecializationsPlayerDeathsSelector: '#filter_specializations_player_deaths',
+    filterKeyLevelSelector: '#filter_key_level',
+    keyLevelMin: KEY_LEVEL_MIN,
+    keyLevelMax: KEY_LEVEL_MAX,
 };
 
 /**
@@ -183,7 +194,16 @@ function buildSidebarDom() {
             <input type="radio" name="region" class="btn-check world" value="world" checked>
             <input type="radio" name="region" class="btn-check us" value="us">
         </div>
+
+        <input type="text" id="filter_key_level" value="${KEY_LEVEL_MIN};${KEY_LEVEL_MAX}">
     `;
+
+    // Stands in for the ion-range-slider instance KeyLevelHandler attaches: the filter reads the input's value and
+    // writes through the slider's update() - both of which have to keep the `min;max` string in sync.
+    const $keyLevel = $('#filter_key_level');
+    $keyLevel.data('rangeSlider', {
+        update: ({from, to}) => $keyLevel.val(`${from};${to}`),
+    });
 }
 
 /**
@@ -369,5 +389,98 @@ describe('CommonMapsHeatmapsearchsidebar - restoring filters from the URL', () =
             dataType: COMBAT_LOG_EVENT_DATA_TYPE_PLAYER_POSITION,
             region: 'world',
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Regression suite for #3837: an embed URL carries display-only options next to the search filters
+// (defaultZoom, showHeader, mapFacadeStyle, ...). The sidebar's initial search used to rebuild the query string
+// from its filters alone, so those options - and any filter value that happened to equal its own default -
+// were silently dropped from the address bar, and an F5 came back with a differently rendered page.
+// ---------------------------------------------------------------------------
+describe('CommonMapsHeatmapsearchsidebar - preserving embed params in the URL', () => {
+    const EMBED_PARAMS = {
+        defaultZoom: '1.4',
+        showHeader: '0',
+        showDataSourceSnackbar: '0',
+        mapFacadeStyle: 'facade',
+    };
+    const EMBED_QUERY_STRING = Object.entries(EMBED_PARAMS).map(([key, value]) => `${key}=${value}`).join('&');
+
+    beforeEach(() => {
+        searchSpy.mockClear();
+    });
+
+    test('activate_givenDisplayOnlyEmbedParams_keepsThemInTheUrl', () => {
+        // Arrange & Act
+        activateSidebar(`?type=${COMBAT_LOG_EVENT_EVENT_TYPE_NPC_DEATH}&dataType=${COMBAT_LOG_EVENT_DATA_TYPE_ENEMY_POSITION}&region=world&${EMBED_QUERY_STRING}`);
+
+        // Assert - none of these belong to a filter, so the sidebar must leave them exactly as it found them
+        expect(writtenParams()).toEqual({
+            type: COMBAT_LOG_EVENT_EVENT_TYPE_NPC_DEATH,
+            dataType: COMBAT_LOG_EVENT_DATA_TYPE_ENEMY_POSITION,
+            region: 'world',
+            ...EMBED_PARAMS,
+        });
+    });
+
+    test('activate_givenDisplayOnlyEmbedParams_doesNotSendThemToTheBackend', () => {
+        // Arrange & Act
+        activateSidebar(`?type=${COMBAT_LOG_EVENT_EVENT_TYPE_NPC_DEATH}&region=world&${EMBED_QUERY_STRING}`);
+
+        // Assert - they're display options for this page, the heatmap endpoint has no use for them
+        for (const key of Object.keys(EMBED_PARAMS)) {
+            expect(searchSpy.mock.calls[0][0].params).not.toHaveProperty(key);
+        }
+    });
+
+    test('changeEventType_givenDisplayOnlyEmbedParams_keepsThemInTheUrl', () => {
+        // Arrange
+        activateSidebar(`?type=${COMBAT_LOG_EVENT_EVENT_TYPE_NPC_DEATH}&region=world&${EMBED_QUERY_STRING}`);
+
+        // Act - a search after the initial restore rewrites the URL again, and must not drop them either
+        $(`input[name="event_type"].${COMBAT_LOG_EVENT_EVENT_TYPE_PLAYER_DEATH}`).prop('checked', true).trigger('change');
+
+        // Assert
+        expect(writtenParams()).toMatchObject(EMBED_PARAMS);
+    });
+
+    test('activate_givenADisabledFiltersParamInTheUrl_stillDropsIt', () => {
+        // Arrange & Act - the data type filter only applies to npc deaths
+        activateSidebar(`?type=${COMBAT_LOG_EVENT_EVENT_TYPE_PLAYER_DEATH}&dataType=${COMBAT_LOG_EVENT_DATA_TYPE_ENEMY_POSITION}&region=world&${EMBED_QUERY_STRING}`);
+
+        // Assert - preserving unknown params must not turn into preserving params the filters do own
+        expect(writtenParams()).not.toHaveProperty('dataType');
+        expect(writtenParams()).toMatchObject(EMBED_PARAMS);
+    });
+
+    test('activate_givenAMinMythicLevelEqualToTheSeasonDefault_keepsItInTheUrl', () => {
+        // Arrange & Act
+        activateSidebar(`?type=${COMBAT_LOG_EVENT_EVENT_TYPE_PLAYER_DEATH}&region=world&minMythicLevel=${KEY_LEVEL_MIN}&maxMythicLevel=${KEY_LEVEL_MAX}`);
+
+        // Assert - an explicitly requested value must round trip even when it matches the filter's own default
+        expect(writtenParams()).toEqual({
+            type: COMBAT_LOG_EVENT_EVENT_TYPE_PLAYER_DEATH,
+            region: 'world',
+            minMythicLevel: `${KEY_LEVEL_MIN}`,
+            maxMythicLevel: `${KEY_LEVEL_MAX}`,
+        });
+    });
+
+    test('activate_givenANonDefaultMinMythicLevel_keepsItInTheUrl', () => {
+        // Arrange & Act
+        activateSidebar(`?type=${COMBAT_LOG_EVENT_EVENT_TYPE_PLAYER_DEATH}&region=world&minMythicLevel=10`);
+
+        // Assert
+        expect(writtenParams().minMythicLevel).toBe('10');
+    });
+
+    test('activate_givenNoMythicLevelParams_leavesThemOutOfTheUrl', () => {
+        // Arrange & Act
+        activateSidebar(`?type=${COMBAT_LOG_EVENT_EVENT_TYPE_PLAYER_DEATH}&region=world`);
+
+        // Assert - untouched filters stay implicit, so a plain link doesn't grow every default under the sun
+        expect(writtenParams()).not.toHaveProperty('minMythicLevel');
+        expect(writtenParams()).not.toHaveProperty('maxMythicLevel');
     });
 });

--- a/resources/assets/js/custom/inline/common/search/filters/filter.js
+++ b/resources/assets/js/custom/inline/common/search/filters/filter.js
@@ -4,6 +4,8 @@ class SearchFilter {
         this.onChange = onChange;
         this.options = options;
         this.enabled = true;
+        // Names of the params override keys that were explicitly restored from the URL - see markValueOverrideExplicit()
+        this.explicitValueOverrides = {};
     }
 
     activate() {
@@ -61,6 +63,26 @@ class SearchFilter {
 
     getDefaultValueOverride(name) {
         return null;
+    }
+
+    /**
+     * Marks a params override key as having been set explicitly (rather than being left at its default).
+     *
+     * A value that happens to equal its own default is otherwise indistinguishable from "not set" and would be
+     * dropped from the URL again on the next search - which silently truncates a shared/embedded link (#3837).
+     *
+     * @param name {String}
+     */
+    markValueOverrideExplicit(name) {
+        this.explicitValueOverrides[name] = true;
+    }
+
+    /**
+     * @param name {String}
+     * @returns {boolean}
+     */
+    hasExplicitValueOverride(name) {
+        return this.explicitValueOverrides.hasOwnProperty(name);
     }
 }
 

--- a/resources/assets/js/custom/inline/common/search/filters/filterinputkeylevel.js
+++ b/resources/assets/js/custom/inline/common/search/filters/filterinputkeylevel.js
@@ -61,3 +61,9 @@ class SearchFilterKeyLevel extends SearchFilterInput {
         }
     }
 }
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {SearchFilterKeyLevel};
+}

--- a/resources/assets/js/custom/inline/common/search/filters/filterinputmythiclevel.js
+++ b/resources/assets/js/custom/inline/common/search/filters/filterinputmythiclevel.js
@@ -33,3 +33,9 @@ class SearchFilterMythicLevel extends SearchFilterKeyLevel {
         return result;
     }
 }
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {SearchFilterMythicLevel};
+}

--- a/resources/assets/js/custom/inline/common/search/searchparams.js
+++ b/resources/assets/js/custom/inline/common/search/searchparams.js
@@ -21,7 +21,11 @@ class SearchParams {
                 let paramsOverride = filter.getParamsOverride();
                 if (paramsOverride !== null && paramsOverride.length !== null) {
                     for (let key in paramsOverride) {
-                        if (paramsOverride.hasOwnProperty(key) && paramsOverride[key] !== filter.getDefaultValueOverride(key)) {
+                        // A value equal to its own default is only dropped when it wasn't explicitly asked for -
+                        // otherwise an explicit ?minMythicLevel=2 vanishes from the URL just because 2 also
+                        // happens to be that filter's default (#3837).
+                        if (paramsOverride.hasOwnProperty(key) &&
+                            (filter.hasExplicitValueOverride(key) || paramsOverride[key] !== filter.getDefaultValueOverride(key))) {
                             this.params[key] = paramsOverride[key];
                         }
                     }


### PR DESCRIPTION
:robot:

Closes #3837

## What was wrong

`SearchInlineBase._updateUrl()` threw away the entire existing query string and rebuilt it from the
search filters via `history.pushState`. A heatmap embed URL carries display-only options next to the
filters, and those aren't filters at all — so `defaultZoom`, `showHeader`, `showDataSourceSnackbar`
and `mapFacadeStyle` vanished from the address bar the moment the sidebar's initial search ran.

Separately, `SearchParams` omits any params-override value equal to `filter.getDefaultValueOverride()`.
An explicit `?minMythicLevel=2` on a season whose own minimum is also 2 is then indistinguishable from
"not set", so it was dropped too (while `maxMythicLevel=99` survived, because it differs from its default).

The page rendered correctly on first load — the bug only surfaced on F5, or when the (already truncated)
URL was copied and reused.

## What changed

- `_updateUrl()` carries over every query parameter that none of the filters own, instead of replacing
  the whole query string. Ownership is computed from each filter's `getParamsOverride()` keys, or its
  name (plus `name[]`) when it has none. **Disabled** filters count as owners, so their params are still
  dropped from the URL rather than preserved — the existing `dataType`-on-player-deaths behaviour is
  unchanged.
- Restoring a params-override value from the URL now marks it explicit (`SearchFilter.markValueOverrideExplicit()`),
  and `SearchParams` only applies the equals-default suppression to values that were *not* explicitly asked for.
- "Ours" also covers every param name `_updateUrl()` has written itself, not just the filters' — `_search()` merges
  caller-supplied `queryParameters` into the URL too, and those would otherwise be preserved forever once written
  (`npc_id` on the enemy failures search). Preserved keys are re-encoded, since `getQueryParams()` hands them back
  decoded.

The display-only options deliberately stay out of the filter set, so they round-trip through the URL
without being posted to the heatmap endpoint (asserted by a test).

## Testing

Extended `resources/assets/js/custom/inline/common/maps/heatmapsearchsidebar.urlrestore.test.js` with a
second suite (7 tests). The real `SearchFilterMythicLevel`/`SearchFilterKeyLevel` are now wired into the
harness instead of being stubbed — it is the one filter there that claims its URL params through
`getParamsOverride()`, which is where the `minMythicLevel` truncation lived.

New `resources/assets/js/custom/inline/base/searchinlinebase.urlsync.test.js` (5 tests) pins the ownership
boundary on the base class the four search inlines share: preserved / filter-cleared / injected-and-cleared /
blacklisted / reserved-character keys.

- Reverting only the source files makes 4 of the heatmap tests fail; dropping the written-params ownership
  makes the injected-param test fail. With the fix all 23 in the two files pass.
- Full JS suite green: 364 tests / 40 files.

## Verification

The heatmap page itself can't be opened in this dev stack (`App\Features\Heatmap` requires
`opensearch-laravel.host` to be configured when `APP_ENV=local`, so every heatmap URL redirects to the
dungeon-select page). Instead the built bundle was driven directly in real headless Chrome on
`/routes/retail/pit-of-saron?title=abc&someUnknownParam=keepme&minMythicLevel=2&maxMythicLevel=99`,
constructing a `SearchInlineBase` with a title filter and a `SearchFilterMythicLevel(2, 99)`, restoring
from the URL and calling `_updateUrl()`:

| bundle | resulting `window.location.search` |
| --- | --- |
| before | `?title=abc` |
| after | `?someUnknownParam=keepme&title=abc&minMythicLevel=2&maxMythicLevel=99` |

No rendered output changed, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
