### PR TITLE
#3674 Cover StateManager's state transitions and subscriber notification with Vitest tests

### DIFF
--- a/resources/assets/js/custom/constants.js
+++ b/resources/assets/js/custom/constants.js
@@ -58,6 +58,15 @@ const MAP_FACADE_STYLE_BOTH = 'both';
 const MAP_MAX_LAT = -256;
 const MAP_MAX_LNG = 384;
 
+// Enemy display types - must match the options rendered by
+// resources/views/common/maps/controls/elements/enemyvisualtype.blade.php
+const DISPLAY_TYPE_ENEMY_PORTRAIT = 'enemy_portrait';
+const DISPLAY_TYPE_NPC_CLASS = 'npc_class';
+const DISPLAY_TYPE_NPC_TYPE = 'npc_type';
+const DISPLAY_TYPE_ENEMY_FORCES = 'enemy_forces';
+const DISPLAY_TYPE_ENEMY_GROUP = 'enemy_group';
+const DISPLAY_TYPE_ENEMY_SKIPPABLE = 'enemy_skippable';
+
 // Map context
 const MAP_CONTEXT_TYPE_DUNGEON_ROUTE = 'dungeonroute';
 const MAP_CONTEXT_TYPE_LIVE_SESSION = 'livesession';
@@ -714,6 +723,12 @@ if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         c,
         polylineDefaultColor,
+        DISPLAY_TYPE_ENEMY_PORTRAIT,
+        DISPLAY_TYPE_NPC_CLASS,
+        DISPLAY_TYPE_NPC_TYPE,
+        DISPLAY_TYPE_ENEMY_FORCES,
+        DISPLAY_TYPE_ENEMY_GROUP,
+        DISPLAY_TYPE_ENEMY_SKIPPABLE,
         AFFIX_FORTIFIED,
         AFFIX_TYRANNICAL,
         AFFIX_THUNDERING,

--- a/resources/assets/js/custom/signalable.js
+++ b/resources/assets/js/custom/signalable.js
@@ -120,3 +120,11 @@ class Signalable {
         this._cleanedUp = true;
     }
 }
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        Signalable,
+    };
+}

--- a/resources/assets/js/custom/statemanager.js
+++ b/resources/assets/js/custom/statemanager.js
@@ -814,3 +814,11 @@ class StateManager extends Signalable {
         });
     }
 }
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        StateManager,
+    };
+}

