### PR TITLE
#3664 Fix Mockery\Exception imported instead of \Exception

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxPathController.php
+++ b/app/Http/Controllers/Ajax/AjaxPathController.php
@@ -23,7 +23,6 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
-use Mockery\Exception;
 use Teapot\StatusCode\Http;
 
 class AjaxPathController extends Controller
@@ -55,57 +54,58 @@ class AjaxPathController extends Controller
             return $result;
         }
 
-        DB::transaction(function () use ($coordinatesService, $path, $dungeonRoute, $validated, &$result) {
-            $beforeModel = $path === null ? null : clone $path;
+        try {
+            DB::transaction(function () use ($coordinatesService, $path, $dungeonRoute, $validated, &$result) {
+                $beforeModel = $path === null ? null : clone $path;
 
-            if ($path === null) {
-                $path = Path::create([
-                    'dungeon_route_id' => $dungeonRoute->id,
-                    'floor_id'         => $validated['floor_id'],
-                    'polyline_id'      => -1,
-                ]);
-                $success = true;
-            } else {
-                $success = $path->update([
-                    'dungeon_route_id' => $dungeonRoute->id,
-                    'floor_id'         => $validated['floor_id'],
-                ]);
-            }
-
-            try {
-                if ($success) {
-                    // Create a new polyline and save it
-                    $this->savePolylineToModel(
-                        $coordinatesService,
-                        $dungeonRoute,
-                        $dungeonRoute->mappingVersion,
-                        Polyline::findOrNew($path->polyline_id),
-                        $beforeModel,
-                        $path,
-                        $validated['polyline'],
-                    );
-
-                    // Set or unset the linked awakened obelisks now that we have an ID
-                    $path->setLinkedAwakenedObeliskByMapIconId($validated['linked_awakened_obelisk_id'] ?? null);
-
-                    // Something's updated; broadcast it
-                    if (Auth::check()) {
-                        /** @var User $user */
-                        $user = Auth::getUser();
-                        broadcast(new PathChangedEvent($coordinatesService, $dungeonRoute, $user, $path));
-                    }
-
-                    // Touch the route so that the thumbnail gets updated
-                    $dungeonRoute->touch();
+                if ($path === null) {
+                    $path = Path::create([
+                        'dungeon_route_id' => $dungeonRoute->id,
+                        'floor_id'         => $validated['floor_id'],
+                        'polyline_id'      => -1,
+                    ]);
+                    $success = true;
                 } else {
+                    $success = $path->update([
+                        'dungeon_route_id' => $dungeonRoute->id,
+                        'floor_id'         => $validated['floor_id'],
+                    ]);
+                }
+
+                if (! $success) {
+                    // Caught below, which rolls back this transaction and responds with a 404
                     throw new \Exception(__('controller.path.error.unable_to_save_path'));
                 }
 
+                // Create a new polyline and save it
+                $this->savePolylineToModel(
+                    $coordinatesService,
+                    $dungeonRoute,
+                    $dungeonRoute->mappingVersion,
+                    Polyline::findOrNew($path->polyline_id),
+                    $beforeModel,
+                    $path,
+                    $validated['polyline'],
+                );
+
+                // Set or unset the linked awakened obelisks now that we have an ID
+                $path->setLinkedAwakenedObeliskByMapIconId($validated['linked_awakened_obelisk_id'] ?? null);
+
+                // Something's updated; broadcast it
+                if (Auth::check()) {
+                    /** @var User $user */
+                    $user = Auth::getUser();
+                    broadcast(new PathChangedEvent($coordinatesService, $dungeonRoute, $user, $path));
+                }
+
+                // Touch the route so that the thumbnail gets updated
+                $dungeonRoute->touch();
+
                 $result = $path;
-            } catch (Exception) {
-                $result = response(__('controller.generic.error.not_found'), Http::NOT_FOUND);
-            }
-        });
+            });
+        } catch (\Exception) {
+            $result = response(__('controller.generic.error.not_found'), Http::NOT_FOUND);
+        }
 
         return $result;
     }

--- a/app/Models/Dungeon.php
+++ b/app/Models/Dungeon.php
@@ -34,7 +34,6 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
-use Mockery\Exception;
 use Override;
 
 /**
@@ -178,19 +177,15 @@ class Dungeon extends CacheModel implements CombatLogCriterionModelInterface, Ma
 
         $this->npcs->load('npcEnemyForces');
 
-        try {
-            // Loop through all floors
-            foreach ($this->npcs as $npc) {
-                /** @var Npc $npc */
-                if ($npc->classification_id < NpcClassification::ALL[NpcClassification::NPC_CLASSIFICATION_BOSS]) {
-                    /** @var NpcEnemyForces|null $npcEnemyForces */
-                    $npcEnemyForces = $npc->enemyForcesByMappingVersion();
+        // Loop through all floors
+        foreach ($this->npcs as $npc) {
+            /** @var Npc $npc */
+            if ($npc->classification_id < NpcClassification::ALL[NpcClassification::NPC_CLASSIFICATION_BOSS]) {
+                /** @var NpcEnemyForces|null $npcEnemyForces */
+                $npcEnemyForces = $npc->enemyForcesByMappingVersion();
 
-                    $npcs[$npc->id] = ($npcEnemyForces?->enemy_forces ?? -1) >= 0; // @phpstan-ignore nullsafe.neverNull
-                }
+                $npcs[$npc->id] = ($npcEnemyForces?->enemy_forces ?? -1) >= 0; // @phpstan-ignore nullsafe.neverNull
             }
-        } catch (Exception $exception) {
-            dd($exception);
         }
 
         // Calculate which ones are unmapped

