### PR TITLE
#3833 Track Feign Death, Mage Invisibility and Cloak of Shadows as counter spells

### DIFF
--- a/app/Models/CombatLog/SpellProperty.php
+++ b/app/Models/CombatLog/SpellProperty.php
@@ -6,21 +6,24 @@ use App\Models\Spell\Spell;
 
 enum SpellProperty: string
 {
-    case Aura              = 'aura';
-    case Debuff            = 'debuff';
-    case MissAbsorb        = 'miss_absorb';
-    case MissBlock         = 'miss_block';
-    case MissDeflect       = 'miss_deflect';
-    case MissDodge         = 'miss_dodge';
-    case MissEvade         = 'miss_evade';
-    case MissImmune        = 'miss_immune';
-    case MissMiss          = 'miss_miss';
-    case MissParry         = 'miss_parry';
-    case MissReflect       = 'miss_reflect';
-    case MissResist        = 'miss_resist';
-    case MissInterrupt     = 'miss_interrupt';
-    case CounterVanish     = 'counter_vanish';
-    case CounterShadowmeld = 'counter_shadowmeld';
+    case Aura                  = 'aura';
+    case Debuff                = 'debuff';
+    case MissAbsorb            = 'miss_absorb';
+    case MissBlock             = 'miss_block';
+    case MissDeflect           = 'miss_deflect';
+    case MissDodge             = 'miss_dodge';
+    case MissEvade             = 'miss_evade';
+    case MissImmune            = 'miss_immune';
+    case MissMiss              = 'miss_miss';
+    case MissParry             = 'miss_parry';
+    case MissReflect           = 'miss_reflect';
+    case MissResist            = 'miss_resist';
+    case MissInterrupt         = 'miss_interrupt';
+    case CounterVanish         = 'counter_vanish';
+    case CounterShadowmeld     = 'counter_shadowmeld';
+    case CounterFeignDeath     = 'counter_feign_death';
+    case CounterInvisibility   = 'counter_invisibility';
+    case CounterCloakOfShadows = 'counter_cloak_of_shadows';
 
     public static function fromMissTypeBit(int $bit): self
     {

--- a/app/Models/Spell/SpellConstants.php
+++ b/app/Models/Spell/SpellConstants.php
@@ -72,12 +72,18 @@ trait SpellConstants
         Resist::class  => self::MISS_TYPE_RESIST,
     ];
 
-    public const int COUNTER_VANISH     = 1;
-    public const int COUNTER_SHADOWMELD = 2;
+    public const int COUNTER_VANISH           = 1;
+    public const int COUNTER_SHADOWMELD       = 2;
+    public const int COUNTER_FEIGN_DEATH      = 4;
+    public const int COUNTER_INVISIBILITY     = 8;
+    public const int COUNTER_CLOAK_OF_SHADOWS = 16;
 
     public const array ALL_COUNTERS = [
-        self::COUNTER_VANISH     => 'vanish',
-        self::COUNTER_SHADOWMELD => 'shadowmeld',
+        self::COUNTER_VANISH           => 'vanish',
+        self::COUNTER_SHADOWMELD       => 'shadowmeld',
+        self::COUNTER_FEIGN_DEATH      => 'feign_death',
+        self::COUNTER_INVISIBILITY     => 'invisibility',
+        self::COUNTER_CLOAK_OF_SHADOWS => 'cloak_of_shadows',
     ];
 
     public const string DISPEL_TYPE_MAGIC         = 'magic';

--- a/app/Models/Spell/SpellConstants.php
+++ b/app/Models/Spell/SpellConstants.php
@@ -86,6 +86,9 @@ trait SpellConstants
         self::COUNTER_CLOAK_OF_SHADOWS => 'cloak_of_shadows',
     ];
 
+    /** The prefix `spells`.`dispel_type` carries since its values became translation keys. */
+    public const string DISPEL_TYPE_TRANSLATION_KEY_PREFIX = 'spelldispeltype.';
+
     public const string DISPEL_TYPE_MAGIC         = 'magic';
     public const string DISPEL_TYPE_DISEASE       = 'disease';
     public const string DISPEL_TYPE_POISON        = 'poison';

--- a/app/Service/CombatLog/DataExtractors/Logging/SpellCounterDataExtractorLogging.php
+++ b/app/Service/CombatLog/DataExtractors/Logging/SpellCounterDataExtractorLogging.php
@@ -24,6 +24,11 @@ class SpellCounterDataExtractorLogging extends StructuredLogging implements Spel
         $this->debug(__METHOD__, get_defined_vars());
     }
 
+    public function extractDataDebuffNotStrippableByCounter(int $spellId, string $property, string $dispelType): void
+    {
+        $this->debug(__METHOD__, get_defined_vars());
+    }
+
     public function extractDataAbandonedCastWasDisturbed(string $casterGuid, int $spellId): void
     {
         $this->debug(__METHOD__, get_defined_vars());

--- a/app/Service/CombatLog/DataExtractors/Logging/SpellCounterDataExtractorLoggingInterface.php
+++ b/app/Service/CombatLog/DataExtractors/Logging/SpellCounterDataExtractorLoggingInterface.php
@@ -10,6 +10,8 @@ interface SpellCounterDataExtractorLoggingInterface
 
     public function extractDataDebuffExpiredNaturally(int $spellId, int $observedLifetimeMs, int $duration): void;
 
+    public function extractDataDebuffNotStrippableByCounter(int $spellId, string $property, string $dispelType): void;
+
     public function extractDataAbandonedCastWasDisturbed(string $casterGuid, int $spellId): void;
 
     public function extractDataAbandonedCastHasNoCounterInWindow(string $casterGuid, int $spellId): void;

--- a/app/Service/CombatLog/DataExtractors/SpellCounterDataExtractor.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounterDataExtractor.php
@@ -66,9 +66,6 @@ class SpellCounterDataExtractor implements DataExtractorInterface
      */
     public const int EPSILON_MS = 100;
 
-    /** @var string Prefix `spells`.`dispel_type` carries since the values became translation keys. */
-    public const string DISPEL_TYPE_TRANSLATION_KEY_PREFIX = 'spelldispeltype.';
-
     /** @var int Window in which a nil-source debuff is linked back to a temporally adjacent NPC SPELL_CAST_START. */
     public const int CAST_START_LINK_WINDOW_MS = 500;
 
@@ -790,7 +787,7 @@ class SpellCounterDataExtractor implements DataExtractorInterface
         }
 
         // Rows predating the translation-key migration still hold the bare value, so compare on that
