### PR TITLE
#3845 Parse the hex prefix spell school so combat-log-created spells keep their school

### DIFF
--- a/app/Logic/CombatLog/CombatEvents/Prefixes/Range.php
+++ b/app/Logic/CombatLog/CombatEvents/Prefixes/Range.php
@@ -28,6 +28,20 @@ class Range extends Prefix
         return $this->spellSchool;
     }
 
+    /**
+     * The spell school as a bitmask, ready to be stored in `spells`.`schools_mask`.
+     *
+     * The raw field is a hex string in every retail log ("0x20"), and a plain (int) cast turns that into 0 rather
+     * than 32 - which is how combat-log-created spells ended up school-less (#3845). Decimal is still accepted
+     * because the *suffix* schools are logged that way, and a future format change is cheaper to absorb here.
+     */
+    public function getSpellSchoolMask(): int
+    {
+        return str_starts_with(strtolower($this->spellSchool), '0x')
+            ? (int)hexdec(substr($this->spellSchool, 2))
+            : (int)$this->spellSchool;
+    }
+
     #[Override]
     public function setParameters(array $parameters): HasParameters
     {

--- a/app/Models/CombatLog/CombatLogSpellEventType.php
+++ b/app/Models/CombatLog/CombatLogSpellEventType.php
@@ -7,4 +7,5 @@ enum CombatLogSpellEventType: string
     case SpellCreated    = 'spell_created';
     case PropertyChanged = 'property_changed';
     case PropertyRemoved = 'property_removed';
+    case SchoolRecorded  = 'school_recorded';
 }

--- a/app/Service/CombatLog/DataExtractors/Logging/SpellDataExtractorLogging.php
+++ b/app/Service/CombatLog/DataExtractors/Logging/SpellDataExtractorLogging.php
@@ -31,6 +31,11 @@ class SpellDataExtractorLogging extends StructuredLogging implements SpellDataEx
         $this->start(__METHOD__, get_defined_vars());
     }
 
+    public function ensureSpellExistsRepairedSchoolsMask(int $spellId, int $schoolsMask): void
+    {
+        $this->info(__METHOD__, get_defined_vars());
+    }
+
     public function createMissingSpellCreatedSpell(string $name, int $spellId): void
     {
         $this->debug(__METHOD__, get_defined_vars());

--- a/app/Service/CombatLog/DataExtractors/Logging/SpellDataExtractorLoggingInterface.php
+++ b/app/Service/CombatLog/DataExtractors/Logging/SpellDataExtractorLoggingInterface.php
@@ -16,5 +16,7 @@ interface SpellDataExtractorLoggingInterface
 
     public function createMissingSpellCreatedSpell(string $name, int $spellId): void;
 
+    public function ensureSpellExistsRepairedSchoolsMask(int $spellId, int $schoolsMask): void;
+
     public function afterExtractDungeonEnd(): void;
 }