--- a/resources/assets/js/custom/statemanager.js
+++ b/resources/assets/js/custom/statemanager.js
@@ -316,7 +316,12 @@ class StateManager extends Signalable {
      */
     getUnkilledEnemyOpacity() {
         console.assert(this instanceof StateManager, 'this is not a StateManager', this);
-        return Number(Cookies.get('map_unkilled_enemy_opacity'));
+        let opacity = Number(Cookies.get('map_unkilled_enemy_opacity'));
+
+        // Same hazard as getKillZonePathWeight(): the cookie may be missing on a cookie-less
+        // headless render, and `opacity: NaN%` is simply dropped by the browser - rendering
+        // unkilled enemies fully opaque. Fall back to the default map.js first sets it to.
+        return isNaN(opacity) ? 50 : opacity;
     }
 
     /**
@@ -337,7 +342,10 @@ class StateManager extends Signalable {
      */
     getUnkilledImportantEnemyOpacity() {
         console.assert(this instanceof StateManager, 'this is not a StateManager', this);
-        return Number(Cookies.get('map_unkilled_important_enemy_opacity'));
+        let opacity = Number(Cookies.get('map_unkilled_important_enemy_opacity'));
+
+        // See getUnkilledEnemyOpacity() - same missing-cookie fallback, different default.
+        return isNaN(opacity) ? 80 : opacity;
     }
 
     /**
@@ -401,16 +409,18 @@ class StateManager extends Signalable {
     getCurrentFloor() {
         console.assert(this instanceof StateManager, 'this is not a StateManager', this);
 
-        if (this._visibleFloorsByFloorId === null) {
-            this._visibleFloorsByFloorId = new Map();
+        return this._getVisibleFloorsByFloorId().get(Number(this._floorId)) ?? false;
+    }
 
-            let floors = this._mapContext.getVisibleFloors();
-            for (let i = 0; i < floors.length; i++) {
-                this._visibleFloorsByFloorId.set(Number(floors[i].id), floors[i]);
-            }
-        }
+    /**
+     * Checks if the given floor is one of the floors visible in the current map context.
+     * @param {Number|String} floorId
+     * @returns {boolean}
+     */
+    isVisibleFloorId(floorId) {
+        console.assert(this instanceof StateManager, 'this is not a StateManager', this);
 
-        return this._visibleFloorsByFloorId?.get(Number(this._floorId)) ?? false;
+        return this._getVisibleFloorsByFloorId().has(Number(floorId));
     }
 
     /**
@@ -421,10 +431,41 @@ class StateManager extends Signalable {
      */
     setFloorId(floorId, center = null, zoom = null) {
         console.assert(this instanceof StateManager, 'this is not a StateManager', this);
+
+        // Refuse a floor that isn't visible in this map context. getCurrentFloor() answers `false`
+        // for an unknown floor, and every consumer reads `.id`/`.index` straight off that result -
+        // which is `undefined` rather than a throw, so a bad floor id would otherwise propagate
+        // silently into tile URLs and ajax payloads. Keeping the floor we're on is the safer of the
+        // two bad options, and the error says why. Skipped while the map context is still unset,
+        // so this cannot fire before statemanager.blade.php has installed one.
+        if (this._mapContext !== null && !this.isVisibleFloorId(floorId)) {
+            console.error(`Refusing to set floor id '${floorId}'; it is not visible in the current map context`);
+
+            return;
+        }
+
         this._floorId = floorId;
 
         // Let everyone know it's changed
         this.signal('floorid:changed', {floorId: this._floorId, center: center, zoom: zoom});
+    }
+
+    /**
+     * Builds - once - a lookup of the map context's visible floors, keyed by their numeric id.
+     * @returns {Map<Number, Object>}
+     * @private
+     */
+    _getVisibleFloorsByFloorId() {
+        if (this._visibleFloorsByFloorId === null) {
+            this._visibleFloorsByFloorId = new Map();
+
+            let floors = this._mapContext.getVisibleFloors();
+            for (let i = 0; i < floors.length; i++) {
+                this._visibleFloorsByFloorId.set(Number(floors[i].id), floors[i]);
+            }
+        }
+
+        return this._visibleFloorsByFloorId;
     }
 
     /**
@@ -668,15 +709,23 @@ class StateManager extends Signalable {
                 if (handlers.hasOwnProperty(index)) {
                     let handler = handlers[index];
                     let values = handler.trim().split(' ');
-                    // Only RGB values
-                    if (values[1].indexOf('#') === 0) {
+                    // Only RGB values. The color may be missing entirely - a trailing comma, or a
+                    // handler with no space in it, leaves values[1] undefined - so check for it
+                    // before dereferencing rather than throwing on the way to drawing the map.
+                    if (values.length > 1 && values[1].indexOf('#') === 0) {
                         result.push([parseInt(('' + values[0]).replace('%', '')), values[1]]);
                     } else {
                         console.warn('Invalid handler found:', handler);
                     }
                 }
             }
-        } else {
+        }
+
+        // pull_gradient is persisted without any format validation, so a route may well carry a
+        // gradient that yields fewer than the two handlers pickHexFromHandlers() requires (it
+        // indexes handlers[0] and handlers[length - 1] unconditionally). Fall back to the defaults
+        // rather than handing it a list it cannot work with.
+        if (result.length < 2) {
             result = c.map.editsidebar.pullGradient.defaultHandlers;
         }
 

--- a/resources/assets/js/custom/statemanager.js
+++ b/resources/assets/js/custom/statemanager.js
@@ -434,7 +434,11 @@ class StateManager extends Signalable {
     getMapZoomSpeed() {
         console.assert(this instanceof StateManager, 'this is not a StateManager', this);
 
-        return parseInt(Cookies.get('map_zoom_speed'));
+        let zoomSpeed = parseInt(Cookies.get('map_zoom_speed'));
+
+        // The cookie may be missing; fall back to the same default used when it's first set
+        // (see map.js/mapsettings.blade.php) rather than returning NaN.
+        return isNaN(zoomSpeed) ? 50 : zoomSpeed;
     }
 
     /**

--- a/resources/assets/js/custom/statemanager.js
+++ b/resources/assets/js/custom/statemanager.js
@@ -722,10 +722,13 @@ class StateManager extends Signalable {
         }
 
         // pull_gradient is persisted without any format validation, so a route may well carry a
-        // gradient that yields fewer than the two handlers pickHexFromHandlers() requires (it
-        // indexes handlers[0] and handlers[length - 1] unconditionally). Fall back to the defaults
-        // rather than handing it a list it cannot work with.
-        if (result.length < 2) {
+        // gradient from which nothing usable survives. pickHexFromHandlers() indexes handlers[0]
+        // unconditionally, so an empty list is its own TypeError - fall back to the defaults.
+        // A single handler is deliberately kept: it is reachable (grapick lets you remove stops
+        // down to one) and works, since handlers[0] === handlers[length - 1] makes every weight
+        // resolve to that one color. Replacing it would also feed the defaults back into grapick
+        // on SettingsTabPull.activate(), overwriting the user's saved gradient on the next edit.
+        if (result.length < 1) {
             result = c.map.editsidebar.pullGradient.defaultHandlers;
         }
 

--- a/resources/assets/js/custom/statemanager.js
+++ b/resources/assets/js/custom/statemanager.js
@@ -312,11 +312,11 @@ class StateManager extends Signalable {
 
     /**
      * Get the opacity at which unkilled enemies should be rendered at.
-     * @returns {string}
+     * @returns {Number}
      */
     getUnkilledEnemyOpacity() {
         console.assert(this instanceof StateManager, 'this is not a StateManager', this);
-        return Cookies.get('map_unkilled_enemy_opacity');
+        return Number(Cookies.get('map_unkilled_enemy_opacity'));
     }
 
     /**
@@ -333,11 +333,11 @@ class StateManager extends Signalable {
 
     /**
      * Get the opacity at which unkilled important enemies should be rendered at.
-     * @returns {string}
+     * @returns {Number}
      */
     getUnkilledImportantEnemyOpacity() {
         console.assert(this instanceof StateManager, 'this is not a StateManager', this);
-        return Cookies.get('map_unkilled_important_enemy_opacity');
+        return Number(Cookies.get('map_unkilled_important_enemy_opacity'));
     }
 
     /**

--- a/resources/assets/js/custom/statemanager.test.js
+++ b/resources/assets/js/custom/statemanager.test.js
@@ -29,18 +29,33 @@ global.cookieDefaultAttributes = undefined;
 // 1c. Map context classes. Only their identity matters to StateManager: setMapContext() picks one
 // by `type` and isMapAdmin() answers `instanceof MapContextMappingVersionEdit`. Each records the
 // raw context it was constructed with so a test can prove the payload was handed through.
-global.MapContextDungeonRoute = class MapContextDungeonRoute {
+// The `extends` chain mirrors the real one (custom/mapcontext/*.js) exactly:
+//
+//   MapContext
+//   |- MapContextDungeonRoute -> MapContextLiveSession
+//   `- MapContextMappingVersion
+//      |- MapContextDungeonExplore -> MapContextDungeonRouteSearch
+//      `- MapContextMappingVersionEdit
+//
+// isMapAdmin() would answer identically under a flatter stub, but only this shape can tell a
+// widening to `instanceof MapContextMappingVersion` (which would wrongly admit explore/search)
+// apart from a widening to `instanceof MapContextDungeonRoute` (which would not).
+global.MapContext = class MapContext {
     constructor(mapContext) {
         this.mapContext = mapContext;
     }
 };
+global.MapContextDungeonRoute = class MapContextDungeonRoute extends global.MapContext {
+};
 global.MapContextLiveSession = class MapContextLiveSession extends global.MapContextDungeonRoute {
 };
-global.MapContextMappingVersionEdit = class MapContextMappingVersionEdit extends global.MapContextDungeonRoute {
+global.MapContextMappingVersion = class MapContextMappingVersion extends global.MapContext {
 };
-global.MapContextDungeonExplore = class MapContextDungeonExplore extends global.MapContextDungeonRoute {
+global.MapContextMappingVersionEdit = class MapContextMappingVersionEdit extends global.MapContextMappingVersion {
 };
-global.MapContextDungeonRouteSearch = class MapContextDungeonRouteSearch extends global.MapContextDungeonRoute {
+global.MapContextDungeonExplore = class MapContextDungeonExplore extends global.MapContextMappingVersion {
+};
+global.MapContextDungeonRouteSearch = class MapContextDungeonRouteSearch extends global.MapContextDungeonExplore {
 };
 
 // 1d. A cookie jar with real read-back, unlike the shared setup's write-less stub. The settings
@@ -61,6 +76,8 @@ global.c = {
         editsidebar: {
             pullGradient: {defaultHandlers: [[0, '#000000'], [100, '#ffffff']]},
         },
+        // Real value from constants.js - getKillZonePathWeight() falls back to it.
+        polyline: {killzonepath: {weight: 5}},
     },
 };
 
@@ -209,9 +226,12 @@ describe('StateManager floor state', () => {
         expect(stateManager.getCurrentFloor()).toBe(floor);
     });
 
-    test('getCurrentFloor_givenAStringFloorId_stillResolvesTheFloor', () => {
-        // Both sides are pushed through Number(): the id can arrive as a string from the DOM.
-        const floor = {id: '2'};
+    test('getCurrentFloor_givenAFloorIdFromTheDom_stillResolvesTheFloor', () => {
+        // The real asymmetry both Number() calls exist for: visibleFloors comes from
+        // MapContextBase::toArray() with integer ids, while setFloorId() is fed a STRING by the
+        // floor <select> (sidebarnavigation.js) and the map's floor switch. Model both sides as
+        // strings and the lookup would match without any coercion at all.
+        const floor = {id: 2};
         const stateManager = makeStateManager(makeFakeMapContext({visibleFloors: [floor]}));
 
         stateManager.setFloorId('2');
@@ -228,10 +248,12 @@ describe('StateManager floor state', () => {
     });
 
     test('getCurrentFloor_givenTheContextChangedAfterTheFirstCall_keepsTheStaleFloorList', () => {
-        // The visible-floor lookup is built once and never invalidated - not even by
-        // setMapContext() or setFloorId(). Pinned deliberately: anything that swaps the map
-        // context on a live StateManager (a facade style change rebuilding the map) has to
-        // account for this, and today only a fresh StateManager clears it.
+        // The visible-floor lookup is built once and never invalidated - not by setMapContext(),
+        // not by setFloorId(). Nothing swaps _mapContext on a live StateManager today:
+        // setMapContext() has exactly one caller (statemanager.blade.php, once per page load) and
+        // the facade toggle reloads the page rather than rebuilding in place. So this is latent,
+        // not live - pinned so that whoever introduces the first in-page context swap finds out
+        // here rather than through floors silently resolving against the old list.
         const stateManager = makeStateManager(makeFakeMapContext({visibleFloors: [{id: 1}]}));
         stateManager.setFloorId(1);
         expect(stateManager.getCurrentFloor()).toEqual({id: 1});
@@ -347,6 +369,36 @@ describe('StateManager cookie-backed display settings', () => {
 
     test('getMapNumberStyle_givenNoStoredValue_defaultsToPercentage', () => {
         expect(makeStateManager().getMapNumberStyle()).toBe(NUMBER_STYLE_PERCENTAGE);
+    });
+
+    test('getKillZonePathWeight_givenNoStoredValue_fallsBackToTheDefaultWeight', () => {
+        // parseInt(undefined) is NaN; returning that would draw invisible lines. The cookie really
+        // can be missing - cookie-less headless renders reject the secure cookie.
+        expect(makeStateManager().getKillZonePathWeight()).toBe(c.map.polyline.killzonepath.weight);
+    });
+
+    test('setKillZonePathWeight_givenAWeight_storesItAndNotifies', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'killzonepathweight:changed');
+
+        stateManager.setKillZonePathWeight(9);
+
+        expect(stateManager.getKillZonePathWeight()).toBe(9);
+        expect(received[0].data).toEqual({weight: 9});
+    });
+
+    test('getMapZoomSpeed_givenAStoredValue_parsesItBackToANumber', () => {
+        const stateManager = makeStateManager();
+
+        stateManager.setMapZoomSpeed(3);
+
+        expect(stateManager.getMapZoomSpeed()).toBe(3);
+    });
+
+    test('getMapZoomSpeed_givenNoStoredValue_returnsNaN', () => {
+        // Unlike getKillZonePathWeight() this one has no isNaN() guard, so a missing cookie yields
+        // NaN rather than a usable default. Pinned as the current behaviour, not endorsed.
+        expect(makeStateManager().getMapZoomSpeed()).toBeNaN();
     });
 });
 

--- a/resources/assets/js/custom/statemanager.test.js
+++ b/resources/assets/js/custom/statemanager.test.js
@@ -1,0 +1,601 @@
+// ---------------------------------------------------------------------------
+// Coverage for StateManager (#3674, target C): state transitions and subscriber
+// notification - the global state every map page reads, where a regression is
+// felt everywhere at once.
+//
+// Follows the global-script recipe documented at the top of killzone.test.js, with
+// one deliberate difference: Signalable is NOT stubbed here. Subscriber notification
+// IS the subject of this file, so the tests register real listeners on the real event
+// bus (signalable.js) and assert on what they receive - a stub would only prove the
+// stub works.
+// ---------------------------------------------------------------------------
+
+// 1a. The real event bus StateManager extends.
+const {Signalable} = require('./signalable');
+global.Signalable = Signalable;
+
+// 1b. Constants referenced as bare globals, with their real values from constants.js.
+global.MAP_CONTEXT_TYPE_DUNGEON_ROUTE = 'dungeonroute';
+global.MAP_CONTEXT_TYPE_LIVE_SESSION = 'livesession';
+global.MAP_CONTEXT_TYPE_MAPPING_VERSION_EDIT = 'mappingVersionEdit';
+global.MAP_CONTEXT_TYPE_DUNGEON_EXPLORE = 'dungeonExplore';
+global.MAP_CONTEXT_TYPE_DUNGEON_ROUTE_SEARCH = 'dungeonRouteSearch';
+global.MAP_FACADE_STYLE_FACADE = 'facade';
+global.MAP_FACADE_STYLE_SPLIT_FLOORS = 'split_floors';
+global.NUMBER_STYLE_PERCENTAGE = 'percentage';
+global.NUMBER_STYLE_ENEMY_FORCES = 'enemy_forces';
+global.cookieDefaultAttributes = undefined;
+
+// 1c. Map context classes. Only their identity matters to StateManager: setMapContext() picks one
+// by `type` and isMapAdmin() answers `instanceof MapContextMappingVersionEdit`. Each records the
+// raw context it was constructed with so a test can prove the payload was handed through.
+global.MapContextDungeonRoute = class MapContextDungeonRoute {
+    constructor(mapContext) {
+        this.mapContext = mapContext;
+    }
+};
+global.MapContextLiveSession = class MapContextLiveSession extends global.MapContextDungeonRoute {
+};
+global.MapContextMappingVersionEdit = class MapContextMappingVersionEdit extends global.MapContextDungeonRoute {
+};
+global.MapContextDungeonExplore = class MapContextDungeonExplore extends global.MapContextDungeonRoute {
+};
+global.MapContextDungeonRouteSearch = class MapContextDungeonRouteSearch extends global.MapContextDungeonRoute {
+};
+
+// 1d. A cookie jar with real read-back, unlike the shared setup's write-less stub. The settings
+// getters read straight back out of Cookies, so a jar that forgets would make them untestable.
+const cookieJar = new Map();
+global.Cookies = {
+    get: (key) => cookieJar.get(key),
+    set: (key, value) => cookieJar.set(key, `${value}`),
+};
+
+// 1e. lodash (snackbar bookkeeping) and the `c` constants object (pull gradient defaults).
+global._ = {
+    indexOf: (array, value) => array.indexOf(value),
+    without: (array, value) => array.filter((entry) => entry !== value),
+};
+global.c = {
+    map: {
+        editsidebar: {
+            pullGradient: {defaultHandlers: [[0, '#000000'], [100, '#ffffff']]},
+        },
+    },
+};
+
+const {StateManager} = require('./statemanager');
+
+/**
+ * A fake map context exposing only what StateManager asks of it.
+ *
+ * @param {Object} options
+ * @param {Array<Object>} options.visibleFloors Floors the context considers visible.
+ * @param {String|undefined} options.pullGradient The stored pull gradient string.
+ * @param {boolean} options.facadeEnabled Whether the dungeon supports a facade.
+ * @returns {Object}
+ */
+function makeFakeMapContext({visibleFloors = [{id: 1}, {id: 2}], pullGradient = '', facadeEnabled = false} = {}) {
+    return {
+        getVisibleFloors: () => visibleFloors,
+        getPullGradient: () => pullGradient,
+        getMappingVersion: () => ({facade_enabled: facadeEnabled}),
+    };
+}
+
+/**
+ * A StateManager with a fake map context already installed, bypassing setMapContext()'s
+ * type-based construction (which has its own tests below).
+ *
+ * @param {Object} mapContext
+ * @returns {StateManager}
+ */
+function makeStateManager(mapContext = makeFakeMapContext()) {
+    const stateManager = new StateManager();
+    stateManager._mapContext = mapContext;
+
+    return stateManager;
+}
+
+/**
+ * Records every payload delivered for `event` on the real Signalable bus.
+ *
+ * @param {StateManager} stateManager
+ * @param {String} event
+ * @returns {Array<Object>}
+ */
+function listenFor(stateManager, event) {
+    const received = [];
+    stateManager.register(event, {}, (signal) => received.push(signal));
+
+    return received;
+}
+
+beforeEach(() => {
+    cookieJar.clear();
+});
+
+describe('StateManager.setMapContext', () => {
+    test.each([
+        ['dungeon route', MAP_CONTEXT_TYPE_DUNGEON_ROUTE, 'MapContextDungeonRoute'],
+        ['live session', MAP_CONTEXT_TYPE_LIVE_SESSION, 'MapContextLiveSession'],
+        ['mapping version edit', MAP_CONTEXT_TYPE_MAPPING_VERSION_EDIT, 'MapContextMappingVersionEdit'],
+        ['dungeon explore', MAP_CONTEXT_TYPE_DUNGEON_EXPLORE, 'MapContextDungeonExplore'],
+        ['dungeon route search', MAP_CONTEXT_TYPE_DUNGEON_ROUTE_SEARCH, 'MapContextDungeonRouteSearch'],
+    ])('setMapContext_given%sType_buildsThatContext', (label, type, expectedClass) => {
+        const stateManager = new StateManager();
+
+        stateManager.setMapContext({type});
+
+        expect(stateManager.getMapContext()).toBeInstanceOf(global[expectedClass]);
+        expect(stateManager.getMapContext().mapContext).toEqual({type});
+    });
+
+    test('setMapContext_givenAnUnknownType_leavesTheContextUnchanged', () => {
+        const stateManager = new StateManager();
+        stateManager.setMapContext({type: MAP_CONTEXT_TYPE_DUNGEON_ROUTE});
+        const before = stateManager.getMapContext();
+        // The unknown branch only console.error()s; silence it so the run stays readable.
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {
+        });
+
+        stateManager.setMapContext({type: 'somethingElse'});
+
+        expect(stateManager.getMapContext()).toBe(before);
+        expect(consoleError).toHaveBeenCalled();
+    });
+});
+
+describe('StateManager.isMapAdmin', () => {
+    test('isMapAdmin_givenTheMappingEditorContext_returnsTrue', () => {
+        const stateManager = new StateManager();
+
+        stateManager.setMapContext({type: MAP_CONTEXT_TYPE_MAPPING_VERSION_EDIT});
+
+        expect(stateManager.isMapAdmin()).toBe(true);
+    });
+
+    test.each([
+        ['dungeon route', MAP_CONTEXT_TYPE_DUNGEON_ROUTE],
+        ['live session', MAP_CONTEXT_TYPE_LIVE_SESSION],
+        ['dungeon explore', MAP_CONTEXT_TYPE_DUNGEON_EXPLORE],
+    ])('isMapAdmin_given%sContext_returnsFalse', (label, type) => {
+        const stateManager = new StateManager();
+
+        stateManager.setMapContext({type});
+
+        expect(stateManager.isMapAdmin()).toBe(false);
+    });
+});
+
+describe('StateManager floor state', () => {
+    test('setFloorId_givenAFloor_notifiesSubscribersWithTheCenterAndZoom', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'floorid:changed');
+
+        stateManager.setFloorId(2, [1, 2], 3);
+
+        expect(received).toHaveLength(1);
+        expect(received[0].data).toEqual({floorId: 2, center: [1, 2], zoom: 3});
+    });
+
+    test('setFloorId_givenNoCenterOrZoom_notifiesWithNulls', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'floorid:changed');
+
+        stateManager.setFloorId(2);
+
+        expect(received[0].data).toEqual({floorId: 2, center: null, zoom: null});
+    });
+
+    test('setFloorId_givenTheSameFloorAgain_notifiesAgain', () => {
+        // Unlike setMapZoomLevel(), this one has no changed-check: consumers rely on the signal
+        // firing on every set, including a re-select of the floor already displayed.
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'floorid:changed');
+
+        stateManager.setFloorId(2);
+        stateManager.setFloorId(2);
+
+        expect(received).toHaveLength(2);
+    });
+
+    test('getCurrentFloor_givenTheCurrentFloorId_returnsThatFloor', () => {
+        const floor = {id: 2, name: 'Second floor'};
+        const stateManager = makeStateManager(makeFakeMapContext({visibleFloors: [{id: 1}, floor]}));
+
+        stateManager.setFloorId(2);
+
+        expect(stateManager.getCurrentFloor()).toBe(floor);
+    });
+
+    test('getCurrentFloor_givenAStringFloorId_stillResolvesTheFloor', () => {
+        // Both sides are pushed through Number(): the id can arrive as a string from the DOM.
+        const floor = {id: '2'};
+        const stateManager = makeStateManager(makeFakeMapContext({visibleFloors: [floor]}));
+
+        stateManager.setFloorId('2');
+
+        expect(stateManager.getCurrentFloor()).toBe(floor);
+    });
+
+    test('getCurrentFloor_givenAFloorThatIsNotVisible_returnsFalse', () => {
+        const stateManager = makeStateManager(makeFakeMapContext({visibleFloors: [{id: 1}]}));
+
+        stateManager.setFloorId(99);
+
+        expect(stateManager.getCurrentFloor()).toBe(false);
+    });
+
+    test('getCurrentFloor_givenTheContextChangedAfterTheFirstCall_keepsTheStaleFloorList', () => {
+        // The visible-floor lookup is built once and never invalidated - not even by
+        // setMapContext() or setFloorId(). Pinned deliberately: anything that swaps the map
+        // context on a live StateManager (a facade style change rebuilding the map) has to
+        // account for this, and today only a fresh StateManager clears it.
+        const stateManager = makeStateManager(makeFakeMapContext({visibleFloors: [{id: 1}]}));
+        stateManager.setFloorId(1);
+        expect(stateManager.getCurrentFloor()).toEqual({id: 1});
+
+        stateManager._mapContext = makeFakeMapContext({visibleFloors: [{id: 1, name: 'Renamed'}, {id: 5}]});
+        stateManager.setFloorId(5);
+
+        expect(stateManager.getCurrentFloor()).toBe(false);
+    });
+});
+
+describe('StateManager.setMapZoomLevel', () => {
+    test('setMapZoomLevel_givenANewZoom_notifiesWithBothTheOldAndNewLevel', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'mapzoomlevel:changed');
+
+        stateManager.setMapZoomLevel(5);
+
+        expect(stateManager.getMapZoomLevel()).toBe(5);
+        expect(received[0].data).toEqual({mapZoomLevel: 5, previousMapZoomLevel: 2});
+    });
+
+    test('setMapZoomLevel_givenTheSameZoom_doesNotNotify', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'mapzoomlevel:changed');
+
+        stateManager.setMapZoomLevel(5);
+        stateManager.setMapZoomLevel(5);
+
+        expect(received).toHaveLength(1);
+    });
+});
+
+describe('StateManager cookie-backed display settings', () => {
+    test('setEnemyDisplayType_givenAType_storesItAndNotifies', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'enemydisplaytype:changed');
+
+        stateManager.setEnemyDisplayType('aggressiveness');
+
+        expect(stateManager.getEnemyDisplayType()).toBe('aggressiveness');
+        expect(Cookies.get('enemy_display_type')).toBe('aggressiveness');
+        expect(received[0].data).toEqual({enemyDisplayType: 'aggressiveness'});
+    });
+
+    test('setUnkilledEnemyOpacity_givenAnOpacity_storesItAndNotifies', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'unkilledenemyopacity:changed');
+
+        stateManager.setUnkilledEnemyOpacity(0.5);
+
+        expect(stateManager.getUnkilledEnemyOpacity()).toBe('0.5');
+        expect(received[0].data).toEqual({opacity: 0.5});
+    });
+
+    test('setUnkilledImportantEnemyOpacity_givenAnOpacity_storesItAndNotifies', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'unkilledimportantenemyopacity:changed');
+
+        stateManager.setUnkilledImportantEnemyOpacity(0.8);
+
+        expect(stateManager.getUnkilledImportantEnemyOpacity()).toBe('0.8');
+        expect(received[0].data).toEqual({opacity: 0.8});
+    });
+
+    test.each([
+        ['aggressiveness', 'setEnemyAggressivenessBorder', 'hasEnemyAggressivenessBorder', 'enemyaggressivenessborder:changed'],
+        ['dangerous', 'setEnemyDangerousBorder', 'hasEnemyDangerousBorder', 'enemydangerousborder:changed'],
+    ])('set%sBorder_givenABoolean_storesItAsAFlagAndNotifies', (label, setter, getter, event) => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, event);
+
+        stateManager[setter](true);
+        expect(stateManager[getter]()).toBe(true);
+
+        stateManager[setter](false);
+        expect(stateManager[getter]()).toBe(false);
+
+        expect(received.map((signal) => signal.data)).toEqual([{visible: true}, {visible: false}]);
+    });
+
+    test('hasEnemyAggressivenessBorder_givenNoStoredValue_returnsFalse', () => {
+        // parseInt(undefined) is NaN, which is never 1 - the unset cookie must read as "off".
+        expect(makeStateManager().hasEnemyAggressivenessBorder()).toBe(false);
+    });
+
+    test.each([
+        ['heatmap tooltips', 'setHeatmapShowTooltips', 'map_heatmap_show_tooltips', 'heatmapshowtooltips:changed', 'visible'],
+        ['heatmap on top', 'setHeatmapShowOnTop', 'map_heatmap_show_on_top', 'heatmapshowontop:changed', 'onTop'],
+    ])('set%s_givenABoolean_storesOneOrZeroAndNotifies', (label, setter, cookie, event, payloadKey) => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, event);
+
+        stateManager[setter](true);
+
+        expect(Cookies.get(cookie)).toBe('1');
+        expect(received[0].data).toEqual({[payloadKey]: true});
+    });
+
+    test('getMapFacadeStyle_givenNoStoredValue_defaultsToFacade', () => {
+        expect(makeStateManager().getMapFacadeStyle()).toBe(MAP_FACADE_STYLE_FACADE);
+    });
+
+    test('setMapFacadeStyle_givenAStyle_storesItAndNotifies', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'mapfacadestyle:changed');
+
+        stateManager.setMapFacadeStyle(MAP_FACADE_STYLE_SPLIT_FLOORS);
+
+        expect(stateManager.getMapFacadeStyle()).toBe(MAP_FACADE_STYLE_SPLIT_FLOORS);
+        expect(received).toHaveLength(1);
+    });
+
+    test('getMapNumberStyle_givenNoStoredValue_defaultsToPercentage', () => {
+        expect(makeStateManager().getMapNumberStyle()).toBe(NUMBER_STYLE_PERCENTAGE);
+    });
+});
+
+describe('StateManager.isCurrentDungeonFacadeEnabled', () => {
+    test('isCurrentDungeonFacadeEnabled_givenAFacadeDungeonAndTheFacadeStyle_returnsTrue', () => {
+        const stateManager = makeStateManager(makeFakeMapContext({facadeEnabled: true}));
+
+        stateManager.setMapFacadeStyle(MAP_FACADE_STYLE_FACADE);
+
+        expect(stateManager.isCurrentDungeonFacadeEnabled()).toBe(true);
+    });
+
+    test('isCurrentDungeonFacadeEnabled_givenAFacadeDungeonButSplitFloors_returnsFalse', () => {
+        const stateManager = makeStateManager(makeFakeMapContext({facadeEnabled: true}));
+
+        stateManager.setMapFacadeStyle(MAP_FACADE_STYLE_SPLIT_FLOORS);
+
+        expect(stateManager.isCurrentDungeonFacadeEnabled()).toBe(false);
+    });
+
+    test('isCurrentDungeonFacadeEnabled_givenADungeonWithoutAFacade_returnsFalse', () => {
+        const stateManager = makeStateManager(makeFakeMapContext({facadeEnabled: false}));
+
+        stateManager.setMapFacadeStyle(MAP_FACADE_STYLE_FACADE);
+
+        expect(stateManager.isCurrentDungeonFacadeEnabled()).toBe(false);
+    });
+});
+
+describe('StateManager.setFocusedEnemy', () => {
+    test('setFocusedEnemy_givenAnEnemy_notifiesSubscribers', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'focusedenemy:changed');
+        const enemy = {id: 5};
+
+        stateManager.setFocusedEnemy(enemy);
+
+        expect(stateManager.getFocusedEnemy()).toBe(enemy);
+        expect(received[0].data).toEqual({focusedenemy: enemy});
+    });
+
+    test('setFocusedEnemy_givenNull_notifiesWithNull', () => {
+        const stateManager = makeStateManager();
+        stateManager.setFocusedEnemy({id: 5});
+        const received = listenFor(stateManager, 'focusedenemy:changed');
+
+        stateManager.setFocusedEnemy(null);
+
+        expect(received[0].data).toEqual({focusedenemy: null});
+    });
+});
+
+describe('StateManager.setMdtMappingModeEnabled', () => {
+    test('setMdtMappingModeEnabled_givenTrue_notifiesSubscribers', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'mdtmappingmodeenabled:changed');
+
+        stateManager.setMdtMappingModeEnabled(true);
+
+        expect(stateManager.getMdtMappingModeEnabled()).toBe(true);
+        expect(received[0].data).toEqual({mdtmappingmodeenabled: true});
+    });
+});
+
+describe('StateManager user state', () => {
+    test('userHasRole_givenNoUser_returnsFalse', () => {
+        expect(makeStateManager().userHasRole('admin')).toBe(false);
+    });
+
+    test('userHasRole_givenAUserWithThatRole_returnsTrue', () => {
+        const stateManager = makeStateManager();
+
+        stateManager.setUserData({roles: [{name: 'user'}, {name: 'admin'}]});
+
+        expect(stateManager.userHasRole('admin')).toBe(true);
+        expect(stateManager.userHasRole('moderator')).toBe(false);
+    });
+
+    test('getUser_givenUserData_returnsIt', () => {
+        const stateManager = makeStateManager();
+        const userData = {name: 'Wotuu', roles: []};
+
+        stateManager.setUserData(userData);
+
+        expect(stateManager.getUser()).toBe(userData);
+    });
+
+    test('hasPatreonBenefit_givenTheBenefit_returnsTrue', () => {
+        const stateManager = makeStateManager();
+
+        stateManager.setPatreonBenefits(['adfree', 'animated-polylines']);
+
+        expect(stateManager.hasPatreonBenefit('adfree')).toBe(true);
+        expect(stateManager.hasPatreonBenefit('unlimited-dungeonroutes')).toBe(false);
+    });
+
+    test('hasPatreonBenefit_givenNoBenefits_returnsFalse', () => {
+        expect(makeStateManager().hasPatreonBenefit('adfree')).toBe(false);
+    });
+});
+
+describe('StateManager snackbars', () => {
+    test('addSnackbar_givenHtml_returnsAnIncrementingIdAndNotifies', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'snackbar:add');
+
+        const first = stateManager.addSnackbar('<div>one</div>');
+        const second = stateManager.addSnackbar('<div>two</div>');
+
+        expect(first).toBe('snackbar-1');
+        expect(second).toBe('snackbar-2');
+        expect(received[0].data).toEqual({
+            id: 'snackbar-1',
+            html: '<div>one</div>',
+            compact: false,
+            onDomAdded: null,
+        });
+    });
+
+    test('addSnackbar_givenOptions_passesThemAlong', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'snackbar:add');
+        const onDomAdded = () => {
+        };
+
+        stateManager.addSnackbar('<div>one</div>', {compact: true, onDomAdded});
+
+        expect(received[0].data.compact).toBe(true);
+        expect(received[0].data.onDomAdded).toBe(onDomAdded);
+    });
+
+    test('addSnackbar_givenANonFunctionOnDomAdded_passesNull', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'snackbar:add');
+
+        stateManager.addSnackbar('<div>one</div>', {onDomAdded: 'not a function'});
+
+        expect(received[0].data.onDomAdded).toBeNull();
+    });
+
+    test('removeSnackbar_givenAKnownId_notifiesAndForgetsIt', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'snackbar:remove');
+        const snackbarId = stateManager.addSnackbar('<div>one</div>');
+
+        stateManager.removeSnackbar(snackbarId);
+
+        expect(received).toHaveLength(1);
+        expect(received[0].data).toEqual({id: snackbarId});
+        expect(stateManager.snackbarIds).toEqual([]);
+    });
+
+    test('removeSnackbar_givenTheSameIdTwice_onlyNotifiesOnce', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'snackbar:remove');
+        const snackbarId = stateManager.addSnackbar('<div>one</div>');
+
+        stateManager.removeSnackbar(snackbarId);
+        stateManager.removeSnackbar(snackbarId);
+
+        expect(received).toHaveLength(1);
+    });
+
+    test('removeSnackbar_givenAnUnknownId_doesNotNotify', () => {
+        const stateManager = makeStateManager();
+        const received = listenFor(stateManager, 'snackbar:remove');
+
+        stateManager.removeSnackbar('snackbar-999');
+
+        expect(received).toHaveLength(0);
+    });
+});
+
+describe('StateManager.updateKillZones', () => {
+    test('updateKillZones_givenKillZones_flattensThemIntoTheSaveShape', () => {
+        const stateManager = makeStateManager();
+
+        stateManager.updateKillZones([{
+            id: 1,
+            floor_id: 2,
+            color: '#ff0000',
+            enemies: [10, 11],
+            layer: {getLatLng: () => ({lat: 1.5, lng: 2.5})},
+        }]);
+
+        expect(stateManager.killZones).toEqual([{
+            id: 1,
+            floor_id: 2,
+            color: '#ff0000',
+            killzonenemies: [{enemy_id: 10}, {enemy_id: 11}],
+            lat: 1.5,
+            lng: 2.5,
+        }]);
+    });
+
+    test('updateKillZones_givenAKillZoneWithoutALayer_sendsNullCoordinates', () => {
+        const stateManager = makeStateManager();
+
+        stateManager.updateKillZones([{id: 1, floor_id: 2, color: '#ff0000', enemies: [], layer: null}]);
+
+        expect(stateManager.killZones[0].lat).toBeNull();
+        expect(stateManager.killZones[0].lng).toBeNull();
+        expect(stateManager.killZones[0].killzonenemies).toEqual([]);
+    });
+
+    test('updateKillZones_givenAnEmptyList_clearsThePreviousOne', () => {
+        const stateManager = makeStateManager();
+        stateManager.updateKillZones([{id: 1, floor_id: 2, color: '#ff0000', enemies: [], layer: null}]);
+
+        stateManager.updateKillZones([]);
+
+        expect(stateManager.killZones).toEqual([]);
+    });
+});
+
+describe('StateManager.getPullGradientHandlers', () => {
+    test('getPullGradientHandlers_givenAStoredGradient_parsesThePercentagesAndColors', () => {
+        const stateManager = makeStateManager(makeFakeMapContext({pullGradient: '0% #ff0000, 100% #00ff00'}));
+
+        expect(stateManager.getPullGradientHandlers()).toEqual([[0, '#ff0000'], [100, '#00ff00']]);
+    });
+
+    test('getPullGradientHandlers_givenNoStoredGradient_returnsTheDefaults', () => {
+        const stateManager = makeStateManager(makeFakeMapContext({pullGradient: ''}));
+
+        expect(stateManager.getPullGradientHandlers()).toBe(c.map.editsidebar.pullGradient.defaultHandlers);
+    });
+
+    test('getPullGradientHandlers_givenAHandlerWithoutAColor_skipsIt', () => {
+        const stateManager = makeStateManager(makeFakeMapContext({pullGradient: '0% #ff0000, 50% notacolor'}));
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {
+        });
+
+        expect(stateManager.getPullGradientHandlers()).toEqual([[0, '#ff0000']]);
+        expect(consoleWarn).toHaveBeenCalled();
+    });
+});
+
+describe('StateManager echo state', () => {
+    test('isEchoEnabled_givenAFreshStateManager_returnsFalse', () => {
+        expect(makeStateManager().isEchoEnabled()).toBe(false);
+    });
+
+    test('enableLaravelEcho_givenAnAppKey_enablesEchoAndStoresTheKey', () => {
+        const stateManager = makeStateManager();
+
+        stateManager.enableLaravelEcho('app-key');
+
+        expect(stateManager.isEchoEnabled()).toBe(true);
+        expect(stateManager.getLaravelEchoAppKey()).toBe('app-key');
+    });
+});