-        $dispelType = Str::after($dispelType, self::DISPEL_TYPE_TRANSLATION_KEY_PREFIX);
+        $dispelType = Str::after($dispelType, SpellModel::DISPEL_TYPE_TRANSLATION_KEY_PREFIX);
 
         if (!in_array($dispelType, $unstrippableDispelTypes, true)) {
             return true;

--- a/app/Service/CombatLog/DataExtractors/SpellCounterDataExtractor.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounterDataExtractor.php
@@ -38,19 +38,23 @@ use App\Service\CombatLog\Dtos\DataExtraction\DataExtractionCurrentDungeon;
 use App\Service\CombatLog\Dtos\DataExtraction\ExtractedDataResult;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Str;
 
 /**
- * Detects "spell counter" tricks - a player using a counter ability (Rogue Vanish, Night Elf Shadowmeld) to make an
- * incoming NPC ability fizzle - and records them on the Spell that was countered.
+ * Detects "spell counter" tricks - a player using a counter ability (Rogue Vanish, Night Elf Shadowmeld, Hunter Feign
+ * Death, Mage Invisibility, Rogue Cloak of Shadows) to make an incoming NPC ability fizzle - and records them on the
+ * Spell that was countered.
  *
- * Three signatures are recognized:
+ * A counter is triggered by its own SPELL_CAST_SUCCESS, by a player buff SPELL_AURA_APPLIED, or by both - see
+ * SpellCounterDefinitionInterface::getTriggerAuraSpellIds(). Three signatures are recognized from there:
  * - A: an NPC targeting debuff (applied with a nil source guid, linked back to the NPC's SPELL_CAST_START) is dropped
- *   within EPSILON_MS of a counter cast. The fact attaches to the NPC's *cast* spell id.
- * - B: an NPC-sourced debuff (a channel) on the counter-caster is removed within EPSILON_MS of the counter cast, well
- *   before its natural duration. The fact attaches to the debuff's own spell id.
+ *   within EPSILON_MS of a counter trigger. The fact attaches to the NPC's *cast* spell id.
+ * - B: an NPC-sourced debuff (a channel, or - for Cloak of Shadows - a stripped magic debuff) on the counter-caster is
+ *   removed within EPSILON_MS of the counter trigger, well before its natural duration. The fact attaches to the
+ *   debuff's own spell id.
  * - C: an NPC SPELL_CAST_START never reaches SPELL_CAST_SUCCESS and the same caster starts a fresh cast shortly after
- *   a counter cast, with no other explanation (no fail, no interrupt, no death, no loss-of-control debuff on the
- *   caster).
+ *   a counter trigger, with no other explanation (no fail, no interrupt, no death, no loss-of-control debuff on the
+ *   caster). Only counters that drop threat can produce this signature.
  */
 class SpellCounterDataExtractor implements DataExtractorInterface
 {
@@ -61,6 +65,9 @@ class SpellCounterDataExtractor implements DataExtractorInterface
      * without admitting coincidences.
      */
     public const int EPSILON_MS = 100;
+
+    /** @var string Prefix `spells`.`dispel_type` carries since the values became translation keys. */
+    public const string DISPEL_TYPE_TRANSLATION_KEY_PREFIX = 'spelldispeltype.';
 
     /** @var int Window in which a nil-source debuff is linked back to a temporally adjacent NPC SPELL_CAST_START. */
     public const int CAST_START_LINK_WINDOW_MS = 500;
@@ -103,6 +110,9 @@ class SpellCounterDataExtractor implements DataExtractorInterface
     /** @var Collection<int, SpellCounterDefinitionInterface> Keyed by trigger cast spell id. */
     private readonly Collection $definitionsByTriggerSpellId;
 
+    /** @var Collection<int, SpellCounterDefinitionInterface> Keyed by trigger player buff aura spell id. */
+    private readonly Collection $definitionsByTriggerAuraSpellId;
+
     /** @var Collection<string, SpellCounterDefinitionInterface> Keyed by SpellProperty value. */
     private readonly Collection $definitionsByProperty;
 
@@ -137,7 +147,7 @@ class SpellCounterDataExtractor implements DataExtractorInterface
     /**
      * Debuff removals seen *before* the counter cast that caused them - the backward half of the two-sided window.
      *
-     * @var Collection<int, array{ts: Carbon, playerGuid: string, attributedSpellId: int, npcId: int|null, appliedAt: Carbon, signature: string}>
+     * @var Collection<int, array{ts: Carbon, playerGuid: string, attributedSpellId: int, removedSpellId: int, npcId: int|null, appliedAt: Carbon, signature: string}>
      */
     private Collection $recentDebuffRemovals;
 
@@ -162,6 +172,13 @@ class SpellCounterDataExtractor implements DataExtractorInterface
      */
     private Collection $spellMechanicCache;
 
+    /**
+     * Lazily memoized `spells`.`dispel_type` per spell id. False marks a spell that has no row.
+     *
+     * @var Collection<int, string|null|false>
+     */
+    private Collection $spellDispelTypeCache;
+
     private readonly SpellCounterDataExtractorLoggingInterface $log;
 
     private ?string $currentCombatLogFilePath = null;
@@ -171,23 +188,30 @@ class SpellCounterDataExtractor implements DataExtractorInterface
 
     public function __construct()
     {
-        $definitionsByTriggerSpellId = collect();
-        $definitionsByProperty       = collect();
+        $definitionsByTriggerSpellId     = collect();
+        $definitionsByTriggerAuraSpellId = collect();
+        $definitionsByProperty           = collect();
 
         foreach (SpellCounterDefinitions::all() as $definition) {
             foreach ($definition->getTriggerCastSpellIds() as $triggerCastSpellId) {
                 $definitionsByTriggerSpellId->put($triggerCastSpellId, $definition);
             }
 
+            foreach ($definition->getTriggerAuraSpellIds() as $triggerAuraSpellId) {
+                $definitionsByTriggerAuraSpellId->put($triggerAuraSpellId, $definition);
+            }
+
             $definitionsByProperty->put($definition->getProperty()->value, $definition);
         }
 
-        $this->definitionsByTriggerSpellId = $definitionsByTriggerSpellId;
-        $this->definitionsByProperty       = $definitionsByProperty;
+        $this->definitionsByTriggerSpellId     = $definitionsByTriggerSpellId;
+        $this->definitionsByTriggerAuraSpellId = $definitionsByTriggerAuraSpellId;
+        $this->definitionsByProperty           = $definitionsByProperty;
 
         $this->pendingCounterObservations = collect();
         $this->spellDurationCache         = collect();
         $this->spellMechanicCache         = collect();
+        $this->spellDispelTypeCache       = collect();
         $this->resetCorrelationState();
 
         $log = App::make(SpellCounterDataExtractorLoggingInterface::class);
@@ -252,7 +276,7 @@ class SpellCounterDataExtractor implements DataExtractorInterface
             }
         } elseif ($suffix instanceof CastSuccess) {
             if ($sourceGuid instanceof Player) {
-                $this->handlePlayerCastSuccess($sourceGuid->getGuid(), $prefix->getSpellId(), $timestamp);
+                $this->handleCounterTrigger($this->definitionsByTriggerSpellId, $sourceGuid->getGuid(), $prefix->getSpellId(), $timestamp);
             } elseif ($sourceNpcGuid !== null) {
                 // The cast resolved - it needs no further explanation
                 $this->pendingNpcCasts->forget($sourceNpcGuid);
@@ -269,6 +293,8 @@ class SpellCounterDataExtractor implements DataExtractorInterface
         } elseif ($suffix instanceof AuraAppliedInterface) {
             if ($suffix->getAuraType() === AuraBase::AURA_TYPE_DEBUFF) {
                 $this->handleDebuffApplied($sourceGuid, $destGuid, $prefix->getSpellId(), $prefix->getSpellName(), $timestamp);
+            } elseif ($destGuid instanceof Player) {
+                $this->handleCounterTrigger($this->definitionsByTriggerAuraSpellId, $destGuid->getGuid(), $prefix->getSpellId(), $timestamp);
             }
         } elseif ($suffix instanceof AuraRemovedInterface) {
             if ($suffix->getAuraType() === AuraBase::AURA_TYPE_DEBUFF && $destGuid instanceof Player) {
@@ -317,6 +343,7 @@ class SpellCounterDataExtractor implements DataExtractorInterface
         $this->pendingCounterObservations = collect();
         $this->spellDurationCache         = collect();
         $this->spellMechanicCache         = collect();
+        $this->spellDispelTypeCache       = collect();
         $this->currentCombatLogFilePath   = null;
         $this->currentDungeonId           = null;
         $this->resetCorrelationState();
@@ -481,6 +508,11 @@ class SpellCounterDataExtractor implements DataExtractorInterface
         }
 
         foreach ($this->recentCounterCasts->reverse() as $counterCast) {
+            // A counter that does not drop threat gives the NPC no reason to give up on its cast
+            if (!$counterCast['definition']->dropsThreat()) {
+                continue;
+            }
+
             $counterOffsetMs = $this->millisecondsBetween($pendingCast['startedAt'], $counterCast['ts']);
             // The counter must have happened while the cast was in flight - a hair before it started is allowed
             // because same-instant ordering in the combat log is arbitrary
@@ -502,13 +534,15 @@ class SpellCounterDataExtractor implements DataExtractorInterface
     }
 
     /**
-     * A player counter cast closes the backward half of the two-sided window: debuff removals seen just before it are
-     * attributed retroactively.
+     * A counter trigger - its own cast, or the buff aura marking the moment it takes effect - closes the backward
+     * half of the two-sided window: debuff removals seen just before it are attributed retroactively.
+     *
+     * @param Collection<int, SpellCounterDefinitionInterface> $definitionsBySpellId
      */
-    private function handlePlayerCastSuccess(string $playerGuid, int $spellId, Carbon $timestamp): void
+    private function handleCounterTrigger(Collection $definitionsBySpellId, string $playerGuid, int $spellId, Carbon $timestamp): void
     {
         /** @var SpellCounterDefinitionInterface|null $definition */
-        $definition = $this->definitionsByTriggerSpellId->get($spellId);
+        $definition = $definitionsBySpellId->get($spellId);
         if ($definition === null) {
             return;
         }
@@ -526,6 +560,10 @@ class SpellCounterDataExtractor implements DataExtractorInterface
             }
 
             if (abs($this->millisecondsBetween($debuffRemoval['ts'], $timestamp)) > self::EPSILON_MS) {
+                continue;
+            }
+
+            if (!$this->isStrippableDebuff($definition, $debuffRemoval['removedSpellId'])) {
                 continue;
             }
 
@@ -618,6 +656,10 @@ class SpellCounterDataExtractor implements DataExtractorInterface
                 continue;
             }
 
+            if (!$this->isStrippableDebuff($counterCast['definition'], $spellId)) {
+                continue;
+            }
+
             $this->queueCounterObservation($signature, $attributedSpellId, $counterCast['definition'], $playerGuid, $activeDebuff['npcId']);
 
             return;
@@ -628,6 +670,7 @@ class SpellCounterDataExtractor implements DataExtractorInterface
             'ts'                => $timestamp,
             'playerGuid'        => $playerGuid,
             'attributedSpellId' => $attributedSpellId,
+            'removedSpellId'    => $spellId,
             'npcId'             => $activeDebuff['npcId'],
             'appliedAt'         => $activeDebuff['appliedAt'],
             'signature'         => $signature,
@@ -714,6 +757,46 @@ class SpellCounterDataExtractor implements DataExtractorInterface
                 return true;
             }
         }