--- a/app/Service/CombatLog/DataExtractors/SpellDataCollectors/SpellCreationCollector.php
+++ b/app/Service/CombatLog/DataExtractors/SpellDataCollectors/SpellCreationCollector.php
@@ -60,7 +60,14 @@ class SpellCreationCollector implements SpellDataCollectorInterface
     public function ensureInterruptSpellExists(ExtractedDataResult $result, Interrupt $interrupt): void
     {
         $spellId = $interrupt->getExtraSpellId();
-        if ($this->allSpells->has($spellId)) {
+
+        /** @var SpellModel|null $existingSpell */
+        $existingSpell = $this->allSpells->get($spellId);
+        if ($existingSpell !== null) {
+            // The interrupted spell's school is trusted to create a spell on the line below, so it is good enough
+            // to repair one too
+            $this->repairMissingSchoolsMask($result, $existingSpell, $interrupt->getExtraSchool());
+
             return;
         }
 
@@ -100,6 +107,15 @@ class SpellCreationCollector implements SpellDataCollectorInterface
         $spell->schools_mask = $schoolsMask;
 
         if ($spell->save()) {
+            // Every other spell mutation in this pipeline is auditable from the Compendium's activity feed and
+            // attributable to a combat log; a repaired school is no different
+            CombatLogSpellEvent::create([
+                'spell_id'        => $spell->id,
+                'event_type'      => CombatLogSpellEventType::SchoolRecorded,
+                'property'        => null,
+                'combat_log_path' => $this->currentCombatLogFilePath,
+            ]);
+
             $result->updatedSpell();
             $this->log->ensureSpellExistsRepairedSchoolsMask($spell->id, $schoolsMask);
         }

--- a/app/Service/CombatLog/DataExtractors/SpellDataCollectors/SpellCreationCollector.php
+++ b/app/Service/CombatLog/DataExtractors/SpellDataCollectors/SpellCreationCollector.php
@@ -39,12 +39,18 @@ class SpellCreationCollector implements SpellDataCollectorInterface
 
     public function ensureSpellExists(ExtractedDataResult $result, Spell $prefix): void
     {
-        $spellId = $prefix->getSpellId();
-        if ($this->allSpells->has($spellId)) {
+        $spellId     = $prefix->getSpellId();
+        $schoolsMask = $prefix->getSpellSchoolMask();
+
+        /** @var SpellModel|null $existingSpell */
+        $existingSpell = $this->allSpells->get($spellId);
+        if ($existingSpell !== null) {
+            $this->repairMissingSchoolsMask($result, $existingSpell, $schoolsMask);
+
             return;
         }
 
-        $createdSpell = $this->createSpellModel($result, $spellId, $prefix->getSpellName(), (int)$prefix->getSpellSchool());
+        $createdSpell = $this->createSpellModel($result, $spellId, $prefix->getSpellName(), $schoolsMask);
         $this->allSpells->put($spellId, $createdSpell);
         $this->pendingNewSpells->put($spellId, $createdSpell);
 
@@ -78,6 +84,25 @@ class SpellCreationCollector implements SpellDataCollectorInterface
 
         $this->pendingNewSpells         = collect();
         $this->currentCombatLogFilePath = null;
+    }
+
+    /**
+     * Backfills the school of a spell that has none. Spells created from a combat log before #3845 all got
+     * schools_mask 0, and their real school cannot be recovered from the database - only from a log that mentions
+     * them again, which is exactly here. Spells that legitimately have no school log 0x0 and stay untouched.
+     */
+    private function repairMissingSchoolsMask(ExtractedDataResult $result, SpellModel $spell, int $schoolsMask): void
+    {
+        if ($schoolsMask === 0 || $spell->schools_mask !== 0) {
+            return;
+        }
+
+        $spell->schools_mask = $schoolsMask;
+
+        if ($spell->save()) {
+            $result->updatedSpell();
+            $this->log->ensureSpellExistsRepairedSchoolsMask($spell->id, $schoolsMask);
+        }
     }
 
     private function createSpellModel(ExtractedDataResult $result, int $spellId, string $name, int $schoolsMask): SpellModel

--- a/lang/en_US/view_compendium.php
+++ b/lang/en_US/view_compendium.php
@@ -61,6 +61,7 @@ return [
         'property_removed'       => 'Unaffected by :property',
         'counter_added'          => ':spell can now be countered by :property',
         'counter_removed'        => ':spell can no longer be countered by :property',
+        'school_recorded'        => ':spell deals :schools damage',
         'property'               => [
             'aura'   => 'Aura',
             'debuff' => 'Debuff',

--- a/resources/views/compendium/sections/event_list.blade.php
+++ b/resources/views/compendium/sections/event_list.blade.php
@@ -42,6 +42,7 @@ $eventBadgeClass = static function (CombatLogNpcEvent|CombatLogSpellEvent $event
         CombatLogSpellEventType::SpellCreated => 'info',
         CombatLogSpellEventType::PropertyChanged => 'warning',
         CombatLogSpellEventType::PropertyRemoved => 'danger',
+        CombatLogSpellEventType::SchoolRecorded => 'info',
     };
 };
 
@@ -58,6 +59,7 @@ $eventIcon = static function (CombatLogNpcEvent|CombatLogSpellEvent $event): str
         CombatLogSpellEventType::SpellCreated => 'fas fa-plus',
         CombatLogSpellEventType::PropertyChanged => 'fas fa-arrow-up',
         CombatLogSpellEventType::PropertyRemoved => 'fas fa-times',
+        CombatLogSpellEventType::SchoolRecorded => 'fas fa-plus',
     };
 };
 
@@ -98,6 +100,12 @@ $eventDescription = static function (CombatLogNpcEvent|CombatLogSpellEvent $even
         CombatLogSpellEventType::PropertyRemoved => __($isCounter ? 'view_compendium.event.counter_removed' : 'view_compendium.event.property_removed', [
             'spell'    => $spellName,
             'property' => $spellPropertyName($event->property)
+        ]),
+        CombatLogSpellEventType::SchoolRecorded => __('view_compendium.event.school_recorded', [
+            'spell'   => $spellName,
+            'schools' => $event->spell
+                ? Spell::maskToReadableString(Spell::ALL_SCHOOLS, $event->spell->schools_mask, 'spellschools')
+                : '-',
         ]),
     };
 };

--- a/tests/Feature/App/Service/CombatLog/DataExtractors/SpellDataExtractorTest.php
+++ b/tests/Feature/App/Service/CombatLog/DataExtractors/SpellDataExtractorTest.php
@@ -39,6 +39,9 @@ final class SpellDataExtractorTest extends PublicTestCase
     /** SPELL_INTERRUPT, source=Player, dest=NPC_ID=999601, prefix=Kick/6552, suffix=TestSpell/999602 → triggers SpellProperty::MissInterrupt */
     private const string RAW_INTERRUPT_EVENT = '8/2/2024 16:24:18.477-4  SPELL_INTERRUPT,Player-1084-0B48C032,"TestPlayer",0x512,0x80000000,Creature-0-2085-2290-22744-999601-000000000,"TestNpc",0xa48,0x0,6552,"Kick",0x1,999602,"TestSpell",32';
 
+    /** SPELL_AURA_APPLIED for an unknown spell, prefix school 0x20 (shadow) - hex, exactly as retail logs it */
+    private const string RAW_SHADOW_BUFF_EVENT = '8/2/2024 16:24:18.477-4  SPELL_AURA_APPLIED,Creature-0-2085-2290-22744-999601-000000000,"TestNpc",0xa48,0x0,Creature-0-2085-2290-22744-999601-000000001,"TestNpc",0xa48,0x0,999602,"TestSpell",0x20,BUFF';
+
     private ExtractedDataResult $result;
 
     private DataExtractionCurrentDungeon $currentDungeon;
@@ -137,6 +140,84 @@ final class SpellDataExtractorTest extends PublicTestCase
             $extractor->extractData($this->result, $this->currentDungeon, $event);
         }
         $extractor->afterExtract($this->result, $combatLogPath);