--- a/resources/assets/js/custom/statemanager.test.js
+++ b/resources/assets/js/custom/statemanager.test.js
@@ -24,6 +24,7 @@ global.MAP_FACADE_STYLE_FACADE = 'facade';
 global.MAP_FACADE_STYLE_SPLIT_FLOORS = 'split_floors';
 global.NUMBER_STYLE_PERCENTAGE = 'percentage';
 global.NUMBER_STYLE_ENEMY_FORCES = 'enemy_forces';
+global.DISPLAY_TYPE_NPC_CLASS = 'npc_class';
 global.cookieDefaultAttributes = undefined;
 
 // 1c. Map context classes. Only their identity matters to StateManager: setMapContext() picks one
@@ -292,11 +293,11 @@ describe('StateManager cookie-backed display settings', () => {
         const stateManager = makeStateManager();
         const received = listenFor(stateManager, 'enemydisplaytype:changed');
 
-        stateManager.setEnemyDisplayType('aggressiveness');
+        stateManager.setEnemyDisplayType(DISPLAY_TYPE_NPC_CLASS);
 
-        expect(stateManager.getEnemyDisplayType()).toBe('aggressiveness');
-        expect(Cookies.get('enemy_display_type')).toBe('aggressiveness');
-        expect(received[0].data).toEqual({enemyDisplayType: 'aggressiveness'});
+        expect(stateManager.getEnemyDisplayType()).toBe(DISPLAY_TYPE_NPC_CLASS);
+        expect(Cookies.get('enemy_display_type')).toBe(DISPLAY_TYPE_NPC_CLASS);
+        expect(received[0].data).toEqual({enemyDisplayType: DISPLAY_TYPE_NPC_CLASS});
     });
 
     test('setUnkilledEnemyOpacity_givenAnOpacity_storesItAndNotifies', () => {
@@ -305,7 +306,7 @@ describe('StateManager cookie-backed display settings', () => {
 
         stateManager.setUnkilledEnemyOpacity(0.5);
 
-        expect(stateManager.getUnkilledEnemyOpacity()).toBe('0.5');
+        expect(stateManager.getUnkilledEnemyOpacity()).toBe(0.5);
         expect(received[0].data).toEqual({opacity: 0.5});
     });
 
@@ -315,7 +316,7 @@ describe('StateManager cookie-backed display settings', () => {
 
         stateManager.setUnkilledImportantEnemyOpacity(0.8);
 
-        expect(stateManager.getUnkilledImportantEnemyOpacity()).toBe('0.8');
+        expect(stateManager.getUnkilledImportantEnemyOpacity()).toBe(0.8);
         expect(received[0].data).toEqual({opacity: 0.8});
     });
 

--- a/resources/assets/js/custom/statemanager.test.js
+++ b/resources/assets/js/custom/statemanager.test.js
@@ -680,7 +680,6 @@ describe('StateManager.getPullGradientHandlers', () => {
     });
 
     test.each([
-        ['a trailing comma', '0% #ff0000,'],
         ['no space between the stop and the color', '0%#ff0000, 100%#00ff00'],
         ['no color at all', 'red'],
         ['nothing parseable', 'a,b'],
@@ -697,12 +696,25 @@ describe('StateManager.getPullGradientHandlers', () => {
         expect(stateManager.getPullGradientHandlers()).toBe(c.map.editsidebar.pullGradient.defaultHandlers);
     });
 
-    test('getPullGradientHandlers_givenOnlyOneUsableHandler_fallsBackToTheDefaults', () => {
-        // pickHexFromHandlers() indexes handlers[0] and handlers[length - 1] unconditionally and
-        // asserts length > 1, so handing it a single handler is its own crash.
-        const stateManager = makeStateManager(makeFakeMapContext({pullGradient: '0% #ff0000'}));
+    test('getPullGradientHandlers_givenATrailingComma_keepsTheHandlersThatParsed', () => {
+        // The empty trailing segment is skipped rather than throwing, and the one handler that did
+        // parse is kept - see below for why a single handler is not replaced by the defaults.
+        const stateManager = makeStateManager(makeFakeMapContext({pullGradient: '0% #ff0000,'}));
+        vi.spyOn(console, 'warn').mockImplementation(() => {
+        });
 
-        expect(stateManager.getPullGradientHandlers()).toBe(c.map.editsidebar.pullGradient.defaultHandlers);
+        expect(stateManager.getPullGradientHandlers()).toEqual([[0, '#ff0000']]);
+    });
+
+    test('getPullGradientHandlers_givenOnlyOneUsableHandler_keepsIt', () => {
+        // grapick lets the user remove stops down to a single one, and handler:remove persists
+        // immediately - so a one-stop gradient is real, saved data. It also renders correctly:
+        // pickHexFromHandlers()'s length assert only logs, and handlers[0] === handlers[length - 1]
+        // makes every weight resolve to that color. Substituting the defaults here would show the
+        // user a gradient they did not save and write it back over theirs on the next edit.
+        const stateManager = makeStateManager(makeFakeMapContext({pullGradient: '50% #ff0000'}));
+
+        expect(stateManager.getPullGradientHandlers()).toEqual([[50, '#ff0000']]);
     });
 });
 

--- a/resources/assets/js/custom/statemanager.test.js
+++ b/resources/assets/js/custom/statemanager.test.js
@@ -240,29 +240,58 @@ describe('StateManager floor state', () => {
         expect(stateManager.getCurrentFloor()).toBe(floor);
     });
 
-    test('getCurrentFloor_givenAFloorThatIsNotVisible_returnsFalse', () => {
+    test('getCurrentFloor_givenNoFloorSetYet_returnsFalse', () => {
+        // getCurrentFloor() answers `false` rather than throwing for a floor it cannot resolve.
+        // Callers read `.id`/`.index` straight off the result, so that `false` becomes `undefined`
+        // rather than an error - which is exactly why setFloorId() now refuses to create the
+        // situation in the first place (see below).
         const stateManager = makeStateManager(makeFakeMapContext({visibleFloors: [{id: 1}]}));
-
-        stateManager.setFloorId(99);
 
         expect(stateManager.getCurrentFloor()).toBe(false);
     });
 
-    test('getCurrentFloor_givenTheContextChangedAfterTheFirstCall_keepsTheStaleFloorList', () => {
+    test('setFloorId_givenAFloorThatIsNotVisible_keepsTheCurrentFloorAndDoesNotNotify', () => {
+        const stateManager = makeStateManager(makeFakeMapContext({visibleFloors: [{id: 1}]}));
+        stateManager.setFloorId(1);
+        const received = listenFor(stateManager, 'floorid:changed');
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {
+        });
+
+        stateManager.setFloorId(99);
+
+        expect(stateManager.getCurrentFloor()).toEqual({id: 1});
+        expect(received).toHaveLength(0);
+        expect(consoleError).toHaveBeenCalled();
+    });
+
+    test('isVisibleFloorId_givenAStringIdFromTheDom_stillMatches', () => {
+        // Same coercion asymmetry getCurrentFloor() handles: integer ids from the server, a string
+        // id from the floor <select>. Without it the guard above would reject every real switch.
+        const stateManager = makeStateManager(makeFakeMapContext({visibleFloors: [{id: 2}]}));
+
+        expect(stateManager.isVisibleFloorId('2')).toBe(true);
+        expect(stateManager.isVisibleFloorId('99')).toBe(false);
+    });
+
+    test('setFloorId_givenTheContextChangedAfterTheFirstCall_refusesAgainstTheStaleFloorList', () => {
         // The visible-floor lookup is built once and never invalidated - not by setMapContext(),
         // not by setFloorId(). Nothing swaps _mapContext on a live StateManager today:
         // setMapContext() has exactly one caller (statemanager.blade.php, once per page load) and
         // the facade toggle reloads the page rather than rebuilding in place. So this is latent,
         // not live - pinned so that whoever introduces the first in-page context swap finds out
-        // here rather than through floors silently resolving against the old list.
+        // here. Since setFloorId() validates against that same lookup, a stale list now surfaces as
+        // a refused floor switch (loud) rather than floors resolving against the old list (silent).
         const stateManager = makeStateManager(makeFakeMapContext({visibleFloors: [{id: 1}]}));
         stateManager.setFloorId(1);
         expect(stateManager.getCurrentFloor()).toEqual({id: 1});
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {
+        });
 
         stateManager._mapContext = makeFakeMapContext({visibleFloors: [{id: 1, name: 'Renamed'}, {id: 5}]});
         stateManager.setFloorId(5);
 
-        expect(stateManager.getCurrentFloor()).toBe(false);
+        expect(stateManager.getCurrentFloor()).toEqual({id: 1});
+        expect(consoleError).toHaveBeenCalled();
     });
 });
 
@@ -318,6 +347,16 @@ describe('StateManager cookie-backed display settings', () => {
 
         expect(stateManager.getUnkilledImportantEnemyOpacity()).toBe(0.8);
         expect(received[0].data).toEqual({opacity: 0.8});
+    });
+
+    test.each([
+        ['unkilled enemy', 'getUnkilledEnemyOpacity', 50],
+        ['unkilled important enemy', 'getUnkilledImportantEnemyOpacity', 80],
+    ])('get%sOpacity_givenNoStoredValue_fallsBackToTheDefault', (label, getter, expected) => {
+        // Number(undefined) is NaN, and `opacity: NaN%` is dropped by the browser - rendering
+        // unkilled enemies fully opaque. Same missing-cookie scenario getKillZonePathWeight()
+        // guards against; these must match the defaults map.js first writes the cookies with.
+        expect(makeStateManager()[getter]()).toBe(expected);
     });
 
     test.each([
@@ -630,12 +669,40 @@ describe('StateManager.getPullGradientHandlers', () => {
     });
 
     test('getPullGradientHandlers_givenAHandlerWithoutAColor_skipsIt', () => {
-        const stateManager = makeStateManager(makeFakeMapContext({pullGradient: '0% #ff0000, 50% notacolor'}));
+        const stateManager = makeStateManager(
+            makeFakeMapContext({pullGradient: '0% #ff0000, 50% notacolor, 100% #00ff00'})
+        );
         const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {
         });
 
-        expect(stateManager.getPullGradientHandlers()).toEqual([[0, '#ff0000']]);
+        expect(stateManager.getPullGradientHandlers()).toEqual([[0, '#ff0000'], [100, '#00ff00']]);
         expect(consoleWarn).toHaveBeenCalled();
+    });
+
+    test.each([
+        ['a trailing comma', '0% #ff0000,'],
+        ['no space between the stop and the color', '0%#ff0000, 100%#00ff00'],
+        ['no color at all', 'red'],
+        ['nothing parseable', 'a,b'],
+    ])('getPullGradientHandlers_given%s_fallsBackToTheDefaultsInsteadOfThrowing', (label, pullGradient) => {
+        // pull_gradient is persisted with no format validation at all (storePullGradient() takes a
+        // bare Request), so these really can be stored. Dereferencing the missing color token threw
+        // a TypeError - verified against a live route carrying '0% #ff0000,'. The blast radius is
+        // the route's own editor rather than its viewers: the three callers are the pull settings
+        // tab's init, createNewPull() and the sidebar's drag-reorder, all edit-mode only.
+        const stateManager = makeStateManager(makeFakeMapContext({pullGradient}));
+        vi.spyOn(console, 'warn').mockImplementation(() => {
+        });
+
+        expect(stateManager.getPullGradientHandlers()).toBe(c.map.editsidebar.pullGradient.defaultHandlers);
+    });
+
+    test('getPullGradientHandlers_givenOnlyOneUsableHandler_fallsBackToTheDefaults', () => {
+        // pickHexFromHandlers() indexes handlers[0] and handlers[length - 1] unconditionally and
+        // asserts length > 1, so handing it a single handler is its own crash.
+        const stateManager = makeStateManager(makeFakeMapContext({pullGradient: '0% #ff0000'}));
+
+        expect(stateManager.getPullGradientHandlers()).toBe(c.map.editsidebar.pullGradient.defaultHandlers);
     });
 });
 

--- a/resources/assets/js/custom/statemanager.test.js
+++ b/resources/assets/js/custom/statemanager.test.js
@@ -396,10 +396,11 @@ describe('StateManager cookie-backed display settings', () => {
         expect(stateManager.getMapZoomSpeed()).toBe(3);
     });
 
-    test('getMapZoomSpeed_givenNoStoredValue_returnsNaN', () => {
-        // Unlike getKillZonePathWeight() this one has no isNaN() guard, so a missing cookie yields
-        // NaN rather than a usable default. Pinned as the current behaviour, not endorsed.
-        expect(makeStateManager().getMapZoomSpeed()).toBeNaN();
+    test('getMapZoomSpeed_givenNoStoredValue_returnsTheDefault', () => {
+        // Mirrors getKillZonePathWeight()'s isNaN() guard: a missing cookie now falls back to the
+        // same default (50) that map.js/mapsettings.blade.php use when first setting the cookie,
+        // instead of returning NaN.
+        expect(makeStateManager().getMapZoomSpeed()).toBe(50);
     });
 });
 

--- a/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature\Controller\Ajax;
 
+use App\Models\Dungeon;
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Enemy;
 use App\Models\Floor\Floor;
 use App\Models\KillZone\KillZone;
 use App\Models\KillZone\KillZoneEnemy;
+use App\Models\Mapping\MappingVersion;
 use App\Models\PublishedState;
 use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
@@ -353,20 +355,45 @@ final class AjaxKillZoneControllerTest extends DungeonRouteTestBase
     public function store_givenAFacadeLocationWhileTheMapFacadeStyleSaysSplitFloors_persistsTheLocationOnItsRealFloor(): void
     {
         // Arrange
-        [$dungeon, $mappingVersion] = $this->findDungeon(facadeEnabled: true, minEnemies: 1);
-        /** @var Floor $facadeFloor */
-        $facadeFloor = $dungeon->floors()->where('facade', true)->firstOrFail();
-        /** @var Enemy $enemy */
-        $enemy = $mappingVersion->enemies()->whereHas('floor', static fn($query) => $query->where('facade', false))
-            ->whereNotNull('lat')
-            ->firstOrFail();
-
         /** @var CoordinatesServiceInterface $coordinatesService */
         $coordinatesService = app(CoordinatesServiceInterface::class);
+
+        // Floor union areas cover only part of a floor, so an arbitrary enemy need not sit inside
+        // one - and taking the first enemy and asserting that it did made this test fail for
+        // whichever facade dungeon the shuffle happened to pick (lowerkarazhan, 1 of 53). The
+        // conversion is therefore a *requirement* on the fixture: reject any dungeon with no enemy
+        // that converts onto the facade floor, and hand back the enemy that does.
+        [$dungeon, $mappingVersion, $enemy] = $this->findDungeon(
+            facadeEnabled: true,
+            minEnemies:    1,
+            resolve:       static function (Dungeon $dungeon, MappingVersion $mappingVersion) use ($coordinatesService): ?Enemy {
+                // `floor` is eager loaded because the coordinate conversion reads it, and these
+                // enemies are hydrated as a collection - where preventLazyLoading does enforce
+                $enemies = $mappingVersion->enemies()
+                    ->with('floor')
+                    ->whereHas('floor', static fn($query) => $query->where('facade', false))
+                    ->whereNotNull('lat')
+                    ->get();
+
+                foreach ($enemies as $enemy) {
+                    /** @var Enemy $enemy */
+                    $facadeLatLng = $coordinatesService->convertMapLocationToFacadeMapLocation($mappingVersion, $enemy->getLatLng());
+
+                    if ((bool)$facadeLatLng->getFloor()->facade) {
+                        return $enemy;
+                    }
+                }
+
+                return null;
+            },
+        );
+
+        /** @var Floor $facadeFloor */
+        $facadeFloor = $dungeon->floors()->where('facade', true)->firstOrFail();
+
         // Exactly the location the client would submit for a kill area placed on top of that enemy
         // while the facade map is rendered
         $facadeLatLng = $coordinatesService->convertMapLocationToFacadeMapLocation($mappingVersion, $enemy->getLatLng());
-        $this->assertTrue((bool)$facadeLatLng->getFloor()->facade, 'Expected the enemy to live inside a floor union area');
 
         $dungeonRoute = DungeonRoute::factory()->create([
             'dungeon_id'         => $dungeon->id,


### PR DESCRIPTION
:robot: Part of #3674 (target **C** of the suggested split: `statemanager.js`), alongside #3847 (A) and #3848 (B).

With this one every target in #3674 has an MR, so **merging all three closes the issue** — but none of them claims `Closes` on its own.

## What this does

Adds `resources/assets/js/custom/statemanager.test.js` — coverage over the global state every map
page reads — and, following review, **fixes the bugs that coverage turned up** instead of pinning
them.

### Tests

- **map context** — `setMapContext()` builds the right class per `MAP_CONTEXT_TYPE_*` (all five)
  and leaves the previous context in place on an unknown type; `isMapAdmin()` is true only for the
  mapping editor.
- **floor state** — `setFloorId()` notification payloads, `getCurrentFloor()` resolving through
  `Number()` on both sides, and the new visible-floor guard.
- **zoom** — `setMapZoomLevel()` reports the previous level and stays silent when unchanged
  (`setFloorId()` deliberately has no such guard; that asymmetry is pinned).
- **cookie-backed display settings** — enemy display type, both opacities, both borders, both
  heatmap toggles, facade style and number style, including the unset-cookie defaults.
- the rest of the surface: `isCurrentDungeonFacadeEnabled()`, focused enemy, MDT mapping mode,
  user roles / patreon benefits, snackbar id bookkeeping, `updateKillZones()` flattening, pull
  gradient parsing, and echo state.

### Fixes

1. **`getPullGradientHandlers()` threw on a malformed gradient.** It dereferenced `values[1]`
   without checking it existed, so a `pull_gradient` with a trailing comma — or any handler with no
   space in it — threw a `TypeError`. `pull_gradient` is persisted with **no format validation at
   all** (`storePullGradient()` takes a bare `Request`; the other path is only
   `nullable|string|max:2000`), so those strings really can be stored. Reproduced against a live
   route holding `0% #ff0000,`. Unusable handlers are now skipped, and the defaults are used only
   when *nothing* parses — `pickHexFromHandlers()` indexes `handlers[0]` unconditionally, so an
   empty list is its own `TypeError`.

   Blast radius is the route's **own editor**, not its viewers: the three callers are the pull
   settings tab's init, `createNewPull()`, and the sidebar drag-reorder — all edit-mode only.

2. **Both opacity getters returned `NaN` on a missing cookie.** `Number(undefined)` is `NaN`, and
   `opacity: NaN%` is dropped by the browser, rendering unkilled enemies fully opaque. Given the
   same `isNaN()` fallback `getKillZonePathWeight()` already has (50 / 80, matching what `map.js`
   writes the cookies with). Same class as the `getMapZoomSpeed()` `NaN` fixed earlier in the branch.

3. **`setFloorId()` accepted any floor id** (@Wotuu's review). `getCurrentFloor()` answers `false`
   for a floor it cannot resolve, and callers read `.id`/`.index` straight off that — so `false.id`
   is `undefined` rather than a throw, and that `undefined` reached the tile URL's `{index}` segment
   and `floor_id` on ajax payloads. It now refuses a floor not visible in the current map context
   and logs why, sharing `getCurrentFloor()`'s lookup via a new `isVisibleFloorId()` so the string
   ids the floor `<select>` produces are still accepted.

### Also fixed here: an unrelated CI flake

`AjaxKillZoneControllerTest::store_givenAFacadeLocationWhileTheMapFacadeStyleSaysSplitFloors_persistsTheLocationOnItsRealFloor`
(added in master's `1788bef1b`) took the first non-facade enemy with a `lat` and *asserted* it lived
inside a floor union area. Union areas cover only part of a floor, so that is an assumption, and
`findDungeon()` shuffles — the test failed for whichever facade dungeon it landed on.
`lowerkarazhan` is the one of 53 where it bites: 406 of its 408 candidate enemies convert onto the
facade floor, but the first two do not.

The conversion is now a requirement on the fixture (a `resolve()` closure) rather than an assertion
after the fact. Verified across all 53 facade dungeons: every one resolves a usable enemy, none is
rejected. Not related to this branch — fixed here rather than deferred, since it was red on this PR.

## Notes for the reviewer

- **Signalable is not stubbed.** Subscriber notification *is* the subject of this file, so the
  tests register real listeners on the real event bus and assert on the delivered
  `{name, context, data}` payloads. That is why `signalable.js` gets the guarded UMD export footer
  too — the same no-op already shipping in `killzone.js` / `enemy.js`.
- The cookie jar is a real read-back store rather than the shared setup's write-less stub, because
  several getters read straight back out of `Cookies`.
- **`updateKillZones()` appears to be dead code** — `grep -rn "updateKillZones" resources/ app/`
  finds only its definition, and the `this.killZones` it writes is never read. I've left it (and
  its tests) alone rather than deleting a public method unilaterally, but it's a candidate for
  removal if you agree. Its tests can only ever pin the shape it invents, since nothing calls it.

## Verification

- `npm test` — 46 files / 627 tests green. `composer run fix` (0 files) and `composer run analyse`
  (no errors) both clean.
- **Mutation-checked**: dropping the `values.length` guard fails 4 tests; removing the empty-result
  fallback fails 4; reinstating the over-eager `< 2` threshold the cold reviewer caught fails 2;
  dropping both opacity `isNaN` fallbacks fails 2; dropping the `setFloorId` guard fails 2. Earlier
  set still killed: both `Number()` floor coercions, `isMapAdmin()` widening, the `isNaN` guard in
  `getKillZonePathWeight()`, the zoom changed-check, and the snackbar existence check.
- **Headless Chrome against a real route page** (`/route/halls-of-atonement/...`): map renders, no
  page errors, initial floor accepted on load, string `'78'` from the DOM accepted (resolves to
  floor index 2), `999` refused with the console error and the floor left unchanged. With fix 1
  reverted, a route holding `pull_gradient = '0% #ff0000,'` made `getPullGradientHandlers()` throw a
  real `TypeError`; with it, parsing succeeds.
- No rendered output changed, so no before/after screenshots. The map screenshot posted as a comment
  is evidence the floor guard does not break page load, not a visual diff.

## Follow-ups filed

- #3946 — move focused-enemy state off `StateManager` onto `EnemyMapObjectGroup` (as requested).
- #3947 — use `enemyDisplayType` consistently instead of `enemyVisualType`/`enemy_visual_type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rMbTdvtFZbbuPGNpohE85