+
+        return false;
+    }
+
+    /**
+     * Whether the removal of this debuff can be attributed to the given counter. Counters that drop threat make the
+     * NPC give up on the player whatever it had applied, so nothing rules them out; Cloak of Shadows can only strip
+     * magic, so a poison or disease falling off in its window is provably not its doing.
+     *
+     * Only a dispel type that positively contradicts the counter rejects - an unresolved one (`n_a`, `unknown`, or
+     * the empty string a combat-log-created spell carries until its Wowhead data is fetched) passes. Being
+     * permissive here mirrors the loss-of-control veto: the spells this extractor discovers are precisely the ones
+     * with no fetched data yet, and the observation staleness window self-corrects rare misattributions.
+     */
+    private function isStrippableDebuff(SpellCounterDefinitionInterface $definition, int $removedSpellId): bool
+    {
+        $unstrippableDispelTypes = $definition->getUnstrippableDebuffDispelTypes();
+        if ($unstrippableDispelTypes === []) {
+            return true;
+        }
+
+        if (!$this->spellDispelTypeCache->has($removedSpellId)) {
+            $dispelType = SpellModel::query()->where('id', $removedSpellId)->value('dispel_type');
+
+            $this->spellDispelTypeCache->put($removedSpellId, $dispelType ?? false);
+        }
+
+        $dispelType = $this->spellDispelTypeCache->get($removedSpellId);
+        if (!is_string($dispelType)) {
+            return true;
+        }
+
+        // Rows predating the translation-key migration still hold the bare value, so compare on that
+        $dispelType = Str::after($dispelType, self::DISPEL_TYPE_TRANSLATION_KEY_PREFIX);
+
+        if (!in_array($dispelType, $unstrippableDispelTypes, true)) {
+            return true;
+        }
+
+        $this->log->extractDataDebuffNotStrippableByCounter($removedSpellId, $definition->getProperty()->value, $dispelType);
 
         return false;
     }

--- a/app/Service/CombatLog/DataExtractors/SpellCounters/CloakOfShadowsSpellCounterDefinition.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounters/CloakOfShadowsSpellCounterDefinition.php
@@ -60,6 +60,12 @@ class CloakOfShadowsSpellCounterDefinition extends SpellCounterDefinition
     }
 
     /**
+     * `Spell::DISPEL_TYPE_NONE` is deliberately absent even though "not dispellable at all"
+     * contradicts a magic strip as squarely as a poison does: `2026_04_20_224500_update_spell_dispel_type_to_translation_keys`
+     * folded the legacy empty string into `none` alongside the explicit `None`, so the value no
+     * longer distinguishes "known to be undispellable" from "never had a value" - and rejecting
+     * on it would rule out spells that only look undispellable because nobody filled the field.
+     *
      * @return array<string>
      */
     public function getUnstrippableDebuffDispelTypes(): array

