### PR TITLE
#3853 Anchor the Playwire side rails to the viewport edges

### DIFF
--- a/resources/assets/css/lib/thirdparty/playwire.css
+++ b/resources/assets/css/lib/thirdparty/playwire.css
@@ -12,6 +12,19 @@
     pointer-events: auto !important;
 }
 
+/**
+ * The side rails were positioned too far towards the middle of the viewport and overlapped the
+ * page content underneath them; anchor them back to the viewport edges. Reported to Playwire as
+ * well - once they fix it upstream these two rules only re-assert the intended position.
+ */
+#pw-oop-left_rail {
+    left: 0 !important;
+}
+
+#pw-oop-right_rail {
+    right: 0 !important;
+}
+
 /** Otherwise the video will be above the blank space for the bottom rail */
 .pw-corner-ad-video {
     margin-bottom: 0 !important;


### PR DESCRIPTION
:robot: Closes #3853

## What

The Playwire left/right rail ad units (`#pw-oop-left_rail` / `#pw-oop-right_rail`) sat too far
towards the middle of the viewport and overlapped the page content underneath them. This forces
them back to the viewport edges using the override Playwire suggested:

```css
#pw-oop-left_rail  { left: 0 !important; }
#pw-oop-right_rail { right: 0 !important; }
```

The rails are injected at runtime by the ramp script and are not markup we control, hence
`!important`. This has been relayed to Playwire as well - if they fix it upstream these rules only
re-assert the intended position.

## Where

Added to the existing `resources/assets/css/lib/thirdparty/playwire.css`, which already holds the
bottom-rail and sticky in-content overrides, rather than starting a second home for Playwire CSS.

## Verification

The rails only exist once the ramp script runs, which it does not on a dev stack - so there is
**nothing to screenshot locally** and no way to visually confirm the ads themselves. The
checklist's visual-verification item does not apply here; positioning has to be confirmed on
staging/production after release.

What was verified mechanically instead, against the real built bundle
(`public/css/custom-<sha>.css`) served by the worktree stack, in headless Chrome: stub elements
carrying the ids and an inline `left:250px` / `right:250px` compute to `left: 0px` / `right: 0px`.
That proves the selectors match and the `!important` beats the kind of inline positioning ramp
applies - it does not prove the ads look right.

- `npm run development` - rules present in `public/css/custom-<sha>.css` (the `lib/**/*.css` glob
  in `scripts/build/custom-styles-order.mjs` picks them up).
- `npm test` - 40 files / 364 tests pass, including the css-concat ordering tests.
- `composer run fix` - 0 files changed. `composer run analyse` - no errors.

**This is a compiled-asset change, so it cannot be hotfixed** - it ships in a release.

Cold review skipped under the trivial-change rule (13-line CSS-only diff), by Wotuu's explicit
call in the implementing session. The `pr cold reviewed` label is set so `babysit-prs` does not
dispatch its own review.