+    }
+
+    #[Test]
+    public function extractData_givenAnUnknownSpell_createsItWithTheHexPrefixSchool(): void
+    {
+        // Arrange - the spell does not exist yet, so the collector creates it from the event alone
+        $this->createTestNpc();
+        $extractor = $this->makeExtractor();
+
+        // Act
+        $this->runExtract($extractor, [$this->parsedEvent(self::RAW_SHADOW_BUFF_EVENT)]);
+
+        // Assert - 0x20 is 32, not the 0 a plain (int) cast produces
+        $this->assertDatabaseHas('spells', [
+            'id'           => self::SPELL_ID,
+            'schools_mask' => SpellModel::SCHOOL_SHADOW,
+        ]);
+    }
+
+    #[Test]
+    public function extractData_givenAKnownSpellWithoutASchool_repairsItsSchoolsMask(): void
+    {
+        // Arrange - a spell created from a combat log before #3845, so its school was lost
+        $this->createTestSpell(['schools_mask' => 0]);
+        $extractor = $this->makeExtractor();
+
+        // Act
+        $this->runExtract($extractor, [$this->parsedEvent(self::RAW_SHADOW_BUFF_EVENT)]);
+
+        // Assert
+        $this->assertDatabaseHas('spells', [
+            'id'           => self::SPELL_ID,
+            'schools_mask' => SpellModel::SCHOOL_SHADOW,
+        ]);
+    }
+
+    #[Test]
+    public function extractData_givenAKnownSpellThatAlreadyHasASchool_leavesItAlone(): void
+    {
+        // Arrange - the database is authoritative once a school is known; a single event must not overwrite it
+        $this->createTestSpell(['schools_mask' => SpellModel::SCHOOL_FIRE]);
+        $extractor = $this->makeExtractor();
+
+        // Act
+        $this->runExtract($extractor, [$this->parsedEvent(self::RAW_SHADOW_BUFF_EVENT)]);
+
+        // Assert
+        $this->assertDatabaseHas('spells', [
+            'id'           => self::SPELL_ID,
+            'schools_mask' => SpellModel::SCHOOL_FIRE,
+        ]);
+    }
+
+    #[Test]
+    public function extractData_givenAKnownSchoollessSpellAndASchoollessEvent_leavesItAlone(): void
+    {
+        // Arrange - a spell that genuinely has no school must not churn a write on every event
+        $this->createTestSpell(['schools_mask' => 0]);
+
+        $log = Mockery::mock(SpellDataExtractorLoggingInterface::class)->shouldIgnoreMissing();
+
+        /** @var Mockery\Expectation $expectation */
+        $expectation = $log->shouldReceive('ensureSpellExistsRepairedSchoolsMask');
+        $expectation->never();
+
+        $this->app->bind(SpellDataExtractorLoggingInterface::class, fn() => $log);
+
+        $extractor = $this->makeExtractor();
+
+        // Act - RAW_BUFF_EVENT is logged as 0x1, so use an explicitly school-less event
+        $schoollessEvent = str_replace('"TestSpell",0x20', '"TestSpell",0x0', self::RAW_SHADOW_BUFF_EVENT);
+        $this->runExtract($extractor, [$this->parsedEvent($schoollessEvent)]);
+
+        // Assert
+        $this->assertDatabaseHas('spells', [
+            'id'           => self::SPELL_ID,
+            'schools_mask' => 0,
+        ]);
     }
 
     #[Test]