--- a/app/Service/CombatLog/DataExtractors/SpellCounters/CloakOfShadowsSpellCounterDefinition.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounters/CloakOfShadowsSpellCounterDefinition.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Service\CombatLog\DataExtractors\SpellCounters;
+
+use App\Models\CharacterClass;
+use App\Models\CombatLog\SpellProperty;
+use App\Models\Spell\Spell;
+
+/**
+ * Unlike the threat-drop counters, Cloak of Shadows does not pre-empt anything - it strips the magic debuffs already
+ * on the rogue the instant it goes up. Only the debuff-removal signatures apply to it, and only for magic debuffs.
+ */
+class CloakOfShadowsSpellCounterDefinition extends SpellCounterDefinition
+{
+    /** Cast and self-aura share this id, and both are logged at the same instant. */
+    public const int SPELL_ID_CLOAK_OF_SHADOWS = 31224;
+
+    public function getProperty(): SpellProperty
+    {
+        return SpellProperty::CounterCloakOfShadows;
+    }
+
+    public function getCounterBit(): int
+    {
+        return Spell::COUNTER_CLOAK_OF_SHADOWS;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getTriggerCastSpellIds(): array
+    {
+        return [self::SPELL_ID_CLOAK_OF_SHADOWS];
+    }
+
+    /**
+     * The strip is done by the aura, not by the cast - both are logged at the same instant, but keying off the aura
+     * as well means a cast success that is missing from the log does not lose the detection.
+     *
+     * @return array<int>
+     */
+    public function getTriggerAuraSpellIds(): array
+    {
+        return [self::SPELL_ID_CLOAK_OF_SHADOWS];
+    }
+
+    public function getIconName(): string
+    {
+        return 'spell_shadow_nethercloak';
+    }
+
+    public function getCharacterClassKey(): ?string
+    {
+        return CharacterClass::CHARACTER_CLASS_ROGUE;
+    }
+
+    public function dropsThreat(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getUnstrippableDebuffDispelTypes(): array
+    {
+        return [
+            Spell::DISPEL_TYPE_POISON,
+            Spell::DISPEL_TYPE_DISEASE,
+            Spell::DISPEL_TYPE_CURSE,
+            Spell::DISPEL_TYPE_ENRAGE,
+        ];
+    }
+}

--- a/app/Service/CombatLog/DataExtractors/SpellCounters/FeignDeathSpellCounterDefinition.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounters/FeignDeathSpellCounterDefinition.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Service\CombatLog\DataExtractors\SpellCounters;
+
+use App\Models\CharacterClass;
+use App\Models\CombatLog\SpellProperty;
+use App\Models\Spell\Spell;
+
+class FeignDeathSpellCounterDefinition extends SpellCounterDefinition
+{
+    /** Cast and self-aura share this id, and both are logged at the same instant. */
+    public const int SPELL_ID_FEIGN_DEATH = 5384;
+
+    public function getProperty(): SpellProperty
+    {
+        return SpellProperty::CounterFeignDeath;
+    }
+
+    public function getCounterBit(): int
+    {
+        return Spell::COUNTER_FEIGN_DEATH;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getTriggerCastSpellIds(): array
+    {
+        return [self::SPELL_ID_FEIGN_DEATH];
+    }
+
+    public function getIconName(): string
+    {
+        return 'ability_rogue_feigndeath';
+    }
+
+    public function getCharacterClassKey(): ?string
+    {
+        return CharacterClass::CHARACTER_CLASS_HUNTER;
+    }
+}

--- a/app/Service/CombatLog/DataExtractors/SpellCounters/InvisibilitySpellCounterDefinition.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounters/InvisibilitySpellCounterDefinition.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Service\CombatLog\DataExtractors\SpellCounters;
+
+use App\Models\CharacterClass;
+use App\Models\CombatLog\SpellProperty;
+use App\Models\Spell\Spell;
+
+class InvisibilitySpellCounterDefinition extends SpellCounterDefinition
+{
+    /**
+     * The cast of Invisibility. Deliberately NOT a trigger: it only starts a 3 second fade, and the threat drop
+     * happens when SPELL_ID_INVISIBILITY_AURA lands at the end of it.
+     */
+    public const int SPELL_ID_INVISIBILITY_CAST = 66;
+
+    /** The invisible state proper, applied 3 seconds after the cast - this is the moment threat is dropped. */
+    public const int SPELL_ID_INVISIBILITY_AURA = 32612;
+
+    /** Greater Invisibility (Arcane) has no fade - its cast and aura land together. */
+    public const int SPELL_ID_GREATER_INVISIBILITY = 110959;
+
+    public function getProperty(): SpellProperty
+    {
+        return SpellProperty::CounterInvisibility;
+    }
+
+    public function getCounterBit(): int
+    {
+        return Spell::COUNTER_INVISIBILITY;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getTriggerCastSpellIds(): array
+    {
+        return [self::SPELL_ID_GREATER_INVISIBILITY];
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getTriggerAuraSpellIds(): array
+    {
+        return [self::SPELL_ID_INVISIBILITY_AURA, self::SPELL_ID_GREATER_INVISIBILITY];
+    }
+
+    public function getIconName(): string
+    {
+        return 'ability_mage_invisibility';
+    }
+
+    public function getCharacterClassKey(): ?string
+    {
+        return CharacterClass::CHARACTER_CLASS_MAGE;
+    }
+}

--- a/app/Service/CombatLog/DataExtractors/SpellCounters/InvisibilitySpellCounterDefinition.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounters/InvisibilitySpellCounterDefinition.php
@@ -17,8 +17,14 @@ class InvisibilitySpellCounterDefinition extends SpellCounterDefinition
     /** The invisible state proper, applied 3 seconds after the cast - this is the moment threat is dropped. */
     public const int SPELL_ID_INVISIBILITY_AURA = 32612;
 
-    /** Greater Invisibility (Arcane) has no fade - its cast and aura land together. */
-    public const int SPELL_ID_GREATER_INVISIBILITY = 110959;
+    /** Greater Invisibility (Arcane) has no fade - its cast and aura land in the same millisecond. */
+    public const int SPELL_ID_GREATER_INVISIBILITY_CAST = 110959;
+
+    /**
+     * The Greater Invisibility buff. Real logs show it cast under this id as well as under
+     * SPELL_ID_GREATER_INVISIBILITY_CAST, so it is registered as both a cast and an aura trigger.
+     */
+    public const int SPELL_ID_GREATER_INVISIBILITY_AURA = 110960;
 
     public function getProperty(): SpellProperty
     {
@@ -35,7 +41,7 @@ class InvisibilitySpellCounterDefinition extends SpellCounterDefinition
      */
     public function getTriggerCastSpellIds(): array
     {
-        return [self::SPELL_ID_GREATER_INVISIBILITY];
+        return [self::SPELL_ID_GREATER_INVISIBILITY_CAST, self::SPELL_ID_GREATER_INVISIBILITY_AURA];
     }
 
     /**
@@ -43,7 +49,7 @@ class InvisibilitySpellCounterDefinition extends SpellCounterDefinition
      */
     public function getTriggerAuraSpellIds(): array
     {
-        return [self::SPELL_ID_INVISIBILITY_AURA, self::SPELL_ID_GREATER_INVISIBILITY];
+        return [self::SPELL_ID_INVISIBILITY_AURA, self::SPELL_ID_GREATER_INVISIBILITY_AURA];
     }
 
     public function getIconName(): string

--- a/app/Service/CombatLog/DataExtractors/SpellCounters/ShadowmeldSpellCounterDefinition.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounters/ShadowmeldSpellCounterDefinition.php
@@ -6,7 +6,7 @@ use App\Models\CharacterRace;
 use App\Models\CombatLog\SpellProperty;
 use App\Models\Spell\Spell;
 
-class ShadowmeldSpellCounterDefinition implements SpellCounterDefinitionInterface
+class ShadowmeldSpellCounterDefinition extends SpellCounterDefinition
 {
     public const int SPELL_ID_SHADOWMELD = 58984;
 
@@ -31,11 +31,6 @@ class ShadowmeldSpellCounterDefinition implements SpellCounterDefinitionInterfac
     public function getIconName(): string
     {
         return 'ability_ambush';
-    }
-
-    public function getCharacterClassKey(): ?string
-    {
-        return null;
     }
 
     public function getCharacterRaceKey(): ?string

--- a/app/Service/CombatLog/DataExtractors/SpellCounters/SpellCounterDefinition.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounters/SpellCounterDefinition.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Service\CombatLog\DataExtractors\SpellCounters;
+
+/**
+ * Defaults shared by every counter definition: the archetype is a threat drop that is triggered by its own cast and
+ * puts no requirement on the debuff it makes go away.
+ */
+abstract class SpellCounterDefinition implements SpellCounterDefinitionInterface
+{
+    /**
+     * @return array<int>
+     */
+    public function getTriggerAuraSpellIds(): array
+    {
+        return [];
+    }
+
+    public function getCharacterClassKey(): ?string
+    {
+        return null;
+    }
+
+    public function getCharacterRaceKey(): ?string
+    {
+        return null;
+    }
+
+    public function dropsThreat(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getUnstrippableDebuffDispelTypes(): array
+    {
+        return [];
+    }
+}

--- a/app/Service/CombatLog/DataExtractors/SpellCounters/SpellCounterDefinitionInterface.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounters/SpellCounterDefinitionInterface.php
@@ -22,6 +22,15 @@ interface SpellCounterDefinitionInterface
     public function getTriggerCastSpellIds(): array;
 
     /**
+     * Player buff SPELL_AURA_APPLIED spell ids that mark the moment this counter takes effect. Needed for counters
+     * whose effect does not coincide with their cast - Invisibility fades in over 3 seconds, so its cast lies far
+     * outside the correlation window of the drop it eventually causes.
+     *
+     * @return array<int>
+     */
+    public function getTriggerAuraSpellIds(): array;
+
+    /**
      * The spell icon name, rendered via `ksgAssetImage('spells/<icon>.jpg')`.
      */
     public function getIconName(): string;
@@ -37,4 +46,25 @@ interface SpellCounterDefinitionInterface
      * class ability instead. Exactly one of class/race key is non-null.
      */
     public function getCharacterRaceKey(): ?string;
+
+    /**
+     * Whether this counter makes NPCs lose their target. Only such a counter can explain an NPC abandoning a cast
+     * (signature C) - one that merely strips debuffs off the player has no mechanism to do so, and enabling
+     * signature C for it would credit it with every unrelated abandoned cast in its window.
+     */
+    public function dropsThreat(): bool;
+
+    /**
+     * The `Spell::DISPEL_TYPE_*` values that rule a removed debuff out as something this counter could have caused
+     * to go away (signatures A and B). Empty for a threat drop - it makes the NPC give up on the player regardless
+     * of what it had applied. Cloak of Shadows can only strip magic, so a poison or disease falling off in its
+     * window is provably not its doing.
+     *
+     * Only positively contradicting types belong here. A dispel type that is merely unresolved - `n_a`, `unknown`,
+     * or the empty string combat-log-created spells carry until their Wowhead data is fetched - must not be listed,
+     * or the filter would reject the very spells this extractor exists to discover.
+     *
+     * @return array<string>
+     */
+    public function getUnstrippableDebuffDispelTypes(): array;
 }

--- a/app/Service/CombatLog/DataExtractors/SpellCounters/SpellCounterDefinitions.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounters/SpellCounterDefinitions.php
@@ -17,6 +17,9 @@ final class SpellCounterDefinitions
         return self::$definitions ??= collect([
             new VanishSpellCounterDefinition(),
             new ShadowmeldSpellCounterDefinition(),
+            new FeignDeathSpellCounterDefinition(),
+            new InvisibilitySpellCounterDefinition(),
+            new CloakOfShadowsSpellCounterDefinition(),
         ]);
     }
 }

--- a/app/Service/CombatLog/DataExtractors/SpellCounters/VanishSpellCounterDefinition.php
+++ b/app/Service/CombatLog/DataExtractors/SpellCounters/VanishSpellCounterDefinition.php
@@ -6,7 +6,7 @@ use App\Models\CharacterClass;
 use App\Models\CombatLog\SpellProperty;
 use App\Models\Spell\Spell;
 
-class VanishSpellCounterDefinition implements SpellCounterDefinitionInterface
+class VanishSpellCounterDefinition extends SpellCounterDefinition
 {
     public const int SPELL_ID_VANISH_CAST = 1856;
 
@@ -42,10 +42,5 @@ class VanishSpellCounterDefinition implements SpellCounterDefinitionInterface
     public function getCharacterClassKey(): ?string
     {
         return CharacterClass::CHARACTER_CLASS_ROGUE;
-    }
-
-    public function getCharacterRaceKey(): ?string
-    {
-        return null;
     }
 }

--- a/lang/en_US/spellcounters.php
+++ b/lang/en_US/spellcounters.php
@@ -1,6 +1,9 @@
 <?php
 
 return [
-    'vanish'     => 'Vanish',
-    'shadowmeld' => 'Shadowmeld',
+    'vanish'           => 'Vanish',
+    'shadowmeld'       => 'Shadowmeld',
+    'feign_death'      => 'Feign Death',
+    'invisibility'     => 'Invisibility',
+    'cloak_of_shadows' => 'Cloak of Shadows',
 ];

--- a/tests/Feature/App/Service/CombatLog/DataExtractors/SpellCounterDataExtractorTest.php
+++ b/tests/Feature/App/Service/CombatLog/DataExtractors/SpellCounterDataExtractorTest.php
@@ -17,6 +17,9 @@ use App\Models\Spell\Spell;
 use App\Models\Spell\SpellDungeon;
 use App\Service\CombatLog\DataExtractors\Logging\SpellCounterDataExtractorLoggingInterface;
 use App\Service\CombatLog\DataExtractors\SpellCounterDataExtractor;
+use App\Service\CombatLog\DataExtractors\SpellCounters\CloakOfShadowsSpellCounterDefinition;
+use App\Service\CombatLog\DataExtractors\SpellCounters\FeignDeathSpellCounterDefinition;
+use App\Service\CombatLog\DataExtractors\SpellCounters\InvisibilitySpellCounterDefinition;
 use App\Service\CombatLog\DataExtractors\SpellCounters\ShadowmeldSpellCounterDefinition;
 use App\Service\CombatLog\DataExtractors\SpellCounters\VanishSpellCounterDefinition;
 use App\Service\CombatLog\Dtos\DataExtraction\DataExtractionCurrentDungeon;
@@ -44,7 +47,7 @@ final class SpellCounterDataExtractorTest extends PublicTestCase
     /** @var int The first test spell id - all test spells live in [TEST_SPELL_ID_FIRST, TEST_SPELL_ID_LAST] */
     private const int TEST_SPELL_ID_FIRST = 9990001;
 
-    private const int TEST_SPELL_ID_LAST = 9990020;
+    private const int TEST_SPELL_ID_LAST = 9990040;
 
     private SpellCounterDataExtractor $extractor;
 
@@ -492,6 +495,228 @@ final class SpellCounterDataExtractorTest extends PublicTestCase
         $this->assertNoCounterRecorded($lateRemovalSpellId);
     }
 
+    #[Test]
+    public function extractData_givenFeignDeathTrigger_setsFeignDeathCounter(): void
+    {
+        // Arrange - Feign Death drops threat exactly like Vanish, so it rides the existing signatures unchanged
+        $channelSpellId = 9990021;
+        $this->createTestSpell($channelSpellId, 6000);
+        $this->expectDetectionLoggedForSignature('B', $channelSpellId, SpellProperty::CounterFeignDeath);
+
+        // Act
+        $this->runExtract([
+            $this->npcCastSuccess(0, $channelSpellId, 'Solar Flame'),
+            $this->debuffApplied(0, $channelSpellId, 'Solar Flame', self::CREATURE_GUID),
+            $this->playerCastSuccess(1700, FeignDeathSpellCounterDefinition::SPELL_ID_FEIGN_DEATH, 'Feign Death'),
+            $this->debuffRemoved(1700, $channelSpellId, 'Solar Flame', self::CREATURE_GUID),
+        ]);
+
+        // Assert
+        $this->assertSame(1, $this->result->toArray()['addedSpellCounters']);
+        $this->assertCounterRecorded($channelSpellId, Spell::COUNTER_FEIGN_DEATH, SpellProperty::CounterFeignDeath);
+    }
+
+    #[Test]
+    public function extractData_givenAbandonedCastSupersededAfterFeignDeath_setsCounterOnAbandonedCastSpell(): void
+    {
+        // Arrange - a threat drop is what makes an NPC give up on its cast, so signature C applies to Feign Death
+        $castSpellId = 9990022;
+        $this->createTestSpell($castSpellId);
+        $this->expectDetectionLoggedForSignature('C', $castSpellId, SpellProperty::CounterFeignDeath);
+
+        // Act
+        $this->runExtract([
+            $this->npcCastStart(0, $castSpellId, 'Dread Wind'),
+            $this->playerCastSuccess(1000, FeignDeathSpellCounterDefinition::SPELL_ID_FEIGN_DEATH, 'Feign Death'),
+            $this->npcCastStart(1600, $castSpellId, 'Dread Wind'),
+        ]);
+
+        // Assert
+        $this->assertSame(1, $this->result->toArray()['addedSpellCounters']);
+        $this->assertCounterRecorded($castSpellId, Spell::COUNTER_FEIGN_DEATH, SpellProperty::CounterFeignDeath);
+    }
+
+    #[Test]
+    public function extractData_givenGreaterInvisibilityCast_setsInvisibilityCounter(): void
+    {
+        // Arrange - Greater Invisibility has no fade, so its cast is the moment threat drops
+        $channelSpellId = 9990023;
+        $this->createTestSpell($channelSpellId, 6000);
+        $this->expectDetectionLoggedForSignature('B', $channelSpellId, SpellProperty::CounterInvisibility);
+
+        // Act
+        $this->runExtract([
+            $this->npcCastSuccess(0, $channelSpellId, 'Solar Flame'),
+            $this->debuffApplied(0, $channelSpellId, 'Solar Flame', self::CREATURE_GUID),
+            $this->playerCastSuccess(1700, InvisibilitySpellCounterDefinition::SPELL_ID_GREATER_INVISIBILITY, 'Greater Invisibility'),
+            $this->debuffRemoved(1700, $channelSpellId, 'Solar Flame', self::CREATURE_GUID),
+        ]);
+
+        // Assert
+        $this->assertSame(1, $this->result->toArray()['addedSpellCounters']);
+        $this->assertCounterRecorded($channelSpellId, Spell::COUNTER_INVISIBILITY, SpellProperty::CounterInvisibility);
+    }
+
+    #[Test]
+    public function extractData_givenInvisibilityFadeAuraApplied_setsInvisibilityCounter(): void
+    {
+        // Arrange - Invisibility only drops threat when the invisible state lands 3 seconds after the cast; the
+        // buff aura, not the cast, is what has to line up with the removal
+        $channelSpellId = 9990024;
+        $this->createTestSpell($channelSpellId, 6000);
+        $this->expectDetectionLoggedForSignature('B', $channelSpellId, SpellProperty::CounterInvisibility);
+
+        // Act
+        $this->runExtract([
+            $this->npcCastSuccess(0, $channelSpellId, 'Solar Flame'),
+            $this->debuffApplied(0, $channelSpellId, 'Solar Flame', self::CREATURE_GUID),
+            $this->playerCastSuccess(1700, InvisibilitySpellCounterDefinition::SPELL_ID_INVISIBILITY_CAST, 'Invisibility'),
+            $this->playerBuffApplied(4700, InvisibilitySpellCounterDefinition::SPELL_ID_INVISIBILITY_AURA, 'Invisibility'),
+            $this->debuffRemoved(4700, $channelSpellId, 'Solar Flame', self::CREATURE_GUID),
+        ]);
+
+        // Assert
+        $this->assertSame(1, $this->result->toArray()['addedSpellCounters']);
+        $this->assertCounterRecorded($channelSpellId, Spell::COUNTER_INVISIBILITY, SpellProperty::CounterInvisibility);
+    }
+
+    #[Test]
+    public function extractData_givenDebuffRemovedAtInvisibilityCastInsteadOfItsFade_doesNotSetCounter(): void
+    {
+        // Arrange - the cast only starts the 3 second fade; nothing has happened yet, so a removal next to it is a
+        // coincidence and must not be credited to Invisibility
+        $channelSpellId = 9990025;
+        $this->createTestSpell($channelSpellId, 6000);
+
+        // Act
+        $this->runExtract([
+            $this->npcCastSuccess(0, $channelSpellId, 'Solar Flame'),
+            $this->debuffApplied(0, $channelSpellId, 'Solar Flame', self::CREATURE_GUID),
+            $this->playerCastSuccess(1700, InvisibilitySpellCounterDefinition::SPELL_ID_INVISIBILITY_CAST, 'Invisibility'),
+            $this->debuffRemoved(1700, $channelSpellId, 'Solar Flame', self::CREATURE_GUID),
+        ]);
+
+        // Assert
+        $this->assertSame(0, $this->result->toArray()['addedSpellCounters']);
+        $this->assertNoCounterRecorded($channelSpellId);
+    }
+
+    #[Test]
+    public function extractData_givenMagicDebuffStrippedAtCloakOfShadows_setsCloakOfShadowsCounter(): void
+    {
+        // Arrange - Cloak strips the magic debuff the instant its buff goes up; the fact attaches to the stripped
+        // debuff itself, which is the spell the rogue got out of
+        $debuffSpellId = 9990026;
+        $this->createTestSpell($debuffSpellId, 20000, null, 'spelldispeltype.magic');
+        $this->expectDetectionLoggedForSignature('B', $debuffSpellId, SpellProperty::CounterCloakOfShadows);
+
+        // Act
+        $this->runExtract([
+            $this->npcCastSuccess(0, $debuffSpellId, 'Curse of the Void'),
+            $this->debuffApplied(0, $debuffSpellId, 'Curse of the Void', self::CREATURE_GUID),
+            $this->playerBuffApplied(4000, CloakOfShadowsSpellCounterDefinition::SPELL_ID_CLOAK_OF_SHADOWS, 'Cloak of Shadows'),
+            $this->debuffRemoved(4000, $debuffSpellId, 'Curse of the Void', self::CREATURE_GUID),
+        ]);
+
+        // Assert
+        $this->assertSame(1, $this->result->toArray()['addedSpellCounters']);
+        $this->assertCounterRecorded($debuffSpellId, Spell::COUNTER_CLOAK_OF_SHADOWS, SpellProperty::CounterCloakOfShadows);
+    }
+
+    #[Test]
+    public function extractData_givenUnfetchedDebuffStrippedAtCloakOfShadows_setsCloakOfShadowsCounter(): void
+    {
+        // Arrange - a spell first created from a combat log carries no dispel type until its Wowhead data is
+        // fetched, and those are exactly the spells this extractor exists to discover; unresolved must not reject
+        $debuffSpellId = 9990027;
+        $this->createTestSpell($debuffSpellId, 20000, null, '');
+
+        // Act
+        $this->runExtract([
+            $this->npcCastSuccess(0, $debuffSpellId, 'Curse of the Void'),
+            $this->debuffApplied(0, $debuffSpellId, 'Curse of the Void', self::CREATURE_GUID),
+            $this->playerBuffApplied(4000, CloakOfShadowsSpellCounterDefinition::SPELL_ID_CLOAK_OF_SHADOWS, 'Cloak of Shadows'),
+            $this->debuffRemoved(4000, $debuffSpellId, 'Curse of the Void', self::CREATURE_GUID),
+        ]);
+
+        // Assert
+        $this->assertSame(1, $this->result->toArray()['addedSpellCounters']);
+        $this->assertCounterRecorded($debuffSpellId, Spell::COUNTER_CLOAK_OF_SHADOWS, SpellProperty::CounterCloakOfShadows);
+    }
+
+    #[Test]
+    public function extractData_givenPoisonDebuffRemovedAtCloakOfShadows_doesNotSetCounter(): void
+    {
+        // Arrange - 9990028 covers the counter-before-removal path, 9990029 the removal-before-counter path. Cloak
+        // provably cannot strip a poison, so either ordering is a coincidence.
+        $lateRemovalSpellId  = 9990028;
+        $earlyRemovalSpellId = 9990029;
+        $this->createTestSpell($lateRemovalSpellId, 20000, null, 'spelldispeltype.poison');
+        $this->createTestSpell($earlyRemovalSpellId, 20000, null, 'spelldispeltype.poison');
+
+        // Act
+        $this->runExtract([
+            $this->npcCastSuccess(0, $lateRemovalSpellId, 'Venom Coating'),
+            $this->debuffApplied(0, $lateRemovalSpellId, 'Venom Coating', self::CREATURE_GUID),
+            $this->playerBuffApplied(4000, CloakOfShadowsSpellCounterDefinition::SPELL_ID_CLOAK_OF_SHADOWS, 'Cloak of Shadows'),
+            $this->debuffRemoved(4020, $lateRemovalSpellId, 'Venom Coating', self::CREATURE_GUID),
+
+            $this->npcCastSuccess(10000, $earlyRemovalSpellId, 'Venom Coating'),
+            $this->debuffApplied(10000, $earlyRemovalSpellId, 'Venom Coating', self::CREATURE_GUID),
+            $this->debuffRemoved(14000, $earlyRemovalSpellId, 'Venom Coating', self::CREATURE_GUID),
+            $this->playerBuffApplied(14020, CloakOfShadowsSpellCounterDefinition::SPELL_ID_CLOAK_OF_SHADOWS, 'Cloak of Shadows'),
+        ]);
+
+        // Assert
+        $this->assertSame(0, $this->result->toArray()['addedSpellCounters']);
+        $this->assertNoCounterRecorded($lateRemovalSpellId);
+        $this->assertNoCounterRecorded($earlyRemovalSpellId);
+    }
+
+    #[Test]
+    public function extractData_givenAbandonedCastSupersededAfterCloakOfShadows_doesNotSetCounter(): void
+    {
+        // Arrange - Cloak leaves the rogue on the threat table, so it has no mechanism to make a caster give up;
+        // without this gate every abandoned cast near a Cloak would be credited to it
+        $castSpellId = 9990030;
+        $this->createTestSpell($castSpellId);
+
+        // Act
+        $this->runExtract([
+            $this->npcCastStart(0, $castSpellId, 'Dread Wind'),
+            $this->playerBuffApplied(1000, CloakOfShadowsSpellCounterDefinition::SPELL_ID_CLOAK_OF_SHADOWS, 'Cloak of Shadows'),
+            $this->npcCastStart(1600, $castSpellId, 'Dread Wind'),
+        ]);
+
+        // Assert
+        $this->assertSame(0, $this->result->toArray()['addedSpellCounters']);
+        $this->assertNoCounterRecorded($castSpellId);
+    }
+
+    #[Test]
+    public function extractData_givenCloakOfShadowsStripsSeveralDebuffsAtOnce_setsCounterOnEach(): void
+    {
+        // Arrange - unlike a threat drop, a strip clears everything magic on the rogue in the same instant
+        $firstDebuffSpellId  = 9990031;
+        $secondDebuffSpellId = 9990032;
+        $this->createTestSpell($firstDebuffSpellId, 20000, null, 'spelldispeltype.magic');
+        $this->createTestSpell($secondDebuffSpellId, 20000, null, 'spelldispeltype.magic');
+
+        // Act
+        $this->runExtract([
+            $this->debuffApplied(0, $firstDebuffSpellId, 'Curse of the Void', self::CREATURE_GUID),
+            $this->debuffApplied(0, $secondDebuffSpellId, 'Shadow Rot', self::CREATURE_GUID),
+            $this->playerBuffApplied(4000, CloakOfShadowsSpellCounterDefinition::SPELL_ID_CLOAK_OF_SHADOWS, 'Cloak of Shadows'),
+            $this->debuffRemoved(4000, $firstDebuffSpellId, 'Curse of the Void', self::CREATURE_GUID),
+            $this->debuffRemoved(4000, $secondDebuffSpellId, 'Shadow Rot', self::CREATURE_GUID),
+        ]);
+
+        // Assert
+        $this->assertSame(2, $this->result->toArray()['addedSpellCounters']);
+        $this->assertCounterRecorded($firstDebuffSpellId, Spell::COUNTER_CLOAK_OF_SHADOWS, SpellProperty::CounterCloakOfShadows);
+        $this->assertCounterRecorded($secondDebuffSpellId, Spell::COUNTER_CLOAK_OF_SHADOWS, SpellProperty::CounterCloakOfShadows);
+    }
+
     /**
      * Runs the full extract lifecycle: beforeExtract → extractData (one or more events) → afterExtract.
      *
@@ -554,13 +779,13 @@ final class SpellCounterDataExtractorTest extends PublicTestCase
         ], 'combatlog');
     }
 
-    private function createTestSpell(int $spellId, ?int $duration = null, ?string $category = null): Spell
+    private function createTestSpell(int $spellId, ?int $duration = null, ?string $category = null, string $dispelType = 'none'): Spell
     {
         return Spell::create([
             'id'              => $spellId,
             'game_version_id' => 1,
             'category'        => $category,
-            'dispel_type'     => 'none',
+            'dispel_type'     => $dispelType,
             'icon_name'       => 'inv_misc_questionmark',
             'name'            => sprintf('Test Spell %d', $spellId),
             'schools_mask'    => 1,
@@ -628,6 +853,22 @@ final class SpellCounterDataExtractorTest extends PublicTestCase
             $this->timestamp($offsetMs),
             $this->actorFields($sourceGuid),
             $this->actorFields($destGuid),
+            $spellId,
+            $spellName,
+        ));
+    }
+
+    /**
+     * A self-buff landing on a player - how a counter whose effect lags its cast (Invisibility) marks the moment it
+     * actually takes effect.
+     */
+    private function playerBuffApplied(int $offsetMs, int $spellId, string $spellName, string $playerGuid = self::PLAYER_GUID): BaseEvent
+    {
+        return $this->parse(sprintf(
+            '%s  SPELL_AURA_APPLIED,%s,%s,%d,"%s",0x1,BUFF',
+            $this->timestamp($offsetMs),
+            $this->actorFields($playerGuid),
+            $this->actorFields($playerGuid),
             $spellId,
             $spellName,
         ));

--- a/tests/Feature/App/Service/CombatLog/DataExtractors/SpellCounterDataExtractorTest.php
+++ b/tests/Feature/App/Service/CombatLog/DataExtractors/SpellCounterDataExtractorTest.php
@@ -717,6 +717,35 @@ final class SpellCounterDataExtractorTest extends PublicTestCase
         $this->assertCounterRecorded($secondDebuffSpellId, Spell::COUNTER_CLOAK_OF_SHADOWS, SpellProperty::CounterCloakOfShadows);
     }
 
+    #[Test]
+    public function extractData_givenCounterLoggedAsBothCastAndAura_recordsOneCounter(): void
+    {
+        // Arrange - Cloak of Shadows and Greater Invisibility are logged as a cast success *and* a buff aura in the
+        // same millisecond, so both triggers fire per use; the queue dedup is what keeps that from double counting
+        $cloakDebuffSpellId        = 9990033;
+        $invisibilityDebuffSpellId = 9990034;
+        $this->createTestSpell($cloakDebuffSpellId, 20000, null, 'spelldispeltype.magic');
+        $this->createTestSpell($invisibilityDebuffSpellId, 20000);
+
+        // Act
+        $this->runExtract([
+            $this->debuffApplied(0, $cloakDebuffSpellId, 'Curse of the Void', self::CREATURE_GUID),
+            $this->playerCastSuccess(4000, CloakOfShadowsSpellCounterDefinition::SPELL_ID_CLOAK_OF_SHADOWS, 'Cloak of Shadows'),
+            $this->playerBuffApplied(4000, CloakOfShadowsSpellCounterDefinition::SPELL_ID_CLOAK_OF_SHADOWS, 'Cloak of Shadows'),
+            $this->debuffRemoved(4000, $cloakDebuffSpellId, 'Curse of the Void', self::CREATURE_GUID),
+
+            $this->debuffApplied(10000, $invisibilityDebuffSpellId, 'Solar Flame', self::CREATURE_GUID),
+            $this->playerCastSuccess(14000, InvisibilitySpellCounterDefinition::SPELL_ID_GREATER_INVISIBILITY_AURA, 'Greater Invisibility'),
+            $this->playerBuffApplied(14000, InvisibilitySpellCounterDefinition::SPELL_ID_GREATER_INVISIBILITY_AURA, 'Greater Invisibility'),
+            $this->debuffRemoved(14000, $invisibilityDebuffSpellId, 'Solar Flame', self::CREATURE_GUID),
+        ]);
+
+        // Assert - one counter per use, not two
+        $this->assertSame(2, $this->result->toArray()['addedSpellCounters']);
+        $this->assertCounterRecorded($cloakDebuffSpellId, Spell::COUNTER_CLOAK_OF_SHADOWS, SpellProperty::CounterCloakOfShadows);
+        $this->assertCounterRecorded($invisibilityDebuffSpellId, Spell::COUNTER_INVISIBILITY, SpellProperty::CounterInvisibility);
+    }
+
     /**
      * Runs the full extract lifecycle: beforeExtract → extractData (one or more events) → afterExtract.
      *

--- a/tests/Feature/App/Service/CombatLog/DataExtractors/SpellCounterDataExtractorTest.php
+++ b/tests/Feature/App/Service/CombatLog/DataExtractors/SpellCounterDataExtractorTest.php
@@ -548,7 +548,7 @@ final class SpellCounterDataExtractorTest extends PublicTestCase
         $this->runExtract([
             $this->npcCastSuccess(0, $channelSpellId, 'Solar Flame'),
             $this->debuffApplied(0, $channelSpellId, 'Solar Flame', self::CREATURE_GUID),
-            $this->playerCastSuccess(1700, InvisibilitySpellCounterDefinition::SPELL_ID_GREATER_INVISIBILITY, 'Greater Invisibility'),
+            $this->playerCastSuccess(1700, InvisibilitySpellCounterDefinition::SPELL_ID_GREATER_INVISIBILITY_CAST, 'Greater Invisibility'),
             $this->debuffRemoved(1700, $channelSpellId, 'Solar Flame', self::CREATURE_GUID),
         ]);
 


### PR DESCRIPTION
:robot: Closes #3833

Follow-up to #3826, adding three more player abilities as tracked counters: **Hunter Feign
Death**, **Mage Invisibility** and **Rogue Cloak of Shadows**.

## What changed

`SpellCounterDefinitionInterface` grew three knobs, all defaulted on a new abstract
`SpellCounterDefinition` base so the existing Vanish/Shadowmeld definitions only shrank:

| knob | why |
| --- | --- |
| `getTriggerAuraSpellIds()` | Invisibility's cast only starts a 3 second fade — the threat drop lands with the buff aura, far outside the ±100 ms correlation window of its cast |
| `dropsThreat()` | Cloak leaves the rogue on the threat table, so it cannot explain an abandoned cast; signature C is off for it |
| `getUnstrippableDebuffDispelTypes()` | Cloak only strips magic, so a poison/disease/curse/enrage falling off in its window is provably not its doing |

Feign Death and Greater Invisibility ride the existing A/B/C signatures unchanged — only their
spell ids are new. Cloak needed the two gates above; the debuff-strip itself is what signature B
already recognises (an NPC-sourced debuff on the player removed well before its natural duration,
within ε of the counter), so no new signature was necessary.

An unresolved dispel type (`n_a`, `unknown`, empty) never rejects — combat-log-created spells
carry none until their Wowhead data is fetched, and those are exactly the spells this extractor
exists to discover. Only positively contradicting types disqualify.

## Validation against real logs

15 real M+ runs / 129 segments pulled with `combatlog:downloadruns`, run through
`combatlog:extractdata`, and cross-checked against a raw-log correlation script.

**Two spell ids were wrong until the logs corrected them** — worth knowing for future counters:

- Greater Invisibility applies its buff under **110960**, not the **110959** it is cast with. Real
  logs also show it *cast* under 110960, so both ids are registered as both kinds of trigger.
- Vanish's aura is 11327, not 1856 (already documented in #3826) — same class of trap.

**Cloak of Shadows — 14 uses, 8 debuff removals inside ε, 5 recorded, 3 correctly rejected:**

| removed debuff | dispel type | outcome |
| --- | --- | --- |
| Permeating Cold (1258437) | magic | recorded |
| Blight Splatter (1259116), Chains of Subjugation (1262509), Shade Shift (1264246), Suppression Field (1269283) | unresolved (`n_a`) | recorded |
| Creeping Void (1281636) | **curse** | rejected by the dispel filter |
| Shadowbind (1264186) | **curse** | rejected by the dispel filter |
| Luciferin Flare (1264354) | `n_a` | rejected — it had run its full 5 s duration |

Two of the eight candidates were curses, i.e. the dispel filter removed two false positives that
would otherwise have shipped. Every recorded strip correlated at **0–1 ms**, matching #3826's
finding that a true positive lands in the same server tick.

**Invisibility — 16 triggers, 0 detections.** No debuff removal fell inside any trigger's window,
so nothing was recorded. No false positives; no true positive available in this corpus either.

**Feign Death — not exercised by the corpus.** All 10 occurrences across the 15 runs are
`SPELL_CAST_FAILED` (the ability on cooldown); no hunter successfully used it. Its registration is
mechanically identical to Vanish/Shadowmeld and is covered by unit tests (signatures B and C), but
it has **not** been confirmed against a real successful use. It produced no false positives, since
it never fired.

## Notes

- `combatlog:searchruns --class=` / `--spec=` do not filter — the returned run set is identical
  with and without them. Pre-existing, not touched here; runs for this validation were picked by
  hand from the unfiltered listing by their member spec ids. Worth its own issue.
- No migration: `counters_mask` is an unsigned int with 3 of 32 bits used, and the `property`
  columns are `varchar`, not enums.
- Backend only — the by-class Compendium page renders counter sections straight off
  `SpellCounterDefinitions::all()`, so the three new ones appear with no view change.

## Test plan

- `SpellCounterDataExtractorTest`: 10 new tests (28 total) — Feign Death via signatures B and C,
  Greater Invisibility via its cast, Invisibility via its fade aura *and* a negative proving its
  cast alone does not trigger, Cloak strips (magic and unresolved dispel types), Cloak rejecting a
  poison in both window directions, Cloak not claiming an abandoned cast, and Cloak stripping
  several debuffs at once.
- `DetectStaleCombatLogDataCommandTest` re-run — the new `SpellProperty` cases flow through its
  `counter_<name>` ↔ `ALL_COUNTERS` bit lookup.
- `composer run fix` and `composer run analyse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