--- a/tests/Feature/Controller/Ajax/AjaxPathControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxPathControllerTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature\Controller\Ajax;
 
 use App\Models\Floor\Floor;
+use App\Models\Path;
+use App\Models\Polyline;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Teapot\StatusCode;
@@ -101,5 +103,57 @@ final class AjaxPathControllerTest extends DungeonRouteTestBase
         // Assert
         $response->assertStatus(StatusCode::FOUND);
         $response->assertSessionHasErrors(['polyline.vertices_json']);
+    }
+
+    #[Test]
+    #[Group('Controller')]
+    public function store_givenUpdateThatFailsToSave_shouldReturnNotFoundAndRollBackTransaction(): void
+    {
+        // Arrange
+        /** @var Floor $randomFloor */
+        $randomFloor = $this->dungeonRoute->dungeon->floors()
+            ->where('facade', false)
+            ->get()
+            ->random();
+
+        $path = Path::create([
+            'dungeon_route_id' => $this->dungeonRoute->id,
+            'floor_id'         => $randomFloor->id,
+            'polyline_id'      => -1,
+        ]);
+
+        // Desync the stored floor_id from what the request below will submit, so that
+        // Path::update() actually has a dirty attribute and fires its 'updating' event -
+        // Eloquent skips the event entirely (and always returns true) when nothing changed
+        Path::query()->where('id', $path->id)->update(['floor_id' => $randomFloor->id + 1]);
+
+        $polyline = PolylineFixtures::createPolyline($randomFloor);
+
+        // Force Path::update() to fail, exercising the same 'unable to save' branch a real DB
+        // failure would take, without mocking the global \Exception the controller now catches
+        Path::updating(fn() => false);
+
+        try {
+            // Act
+            $response = $this->put(route('ajax.dungeonroute.path.update', [
+                'dungeonRoute' => $this->dungeonRoute,
+                'path'         => $path,
+            ]), [
+                'floor_id' => $randomFloor->id,
+                'polyline' => $polyline,
+            ]);
+
+            // Assert
+            $response->assertStatus(StatusCode::NOT_FOUND);
+            // The polyline creation happens after the failed update, inside the same transaction -
+            // it must not have been persisted
+            $this->assertDatabaseMissing((new Polyline())->getTable(), [
+                'model_id'    => $path->id,
+                'model_class' => Path::class,
+            ]);
+        } finally {
+            Path::flushEventListeners();
+            $path->delete();
+        }
     }
 }

--- a/tests/Feature/Controller/Ajax/AjaxPathControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxPathControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Controller\Ajax;
 use App\Models\Floor\Floor;
 use App\Models\Path;
 use App\Models\Polyline;
+use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Teapot\StatusCode;
@@ -152,7 +153,9 @@ final class AjaxPathControllerTest extends DungeonRouteTestBase
                 'model_class' => Path::class,
             ]);
         } finally {
-            Path::flushEventListeners();
+            // Remove only the listener registered above - Path::flushEventListeners() would also
+            // wipe Path::boot()'s cascade-delete listener for the rest of the PHPUnit process
+            Event::forget('eloquent.updating: ' . Path::class);
             $path->delete();
         }
     }


### PR DESCRIPTION
:robot: Closes #3664

`Mockery\Exception` (require-dev only) was imported in place of the global `\Exception` in two catch clauses. PHP doesn't fatal on a `catch` naming a missing class - it just never matches - so both catches were silently dead/wrong in production.

## `AjaxPathController::store()`

The catch never fired, so a failed path save propagated out as a 500 instead of the intended 404. The try/catch sits inside a `DB::transaction(...)` closure - simply fixing the import would make the catch fire and swallow the exception *inside* the closure, which means the transaction would **commit** instead of rolling back. Moved the try/catch to wrap the whole `DB::transaction()` call so a thrown exception triggers Laravel's normal transaction rollback before being caught and turned into the 404 response. `Gate::authorize('edit', ...)` runs before the try, so an `AuthorizationException` is unaffected.

Note: the whole closure (including `Path::create()`/`update()`) is now inside the outer try, so a genuine DB failure there would also be converted to a 404 instead of surfacing as a 500 - this is inherent to fixing the transaction/rollback semantics correctly, flagged during review, and judged acceptable (matches the existing behaviour of the sibling `delete()` method and other Ajax controllers, which also 404 on `catch (\Exception)`).

## `Dungeon::getEnemyForcesMappedStatusAttribute()`

Dead code that would `dd()` in production if it ever fired. Removed the try/catch entirely, per the issue's suggestion. No functional impact - no test exercises this accessor, and the catch never matched in production anyway.

`grep -rn "use Mockery\\\\Exception;" app/` now returns nothing.

## Tests

Added `AjaxPathControllerTest::store_givenUpdateThatFailsToSave_shouldReturnNotFoundAndRollBackTransaction` - forces `Path::update()` to fail via an `updating` model-event listener, then asserts a 404 response and that the polyline created later in the same transaction was never persisted. Confirmed this test fails against the pre-fix code (uncaught error) and passes with the fix.

- `AjaxPathControllerTest` - 5 passed
- `composer run fix` / `composer run analyse` - clean

## Cold review

Independent review (agent, no shared context) confirmed the transaction/rollback restructuring is correct and `AuthorizationException` is unaffected. It found one real bug in the test: `Path::flushEventListeners()` in the `finally` block would have wiped `Path::boot()`'s `deleting` cascade listener for the rest of the PHPUnit process (listeners register once per class, not per test). Fixed by scoping cleanup to `Event::forget('eloquent.updating: '.Path::class)` instead.