--- a/tests/Feature/App/Service/CombatLog/DataExtractors/SpellDataExtractorTest.php
+++ b/tests/Feature/App/Service/CombatLog/DataExtractors/SpellDataExtractorTest.php
@@ -174,6 +174,31 @@ final class SpellDataExtractorTest extends PublicTestCase
             'id'           => self::SPELL_ID,
             'schools_mask' => SpellModel::SCHOOL_SHADOW,
         ]);
+
+        // Assert - the repair is auditable from the activity feed, like every other spell mutation here
+        $this->assertDatabaseHas('combat_log_spell_events', [
+            'spell_id'        => self::SPELL_ID,
+            'event_type'      => CombatLogSpellEventType::SchoolRecorded->value,
+            'combat_log_path' => self::COMBAT_LOG_PATH,
+        ], 'combatlog');
+    }
+
+    #[Test]
+    public function extractData_givenAnInterruptedSpellWithoutASchool_repairsItsSchoolsMask(): void
+    {
+        // Arrange - a spell that only ever reappears as the interrupted spell of a SPELL_INTERRUPT
+        $this->createTestSpell(['schools_mask' => 0]);
+        $this->createTestNpc();
+        $extractor = $this->makeExtractor();
+
+        // Act - RAW_INTERRUPT_EVENT carries extraSchool 32, decimal, as retail logs it
+        $this->runExtract($extractor, [$this->parsedEvent(self::RAW_INTERRUPT_EVENT)]);
+
+        // Assert
+        $this->assertDatabaseHas('spells', [
+            'id'           => self::SPELL_ID,
+            'schools_mask' => SpellModel::SCHOOL_SHADOW,
+        ]);
     }
 
     #[Test]

--- a/tests/Unit/App/Logic/CombatLog/CombatEvents/Prefixes/RangeTest.php
+++ b/tests/Unit/App/Logic/CombatLog/CombatEvents/Prefixes/RangeTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\App\Logic\CombatLog\CombatEvents\Prefixes;
+
+use App\Logic\CombatLog\CombatEvents\Prefixes\Range;
+use App\Logic\CombatLog\CombatLogVersion;
+use App\Models\Spell\Spell;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('CombatLog')]
+#[Group('Range')]
+final class RangeTest extends PublicTestCase
+{
+    #[Test]
+    #[DataProvider('getSpellSchoolMask_givenALoggedSchool_returnsTheMask_DataProvider')]
+    public function getSpellSchoolMask_givenALoggedSchool_returnsTheMask(string $loggedSchool, int $expectedMask): void
+    {
+        // Arrange
+        $range = new Range(CombatLogVersion::RETAIL_11_0_5);
+        $range->setParameters([12345, 'Test Spell', $loggedSchool]);
+
+        // Act
+        $mask = $range->getSpellSchoolMask();
+
+        // Assert
+        $this->assertSame($expectedMask, $mask);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: int}>
+     */
+    public static function getSpellSchoolMask_givenALoggedSchool_returnsTheMask_DataProvider(): array
+    {
+        return [
+            // How retail actually logs the prefix school - a plain (int) cast reads every one of these as 0
+            'hex physical'         => ['0x1', Spell::SCHOOL_PHYSICAL],
+            'hex holy'             => ['0x2', Spell::SCHOOL_HOLY],
+            'hex shadow'           => ['0x20', Spell::SCHOOL_SHADOW],
+            'hex arcane'           => ['0x40', Spell::SCHOOL_ARCANE],
+            'hex uppercase'        => ['0X20', Spell::SCHOOL_SHADOW],
+            'hex multi school'     => ['0x7c', 124],
+            'hex uppercase digits' => ['0x7C', 124],
+            'hex none'             => ['0x0', 0],
+            // Decimal is how the damage *suffix* logs it, and is accepted so the parse survives a format change
+            'decimal'      => ['32', Spell::SCHOOL_SHADOW],
+            'decimal zero' => ['0', 0],
+            'nil'          => ['nil', 0],
+        ];
+    }
+}


### PR DESCRIPTION
:robot: Closes #3845

The combat log writes the **prefix** spell school as a hex string (`0x20`), and `(int)"0x20"` is
`0` in PHP — not `32`. `SpellCreationCollector` did exactly that cast, so every spell it created
from a combat log was stored with no school at all.

## Scale

I filed #3845 claiming all 605 `schools_mask = 0` spells were combat-log-created. That was wrong,
and the issue body is now corrected — the real breakdown on a fresh seed:

| | |
| --- | --- |
| Spells with `schools_mask = 0` | 605 of 7916 |
| …with a `category` — class spells from `SpellService::importFromCsv`, which hardcodes `'schools_mask' => 0` | 569 |
| …with a null `category` — the combat-log-created signature | **36** |
| Combat-log-created spells in total | 38 |

So this bug owns **36 spells, not 605** — but it owns 36 of 38, which is about as clean a
confirmation as the data gives. It is not worse only because `wowhead:fetchspelldata` rewrites
`schools_mask` correctly whenever it runs; that command is not scheduled, so spells it has never
covered stay school-less indefinitely. The 569 CSV-imported class spells are a separate, deliberate
`0` and are out of scope.

## The fix

`Range::getSpellSchoolMask()` parses hex or decimal and is used at the one call site. Decimal is
accepted too, since that is how the *suffix* schools are logged and it costs nothing to be
tolerant.

Verified against a real log (run `40415388`, from #3843's recorded corpus) that only the prefix is
affected:

```
SPELL_DAMAGE,...,275779,"Judgment",0x2,...     ← prefix school, hex
SPELL_INTERRUPT,...,396640,"Healing Touch",8   ← suffix extraSchool, decimal
```

`SpellBase::getExtraSchool()` and `DamageInterface::getSchool()` are typed `int` and read decimal
fields, so the interrupt and damage paths were never wrong — which is why nothing else tripped over
this.

## Repairing the existing rows

**No migration can backfill these.** The school is not derivable from anything in the database; it
exists only in the logs (or on Wowhead). So the repair lives in the collector: when it sees an
event for a spell it already knows whose `schools_mask` is still `0`, it fills it in from the
event. Guarded both ways — it never overwrites a school that is already set, and an event that
itself carries no school (`0x0`) writes nothing.

That is not only a one-off cleanup: `SpellService::importFromCsv` and `MDTMappingImportService`
both create spells with `schools_mask = 0` on an ongoing basis, and this repairs any of them the
next time an NPC is seen casting the spell.

Spells that never appear in a log again still need `wowhead:fetchspelldata`, which is the only
other source of truth for a school.

## Cold review

Reviewed by a fresh-context agent: **2 findings, both fixed** in 06794fe.

1. The repair mutated a `spells` row without writing a `CombatLogSpellEvent`, unlike every other
   spell mutation in this pipeline — so it was invisible in the Compendium activity feed and not
   attributable to a combat log. It now writes one, under a new `SchoolRecorded` event type.
   **Knock-on worth knowing:** the feed blade has *three* exhaustive `match` statements over
   `CombatLogSpellEventType`, so adding an enum case without arms throws `UnhandledMatchError` on
   every Compendium page showing spell events. All three are handled.
2. `ensureInterruptSpellExists()` kept its plain early return, so a spell that only reappears as
   the interrupted spell of a `SPELL_INTERRUPT` was never repaired — even though its `extraSchool`
   is already trusted to *create* a spell. It repairs now too.

## Verification

The activity feed gained a new line type, so this was checked in headless Chrome rather than on
the tests alone — status 200, no page errors, all three match arms handled:

![activity feed](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3846-spell-feed.png)

## Tests

- `RangeTest` — 11 cases over the parse: hex lower/upper case, multi-school masks, `0x0`, decimal
  and `nil`. Every hex case reads as `0` under the old cast.
- `SpellDataExtractorTest` — an unknown spell is created with the hex school; a known school-less
  spell is repaired (and writes its audit event); an interrupted school-less spell is repaired; a
  known spell with a school is left alone; a school-less spell hit by a school-less event is left
  alone (asserted through the repair log call, which must never fire).

## Note for whoever merges

`resources/views/compendium/sections/event_list.blade.php` and `lang/en_US/view_compendium.php` are
also touched by #3843 and #3842. All three changes are additive in different places, so conflicts
should be trivial.
