### PR TITLE
#3666 Fix hasKilledAllRequiredEnemies() and restore the publish guard

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
+++ b/app/Http/Controllers/Ajax/AjaxDungeonRouteController.php
@@ -580,9 +580,9 @@ class AjaxDungeonRouteController extends Controller
      */
     public function publishedState(PublishFormRequest $request, DungeonRoute $dungeonRoute): Response
     {
-        Gate::authorize('publish', $dungeonRoute);
-
         $publishedState = $request->get('published_state', PublishedState::UNPUBLISHED);
+
+        Gate::authorize('publish', [$dungeonRoute, $publishedState]);
 
         if (!PublishedState::getAvailablePublishedStates($dungeonRoute, Auth::user())->contains($publishedState)) {
             abort(422, 'This sharing state is not available for this route');

--- a/app/Models/DungeonRoute/DungeonRoute.php
+++ b/app/Models/DungeonRoute/DungeonRoute.php
@@ -112,7 +112,7 @@ use Override;
  * @property Carbon               $published_at
  * @property Carbon|null          $expires_at
  *
- * @property MappingVersion                    $mappingVersion
+ * @property MappingVersion|null               $mappingVersion
  * @property Dungeon                           $dungeon
  * @property Path                              $route
  * @property Season|null                       $season
@@ -1148,12 +1148,15 @@ class DungeonRoute extends Model implements TracksPageViewInterface
      */
     public function hasKilledAllRequiredEnemies(): bool
     {
-        // Sandbox/unmigrated routes have no mapping version to compare against - nothing can be required of them.
-        if ($this->mapping_version_id === null) {
+        $this->loadMissing('mappingVersion.enemies');
+
+        // Sandbox/unmigrated routes have no mapping version to compare against - and since this schema carries no
+        // foreign keys, a route can also point at a mapping version that has since been deleted. Nothing can be
+        // required of either, and a hard failure here would 500 the publish endpoint and abort the whole
+        // scheduled-publish cron run.
+        if ($this->mappingVersion === null) {
             return true;
         }
-
-        $this->loadMissing('mappingVersion.enemies');
 
         $requiredEnemies = $this->mappingVersion->enemies
             ->filter(fn(Enemy $enemy) => $enemy->required && $this->isEnemyVisibleForTeeming($enemy));

--- a/app/Models/DungeonRoute/DungeonRoute.php
+++ b/app/Models/DungeonRoute/DungeonRoute.php
@@ -1150,9 +1150,9 @@ class DungeonRoute extends Model implements TracksPageViewInterface
     {
         $this->loadMissing('mappingVersion.enemies');
 
-        // Sandbox/unmigrated routes have no mapping version to compare against - and since this schema carries no
-        // foreign keys, a route can also point at a mapping version that has since been deleted. Nothing can be
-        // required of either, and a hard failure here would 500 the publish endpoint and abort the whole
+        // Sandbox routes always have a mapping version, but this schema carries no foreign keys, so a route can
+        // point at a mapping version that has since been deleted. Nothing can be required against a missing
+        // mapping version, and a hard failure here would 500 the publish endpoint and abort the whole
         // scheduled-publish cron run.
         if ($this->mappingVersion === null) {
             return true;

--- a/app/Models/DungeonRoute/DungeonRoute.php
+++ b/app/Models/DungeonRoute/DungeonRoute.php
@@ -1137,37 +1137,34 @@ class DungeonRoute extends Model implements TracksPageViewInterface
      */
     public function isEnemyKilled(int $enemyId): bool
     {
-        $result = false;
-
-        foreach ($this->killZones as $killZone) {
-            if ($killZone->getEnemies()->filter(static fn($enemy) => $enemy->id === $enemyId)->isNotEmpty()) {
-                $result = true;
-                break;
-            }
-        }
-
-        return $result;
+        return isset($this->getKilledEnemyIds()[$enemyId]);
     }
 
     /**
-     * Checks if this route has killed all required enemies.
+     * Checks if this route has killed all enemies that are marked as required in the route's mapping version.
+     *
+     * Enemies are only considered when they are visible for this route's teeming setting - an enemy that only spawns
+     * on teeming keys cannot be required on a non-teeming route and vice versa.
      */
     public function hasKilledAllRequiredEnemies(): bool
     {
-        $result = true;
+        // Sandbox/unmigrated routes have no mapping version to compare against - nothing can be required of them.
+        if ($this->mapping_version_id === null) {
+            return true;
+        }
 
-        //        foreach ($this->dungeon->enemies as $enemy) {
-        //            if ($enemy->required &&
-        //                ($enemy->teeming === null || ($enemy->teeming === 'visible' && $this->teeming) || ($enemy->teeming === 'invisible' && $this->teeming))) {
-        //
-        //                if (!$this->isEnemyKilled($enemy->id)) {
-        //                    $result = false;
-        //                    break;
-        //                }
-        //            }
-        //        }
+        $this->loadMissing('mappingVersion.enemies');
 
-        return $result;
+        $requiredEnemies = $this->mappingVersion->enemies
+            ->filter(fn(Enemy $enemy) => $enemy->required && $this->isEnemyVisibleForTeeming($enemy));
+
+        if ($requiredEnemies->isEmpty()) {
+            return true;
+        }
+
+        $killedEnemyIds = $this->getKilledEnemyIds();
+
+        return $requiredEnemies->every(static fn(Enemy $enemy) => isset($killedEnemyIds[$enemy->id]));
     }
 
     public function hasUniqueAffix(string $affix): bool
@@ -1390,6 +1387,39 @@ class DungeonRoute extends Model implements TracksPageViewInterface
             // Make sure the relation should be reloaded
             $this->unsetRelation('affixGroups');
         }
+    }
+
+    /**
+     * All enemy ids killed by any of this route's kill zones, keyed by enemy id for O(1) lookups.
+     *
+     * @return array<int, true>
+     */
+    private function getKilledEnemyIds(): array
+    {
+        $this->loadMissing('killZones.enemies');
+
+        $result = [];
+
+        foreach ($this->killZones as $killZone) {
+            foreach ($killZone->getEnemies() as $enemy) {
+                $result[$enemy->id] = true;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Whether the enemy spawns at all given this route's teeming setting. Enemies that are not teeming-specific
+     * (teeming === null) always spawn.
+     */
+    private function isEnemyVisibleForTeeming(Enemy $enemy): bool
+    {
+        return match ($enemy->teeming) {
+            Enemy::TEEMING_VISIBLE => (bool)$this->teeming,
+            Enemy::TEEMING_HIDDEN  => !$this->teeming,
+            default                => true,
+        };
     }
 
     /**

--- a/app/Models/DungeonRoute/DungeonRoute.php
+++ b/app/Models/DungeonRoute/DungeonRoute.php
@@ -77,7 +77,7 @@ use Override;
  * @property string               $public_key
  * @property int                  $author_id
  * @property int                  $dungeon_id
- * @property int                  $mapping_version_id
+ * @property int|null             $mapping_version_id
  * @property int                  $season_id
  * @property int                  $faction_id
  * @property int|null             $team_id

--- a/app/Policies/DungeonRoutePolicy.php
+++ b/app/Policies/DungeonRoutePolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Laratrust\Role;
+use App\Models\PublishedState;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -65,10 +66,14 @@ class DungeonRoutePolicy
 
     /**
      * Determine whether the user can publish dungeon routes.
+     *
+     * @param string|null $publishedState The state the route is being changed to, if known. Unpublishing is always
+     *                                    allowed - the required enemies guard would otherwise trap an already
+     *                                    published route in a state its author can no longer undo.
      */
-    public function publish(User $user, DungeonRoute $dungeonroute): Response
+    public function publish(User $user, DungeonRoute $dungeonroute, ?string $publishedState = null): Response
     {
-        if (!$dungeonroute->hasKilledAllRequiredEnemies()) {
+        if ($publishedState !== PublishedState::UNPUBLISHED && !$dungeonroute->hasKilledAllRequiredEnemies()) {
             return $this->deny(__('policy.publish_not_all_required_enemies_killed'));
         }
 

--- a/app/Policies/DungeonRoutePolicy.php
+++ b/app/Policies/DungeonRoutePolicy.php
@@ -67,9 +67,10 @@ class DungeonRoutePolicy
     /**
      * Determine whether the user can publish dungeon routes.
      *
-     * @param string|null $publishedState The state the route is being changed to, if known. Unpublishing is always
-     *                                    allowed - the required enemies guard would otherwise trap an already
-     *                                    published route in a state its author can no longer undo.
+     * @param string|null $publishedState The state the route is being changed to, if known. The required enemies
+     *                                    check is not executed when you are unpublishing the route - otherwise the
+     *                                    guard would trap an already published route in a state its author can no
+     *                                    longer undo.
      */
     public function publish(User $user, DungeonRoute $dungeonroute, ?string $publishedState = null): Response
     {

--- a/app/Repositories/Database/DungeonRoute/DungeonRouteThumbnailRepository.php
+++ b/app/Repositories/Database/DungeonRoute/DungeonRouteThumbnailRepository.php
@@ -20,7 +20,7 @@ class DungeonRouteThumbnailRepository extends DatabaseRepository implements Dung
     public function hasFreshThumbnailForVariant(DungeonRoute $dungeonRoute, DungeonRouteThumbnailVariant $variant): bool
     {
         $mappingVersion = $dungeonRoute->mappingVersion;
-        if ($mappingVersion === null) { // @phpstan-ignore identical.alwaysFalse
+        if ($mappingVersion === null) {
             return false;
         }
 

--- a/app/Service/DungeonRoute/DungeonRouteService.php
+++ b/app/Service/DungeonRoute/DungeonRouteService.php
@@ -282,7 +282,12 @@ readonly class DungeonRouteService implements DungeonRouteServiceInterface
             /** @var Collection<int, DungeonRouteScheduledPublish> $scheduledPublishes */
             $scheduledPublishes = DungeonRouteScheduledPublish::query()
                 ->where('publish_at', '<=', now())
-                ->with(['dungeonRoute.dungeon', 'dungeonRoute.author'])
+                ->with([
+                    'dungeonRoute.dungeon',
+                    'dungeonRoute.author',
+                    'dungeonRoute.mappingVersion.enemies',
+                    'dungeonRoute.killZones.enemies',
+                ])
                 ->get();
 
             foreach ($scheduledPublishes as $scheduledPublish) {
@@ -298,6 +303,12 @@ readonly class DungeonRouteService implements DungeonRouteServiceInterface
 
                 if ($publishedState === PublishedState::WORLD && !$dungeonRoute->dungeon->active) {
                     $this->log->publishScheduledDungeonRouteSkippedInactiveDungeon($dungeonRoute->id, $dungeonRoute->dungeon_id, $scheduledPublish->id);
+                    $scheduledPublish->delete();
+                    continue;
+                }
+
+                if (!$dungeonRoute->hasKilledAllRequiredEnemies()) {
+                    $this->log->publishScheduledDungeonRouteSkippedRequiredEnemiesNotKilled($dungeonRoute->id, $scheduledPublish->id);
                     $scheduledPublish->delete();
                     continue;
                 }

--- a/app/Service/DungeonRoute/DungeonRouteService.php
+++ b/app/Service/DungeonRoute/DungeonRouteService.php
@@ -286,7 +286,8 @@ readonly class DungeonRouteService implements DungeonRouteServiceInterface
                     'dungeonRoute.dungeon',
                     'dungeonRoute.author',
                     'dungeonRoute.mappingVersion.enemies',
-                    'dungeonRoute.killZones.enemies',
+                    // .npc because KillZone::getEnemies() loads it - without it that is a query per kill zone
+                    'dungeonRoute.killZones.enemies.npc',
                 ])
                 ->get();
 

--- a/app/Service/DungeonRoute/Logging/DungeonRouteServiceLogging.php
+++ b/app/Service/DungeonRoute/Logging/DungeonRouteServiceLogging.php
@@ -84,4 +84,9 @@ class DungeonRouteServiceLogging extends StructuredLogging implements DungeonRou
     {
         $this->error(__METHOD__, get_defined_vars());
     }
+
+    public function publishScheduledDungeonRouteSkippedRequiredEnemiesNotKilled(int $dungeonRouteId, int $scheduledPublishId): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
+    }
 }

--- a/app/Service/DungeonRoute/Logging/DungeonRouteServiceLoggingInterface.php
+++ b/app/Service/DungeonRoute/Logging/DungeonRouteServiceLoggingInterface.php
@@ -35,4 +35,6 @@ interface DungeonRouteServiceLoggingInterface
     public function publishScheduledDungeonRouteSkippedNoPatreon(int $dungeonRouteId, int $scheduledPublishId): void;
 
     public function publishScheduledDungeonRouteSkippedInactiveDungeon(int $dungeonRouteId, int $dungeonId, int $scheduledPublishId): void;
+
+    public function publishScheduledDungeonRouteSkippedRequiredEnemiesNotKilled(int $dungeonRouteId, int $scheduledPublishId): void;
 }

--- a/app/Service/DungeonRoute/ThumbnailService.php
+++ b/app/Service/DungeonRoute/ThumbnailService.php
@@ -275,7 +275,7 @@ class ThumbnailService implements ThumbnailServiceInterface
             return false;
         }
 
-        if ($dungeonRoute->mappingVersion === null) { // @phpstan-ignore identical.alwaysFalse
+        if ($dungeonRoute->mappingVersion === null) {
             // Non-standard variants have nothing to fall back on, so bail.
             if (!$isStandard) {
                 return false;

--- a/resources/assets/js/custom/constants.js
+++ b/resources/assets/js/custom/constants.js
@@ -205,6 +205,12 @@ const METRIC_TAG_MDT_COPY_EMBED = 'embed';
 const TEEMING_VISIBLE = 'visible';
 const TEEMING_HIDDEN = 'hidden';
 
+// Published states - must match App\Models\PublishedState
+const PUBLISHED_STATE_UNPUBLISHED = 'unpublished';
+const PUBLISHED_STATE_TEAM = 'team';
+const PUBLISHED_STATE_WORLD_WITH_LINK = 'world_with_link';
+const PUBLISHED_STATE_WORLD = 'world';
+
 // Game versions
 const GAME_VERSION_RETAIL = 'retail';
 const GAME_VERSION_CLASSIC_ERA = 'classic';

--- a/resources/assets/js/custom/inline/common/dungeonroute/publish.js
+++ b/resources/assets/js/custom/inline/common/dungeonroute/publish.js
@@ -64,8 +64,11 @@ class CommonDungeonroutePublish extends InlineCode {
         let killZoneMapObjectGroup = this._getKillZoneMapObjectGroup();
         if (killZoneMapObjectGroup !== null) {
             this._refreshRequiredEnemiesState();
+            // KillZone.setEnemies() suppresses the per-enemy signals and emits only enemieschanged - that is the
+            // path remote/live-session updates take, so all three are needed to keep the state fresh
             killZoneMapObjectGroup.register('killzone:enemyadded', this, this._refreshRequiredEnemiesState.bind(this));
             killZoneMapObjectGroup.register('killzone:enemyremoved', this, this._refreshRequiredEnemiesState.bind(this));
+            killZoneMapObjectGroup.register('killzone:enemieschanged', this, this._refreshRequiredEnemiesState.bind(this));
         }
     }
 
@@ -74,6 +77,7 @@ class CommonDungeonroutePublish extends InlineCode {
         if (killZoneMapObjectGroup !== null) {
             killZoneMapObjectGroup.unregister('killzone:enemyadded', this);
             killZoneMapObjectGroup.unregister('killzone:enemyremoved', this);
+            killZoneMapObjectGroup.unregister('killzone:enemieschanged', this);
         }
 
         super.cleanup();
@@ -85,12 +89,13 @@ class CommonDungeonroutePublish extends InlineCode {
      * @private
      */
     _getKillZoneMapObjectGroup() {
-        // The share modal this select lives in is also rendered on pages that have no map at all
-        if (typeof getState !== 'function') {
-            return null;
-        }
+        // The share modal this select lives in is also rendered on pages that have no map. Both fallbacks on that
+        // path yield `false` rather than a nullish value - util.js defines a no-op getState() and
+        // MapObjectGroupManager.getByName() returns false for an absent group - so normalise with ||, not ??.
+        let state = typeof getState === 'function' ? getState() : null;
+        let dungeonMap = state ? state.getDungeonMap() : null;
 
-        return getState().getDungeonMap()?.mapObjectGroupManager?.getByName(MAP_OBJECT_GROUP_KILLZONE) ?? null;
+        return (dungeonMap?.mapObjectGroupManager?.getByName(MAP_OBJECT_GROUP_KILLZONE)) || null;
     }
 
     /**

--- a/resources/assets/js/custom/inline/common/dungeonroute/publish.js
+++ b/resources/assets/js/custom/inline/common/dungeonroute/publish.js
@@ -59,6 +59,62 @@ class CommonDungeonroutePublish extends InlineCode {
         $select.bind('change', function () {
             self._setPublished($(this).val());
         });
+
+        // Only the route editor has a map (and thus kill zones) to check the required enemies against
+        let killZoneMapObjectGroup = this._getKillZoneMapObjectGroup();
+        if (killZoneMapObjectGroup !== null) {
+            this._refreshRequiredEnemiesState();
+            killZoneMapObjectGroup.register('killzone:enemyadded', this, this._refreshRequiredEnemiesState.bind(this));
+            killZoneMapObjectGroup.register('killzone:enemyremoved', this, this._refreshRequiredEnemiesState.bind(this));
+        }
+    }
+
+    cleanup() {
+        let killZoneMapObjectGroup = this._getKillZoneMapObjectGroup();
+        if (killZoneMapObjectGroup !== null) {
+            killZoneMapObjectGroup.unregister('killzone:enemyadded', this);
+            killZoneMapObjectGroup.unregister('killzone:enemyremoved', this);
+        }
+
+        super.cleanup();
+    }
+
+    /**
+     * The kill zone map object group of the currently displayed map, or null if this page has no editable map.
+     * @returns {KillZoneMapObjectGroup|null}
+     * @private
+     */
+    _getKillZoneMapObjectGroup() {
+        let dungeonMap = getState().getDungeonMap();
+
+        return dungeonMap?.mapObjectGroupManager?.getByName(MAP_OBJECT_GROUP_KILLZONE) ?? null;
+    }
+
+    /**
+     * A route that does not kill all required enemies may not be published - but it must always remain possible to
+     * _unpublish_ it, so only the publishing options are disabled rather than the select as a whole.
+     * @private
+     */
+    _refreshRequiredEnemiesState() {
+        let hasKilledAllRequiredEnemies = this._getKillZoneMapObjectGroup().hasKilledAllRequiredEnemies();
+        let $select = $(this.options.publishSelector);
+
+        $select.find('option').each((index, option) => {
+            if (option.value === 'unpublished') {
+                return;
+            }
+
+            // Never re-enable an option that was unavailable for another reason to begin with
+            let isAvailable = this.options.publishStatesAvailable.includes(option.value);
+            option.disabled = !isAvailable || !hasKilledAllRequiredEnemies;
+        });
+
+        refreshSelectPickers();
+
+        $('#map_route_publish_container')
+            .attr('data-toggle', 'tooltip')
+            .attr('title', hasKilledAllRequiredEnemies ? '' : lang.get('js.cannot_change_sharing_settings_not_all_required_enemies_killed'))
+            .refreshTooltips();
     }
 
     /**

--- a/resources/assets/js/custom/inline/common/dungeonroute/publish.js
+++ b/resources/assets/js/custom/inline/common/dungeonroute/publish.js
@@ -85,9 +85,12 @@ class CommonDungeonroutePublish extends InlineCode {
      * @private
      */
     _getKillZoneMapObjectGroup() {
-        let dungeonMap = getState().getDungeonMap();
+        // The share modal this select lives in is also rendered on pages that have no map at all
+        if (typeof getState !== 'function') {
+            return null;
+        }
 
-        return dungeonMap?.mapObjectGroupManager?.getByName(MAP_OBJECT_GROUP_KILLZONE) ?? null;
+        return getState().getDungeonMap()?.mapObjectGroupManager?.getByName(MAP_OBJECT_GROUP_KILLZONE) ?? null;
     }
 
     /**

--- a/resources/assets/js/custom/inline/common/dungeonroute/publish.js
+++ b/resources/assets/js/custom/inline/common/dungeonroute/publish.js
@@ -18,10 +18,10 @@ class CommonDungeonroutePublish extends InlineCode {
         let $select = $(this.options.publishSelector);
 
         let icons = {
-            'unpublished': 'fa-plane-arrival',
-            'team': 'fa-users',
-            'world': 'fa-globe',
-            'world_with_link': 'fa-link',
+            [PUBLISHED_STATE_UNPUBLISHED]: 'fa-plane-arrival',
+            [PUBLISHED_STATE_TEAM]: 'fa-users',
+            [PUBLISHED_STATE_WORLD]: 'fa-globe',
+            [PUBLISHED_STATE_WORLD_WITH_LINK]: 'fa-link',
         }
 
         for (let index in this.options.publishStates) {
@@ -108,7 +108,7 @@ class CommonDungeonroutePublish extends InlineCode {
         let $select = $(this.options.publishSelector);
 
         $select.find('option').each((index, option) => {
-            if (option.value === 'unpublished') {
+            if (option.value === PUBLISHED_STATE_UNPUBLISHED) {
                 return;
             }
 

--- a/resources/assets/js/custom/inline/dungeonroute/edit.js
+++ b/resources/assets/js/custom/inline/dungeonroute/edit.js
@@ -21,37 +21,8 @@ class DungeonrouteEdit extends InlineCode {
     activate() {
         super.activate();
 
-        // this._refreshRoutePublishButton();
-        // let killZoneMapObjectGroup = getState().getDungeonMap().mapObjectGroupManager.getByName(MAP_OBJECT_GROUP_KILLZONE);
-        // killZoneMapObjectGroup.register('killzone:enemyadded', this, this._refreshRoutePublishButton.bind(this));
-        // killZoneMapObjectGroup.register('killzone:enemyremoved', this, this._refreshRoutePublishButton.bind(this));
-
         if (!this.options.noUI) {
             this.settingsTabRoute.activate();
         }
-    }
-
-    // /**
-    //  *
-    //  * @private
-    //  */
-    // _refreshRoutePublishButton() {
-    //     let $mapRoutePublish = $('#map_route_publish');
-    //
-    //     // Remove disabled from the
-    //     let killZoneMapObjectGroup = getState().getDungeonMap().mapObjectGroupManager.getByName(MAP_OBJECT_GROUP_KILLZONE);
-    //     let hasKilledAllRequiredEnemies = killZoneMapObjectGroup.hasKilledAllRequiredEnemies();
-    //     $mapRoutePublish.attr('disabled', !hasKilledAllRequiredEnemies);
-    //
-    //     $('#map_route_publish_container')
-    //         .attr('data-toggle', 'tooltip')
-    //         .attr('title', hasKilledAllRequiredEnemies ? '' : lang.get('js.cannot_change_sharing_settings_not_all_required_enemies_killed'))
-    //         .refreshTooltips();
-    // }
-
-    cleanup() {
-        // let killZoneMapObjectGroup = getState().getDungeonMap().mapObjectGroupManager.getByName(MAP_OBJECT_GROUP_KILLZONE);
-        // killZoneMapObjectGroup.unregister('killzone:enemyadded', this);
-        // killZoneMapObjectGroup.unregister('killzone:enemyremoved', this);
     }
 }

--- a/resources/assets/js/custom/mapobjectgroups/killzonemapobjectgroup.js
+++ b/resources/assets/js/custom/mapobjectgroups/killzonemapobjectgroup.js
@@ -481,3 +481,9 @@ class KillZoneMapObjectGroup extends MapObjectGroup {
     //     }
     // }
 }
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {KillZoneMapObjectGroup};
+}

--- a/resources/assets/js/custom/mapobjectgroups/killzonemapobjectgroup.js
+++ b/resources/assets/js/custom/mapobjectgroups/killzonemapobjectgroup.js
@@ -383,7 +383,7 @@ class KillZoneMapObjectGroup extends MapObjectGroup {
             // If this enemy SHOULD have been killed by the user
             if (enemy.required &&
                 // If not teeming, OR if enemy is teeming AND we're teeming, or inverse that. THEN this enemy counts, otherwise it does not
-                (enemy.teeming === null || (enemy.teeming === 'visible' && mapContext.getTeeming()) || (enemy.teeming === 'invisible' && !mapContext.getTeeming()))
+                (enemy.teeming === null || (enemy.teeming === 'visible' && mapContext.getTeeming()) || (enemy.teeming === 'hidden' && !mapContext.getTeeming()))
             ) {
                 // But if it's not..
                 if (!this.isEnemyKilled(enemy.id)) {

--- a/resources/assets/js/custom/mapobjectgroups/killzonemapobjectgroup.requiredenemies.test.js
+++ b/resources/assets/js/custom/mapobjectgroups/killzonemapobjectgroup.requiredenemies.test.js
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------------
+// KillZoneMapObjectGroup.hasKilledAllRequiredEnemies() decides whether the route editor lets the user publish
+// (#3666). Its teeming branch checked `enemy.teeming === 'invisible'`, but that column only ever holds null,
+// 'visible' or 'hidden' (Enemy::TEEMING_ALL) - so an enemy that despawns on teeming keys was still demanded of a
+// teeming route, and the branch meant to excuse it was dead. These tests pin all three teeming values against both
+// route teeming settings.
+// ---------------------------------------------------------------------------
+
+const {MAP_OBJECT_GROUP_ENEMY} = require('../constants');
+globalThis.MAP_OBJECT_GROUP_ENEMY = MAP_OBJECT_GROUP_ENEMY;
+
+globalThis.MapObjectGroup = class MapObjectGroup {
+};
+
+const {KillZoneMapObjectGroup} = require('./killzonemapobjectgroup');
+
+/**
+ * A group wired up just enough to answer hasKilledAllRequiredEnemies(): the enemies that exist on the map, the
+ * kill zones that kill some of them, and the route's teeming setting.
+ *
+ * @param {Object[]} enemies
+ * @param {Number[]} killedEnemyIds
+ * @param {Boolean} teeming
+ * @returns {KillZoneMapObjectGroup}
+ */
+function buildGroup(enemies, killedEnemyIds, teeming) {
+    // Object.create bypasses the MapObjectGroup constructor chain, which wants a real map manager.
+    const group = Object.create(KillZoneMapObjectGroup.prototype);
+
+    group.objects = killedEnemyIds.length === 0 ? [] : [{enemies: killedEnemyIds, overpulledEnemies: []}];
+    group.manager = {
+        getByName: (name) => {
+            if (name !== MAP_OBJECT_GROUP_ENEMY) {
+                throw new Error(`Unexpected map object group requested: ${name}`);
+            }
+
+            return {objects: enemies};
+        },
+    };
+
+    globalThis.getState = () => ({getMapContext: () => ({getTeeming: () => teeming})});
+
+    return group;
+}
+
+const requiredEnemy = (id, teeming = null) => ({id, required: true, teeming});
+
+describe('KillZoneMapObjectGroup.hasKilledAllRequiredEnemies', () => {
+    it('returns true when there are no required enemies at all', () => {
+        const group = buildGroup([{id: 1, required: false, teeming: null}], [], false);
+
+        expect(group.hasKilledAllRequiredEnemies()).toBe(true);
+    });
+
+    it('returns false when a required enemy is not in any pull', () => {
+        const group = buildGroup([requiredEnemy(1)], [], false);
+
+        expect(group.hasKilledAllRequiredEnemies()).toBe(false);
+    });
+
+    it('returns true when every required enemy is in a pull', () => {
+        const group = buildGroup([requiredEnemy(1), requiredEnemy(2)], [1, 2], false);
+
+        expect(group.hasKilledAllRequiredEnemies()).toBe(true);
+    });
+
+    it('counts an overpulled enemy as killed', () => {
+        const group = buildGroup([requiredEnemy(1)], [], false);
+        group.objects = [{enemies: [], overpulledEnemies: [1]}];
+
+        expect(group.hasKilledAllRequiredEnemies()).toBe(true);
+    });
+
+    it('ignores a teeming-only required enemy on a non-teeming route', () => {
+        const group = buildGroup([requiredEnemy(1, 'visible')], [], false);
+
+        expect(group.hasKilledAllRequiredEnemies()).toBe(true);
+    });
+
+    it('demands a teeming-only required enemy on a teeming route', () => {
+        const group = buildGroup([requiredEnemy(1, 'visible')], [], true);
+
+        expect(group.hasKilledAllRequiredEnemies()).toBe(false);
+    });
+
+    // The regression: 'hidden' is the real column value - the old code looked for 'invisible', so this enemy was
+    // demanded of a teeming route even though it does not spawn on one.
+    it('ignores a teeming-hidden required enemy on a teeming route', () => {
+        const group = buildGroup([requiredEnemy(1, 'hidden')], [], true);
+
+        expect(group.hasKilledAllRequiredEnemies()).toBe(true);
+    });
+
+    it('demands a teeming-hidden required enemy on a non-teeming route', () => {
+        const group = buildGroup([requiredEnemy(1, 'hidden')], [], false);
+
+        expect(group.hasKilledAllRequiredEnemies()).toBe(false);
+    });
+});

--- a/resources/assets/js/custom/models/mapobject.js
+++ b/resources/assets/js/custom/models/mapobject.js
@@ -766,12 +766,12 @@ class MapObject extends Signalable {
         if (!state.isMapAdmin()) {
             if (this.hasOwnProperty('teeming')) {
                 // If the map isn't teeming, but the enemy is teeming..
-                if (!mapContext.getTeeming() && this.teeming === 'visible') {
+                if (!mapContext.getTeeming() && this.teeming === TEEMING_VISIBLE) {
                     debug ? console.log(`Hiding enemy due to teeming A ${this.id}`) : null;
                     return false;
                 }
                 // If the map is teeming, but the enemy shouldn't be there for teeming maps..
-                else if (mapContext.getTeeming() && this.teeming === 'hidden') {
+                else if (mapContext.getTeeming() && this.teeming === TEEMING_HIDDEN) {
                     debug ? console.log(`Hiding enemy due to teeming B ${this.id}`) : null;
                     return false;
                 }

--- a/resources/assets/js/custom/models/mapobject.js
+++ b/resources/assets/js/custom/models/mapobject.js
@@ -771,7 +771,7 @@ class MapObject extends Signalable {
                     return false;
                 }
                 // If the map is teeming, but the enemy shouldn't be there for teeming maps..
-                else if (mapContext.getTeeming() && this.teeming === 'invisible') {
+                else if (mapContext.getTeeming() && this.teeming === 'hidden') {
                     debug ? console.log(`Hiding enemy due to teeming B ${this.id}`) : null;
                     return false;
                 }

--- a/resources/assets/js/custom/models/mapobject.test.js
+++ b/resources/assets/js/custom/models/mapobject.test.js
@@ -13,10 +13,12 @@
 // #1389 - see the `(#1389)` describe block for the other half.
 // ---------------------------------------------------------------------------
 
-// 1a. Seasonal type constants referenced as bare globals by shouldBeVisible().
+// 1a. Seasonal type and teeming constants referenced as bare globals by shouldBeVisible().
 global.ENEMY_SEASONAL_TYPE_AWAKENED = 'awakened';
 global.ENEMY_SEASONAL_TYPE_TORMENTED = 'tormented';
 global.ENEMY_SEASONAL_TYPE_INSPIRING = 'inspiring';
+global.TEEMING_VISIBLE = 'visible';
+global.TEEMING_HIDDEN = 'hidden';
 
 // 1b. Minimal `Attribute` stub: the real one just copies its options onto itself.
 // MapObject builds three of these in _getAttributes(), which the constructor calls
@@ -102,8 +104,8 @@ function makeFakeMap({sandbox = false, bounds = null} = {}) {
             {key: 'horde', description: 'Horde'},
         ],
         teemingOptions: [
-            {key: 'visible', description: 'Visible'},
-            {key: 'hidden', description: 'Hidden'},
+            {key: TEEMING_VISIBLE, description: 'Visible'},
+            {key: TEEMING_HIDDEN, description: 'Hidden'},
         ],
     };
     map.register = () => {
@@ -186,25 +188,25 @@ describe('MapObject.shouldBeVisible - teeming filter', () => {
     it('hides a teeming-only object on a non-teeming map', () => {
         setFakeState({teeming: false});
 
-        expect(makeMapObject({teeming: 'visible'}).shouldBeVisible()).toBe(false);
+        expect(makeMapObject({teeming: TEEMING_VISIBLE}).shouldBeVisible()).toBe(false);
     });
 
     it('hides a teeming-hidden object on a teeming map', () => {
         setFakeState({teeming: true});
 
-        expect(makeMapObject({teeming: 'hidden'}).shouldBeVisible()).toBe(false);
+        expect(makeMapObject({teeming: TEEMING_HIDDEN}).shouldBeVisible()).toBe(false);
     });
 
     it('shows a teeming-only object on a teeming map', () => {
         setFakeState({teeming: true});
 
-        expect(makeMapObject({teeming: 'visible'}).shouldBeVisible()).toBe(true);
+        expect(makeMapObject({teeming: TEEMING_VISIBLE}).shouldBeVisible()).toBe(true);
     });
 
     it('shows a teeming-hidden object on a non-teeming map', () => {
         setFakeState({teeming: false});
 
-        expect(makeMapObject({teeming: 'hidden'}).shouldBeVisible()).toBe(true);
+        expect(makeMapObject({teeming: TEEMING_HIDDEN}).shouldBeVisible()).toBe(true);
     });
 
     it('shows an object without a teeming preference on either map', () => {
@@ -218,7 +220,7 @@ describe('MapObject.shouldBeVisible - teeming filter', () => {
     it('ignores the teeming filter when the map is in admin (mapping version edit) mode', () => {
         setFakeState({teeming: false, mapAdmin: true});
 
-        expect(makeMapObject({teeming: 'visible'}).shouldBeVisible()).toBe(true);
+        expect(makeMapObject({teeming: TEEMING_VISIBLE}).shouldBeVisible()).toBe(true);
     });
 });
 
@@ -337,7 +339,7 @@ describe('MapObject.shouldBeVisible - filter precedence', () => {
         // teeming/seasonal filters, never the floor the object physically sits on.
         setFakeState({currentFloorId: 2, mapAdmin: true});
 
-        expect(makeMapObject({teeming: 'visible'}).shouldBeVisible()).toBe(false);
+        expect(makeMapObject({teeming: TEEMING_VISIBLE}).shouldBeVisible()).toBe(false);
     });
 });
 

--- a/resources/assets/js/custom/models/mapobject.test.js
+++ b/resources/assets/js/custom/models/mapobject.test.js
@@ -103,7 +103,7 @@ function makeFakeMap({sandbox = false, bounds = null} = {}) {
         ],
         teemingOptions: [
             {key: 'visible', description: 'Visible'},
-            {key: 'invisible', description: 'Invisible'},
+            {key: 'hidden', description: 'Hidden'},
         ],
     };
     map.register = () => {
@@ -189,10 +189,10 @@ describe('MapObject.shouldBeVisible - teeming filter', () => {
         expect(makeMapObject({teeming: 'visible'}).shouldBeVisible()).toBe(false);
     });
 
-    it('hides a teeming-invisible object on a teeming map', () => {
+    it('hides a teeming-hidden object on a teeming map', () => {
         setFakeState({teeming: true});
 
-        expect(makeMapObject({teeming: 'invisible'}).shouldBeVisible()).toBe(false);
+        expect(makeMapObject({teeming: 'hidden'}).shouldBeVisible()).toBe(false);
     });
 
     it('shows a teeming-only object on a teeming map', () => {
@@ -201,10 +201,10 @@ describe('MapObject.shouldBeVisible - teeming filter', () => {
         expect(makeMapObject({teeming: 'visible'}).shouldBeVisible()).toBe(true);
     });
 
-    it('shows a teeming-invisible object on a non-teeming map', () => {
+    it('shows a teeming-hidden object on a non-teeming map', () => {
         setFakeState({teeming: false});
 
-        expect(makeMapObject({teeming: 'invisible'}).shouldBeVisible()).toBe(true);
+        expect(makeMapObject({teeming: 'hidden'}).shouldBeVisible()).toBe(true);
     });
 
     it('shows an object without a teeming preference on either map', () => {

--- a/tests/Feature/App/Models/DungeonRoute/DungeonRouteHasKilledAllRequiredEnemiesTest.php
+++ b/tests/Feature/App/Models/DungeonRoute/DungeonRouteHasKilledAllRequiredEnemiesTest.php
@@ -87,7 +87,7 @@ final class DungeonRouteHasKilledAllRequiredEnemiesTest extends PublicTestCase
     {
         // Arrange - this is the #3666 regression: a required enemy belonging to a *different* mapping version of the
         // same dungeon must not be held against this route. The route's own map does not even contain this enemy.
-        $route      = $this->createRouteWithOwnMappingVersion();
+        $route               = $this->createRouteWithOwnMappingVersion();
         $otherMappingVersion = $this->createMappingVersion($route);
 
         try {

--- a/tests/Feature/App/Models/DungeonRoute/DungeonRouteHasKilledAllRequiredEnemiesTest.php
+++ b/tests/Feature/App/Models/DungeonRoute/DungeonRouteHasKilledAllRequiredEnemiesTest.php
@@ -6,6 +6,7 @@ use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Enemy;
 use App\Models\KillZone\KillZone;
 use App\Models\Mapping\MappingVersion;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
@@ -164,6 +165,28 @@ final class DungeonRouteHasKilledAllRequiredEnemiesTest extends PublicTestCase
         }
     }
 
+    #[Test]
+    public function hasKilledAllRequiredEnemies_givenRouteWhoseMappingVersionWasDeleted_returnsTrue(): void
+    {
+        // Arrange - this schema carries no foreign keys and MappingVersionController::delete() can remove a mapping
+        // version routes still point at, so the relation resolves to null on a non-null id. Dereferencing it would
+        // 500 the publish endpoint and abort the whole scheduled-publish cron run.
+        $route            = $this->createRouteWithOwnMappingVersion();
+        $mappingVersionId = $route->mapping_version_id;
+
+        try {
+            MappingVersion::query()->where('id', $mappingVersionId)->delete();
+
+            // Act
+            $result = $route->fresh()->hasKilledAllRequiredEnemies();
+
+            // Assert
+            $this->assertTrue($result);
+        } finally {
+            $this->cleanup($route);
+        }
+    }
+
     /**
      * Creates a route on a mapping version of its own, so that enemies created for it cannot collide with the
      * seeded mapping data of the dungeon it happens to land on.
@@ -180,13 +203,19 @@ final class DungeonRouteHasKilledAllRequiredEnemiesTest extends PublicTestCase
     }
 
     /**
-     * A brand new, empty mapping version for the route's dungeon, based on the one the route currently points at.
+     * A brand new, genuinely *empty* mapping version for the route's dungeon.
+     *
+     * Inserted quietly, exactly as MappingService::copyMappingVersionToDungeon() does: MappingVersion's `created`
+     * hook clones the entire previous mapping into the new version, which would drag the dungeon's seeded enemies
+     * (some of them `required`) in with it and make these tests depend on whichever dungeon the factory happened to
+     * pick. It also keeps cleanup to this one table instead of every cloned child table.
      */
     private function createMappingVersion(DungeonRoute $route): MappingVersion
     {
         $current = $route->mappingVersion;
+        $now     = Carbon::now()->toDateTimeString();
 
-        return MappingVersion::create([
+        $id = MappingVersion::insertGetId([
             'game_version_id'                 => $current->game_version_id,
             'dungeon_id'                      => $route->dungeon_id,
             'version'                         => $current->version + 1,
@@ -195,7 +224,11 @@ final class DungeonRouteHasKilledAllRequiredEnemiesTest extends PublicTestCase
             'enemy_forces_shrouded'           => $current->enemy_forces_shrouded,
             'enemy_forces_shrouded_zul_gamux' => $current->enemy_forces_shrouded_zul_gamux,
             'timer_max_seconds'               => $current->timer_max_seconds,
+            'created_at'                      => $now,
+            'updated_at'                      => $now,
         ]);
+
+        return MappingVersion::findOrFail($id);
     }
 
     private function createEnemy(MappingVersion $mappingVersion, bool $required, ?string $teeming = null): Enemy

--- a/tests/Feature/App/Models/DungeonRoute/DungeonRouteHasKilledAllRequiredEnemiesTest.php
+++ b/tests/Feature/App/Models/DungeonRoute/DungeonRouteHasKilledAllRequiredEnemiesTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Tests\Feature\App\Models\DungeonRoute;
+
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\Enemy;
+use App\Models\KillZone\KillZone;
+use App\Models\Mapping\MappingVersion;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * hasKilledAllRequiredEnemies() had its entire body commented out and unconditionally returned true (#3666),
+ * because the original implementation walked $this->dungeon->enemies - a hasManyThrough over floors that is NOT
+ * scoped to a mapping version. It therefore saw the required enemies of *every* mapping version the dungeon ever
+ * had, including enemies that no longer exist on the route's own map and can never be killed by it. On the seeded
+ * data that permanently blocked publishing for 10 active dungeons, which is why the check was disabled instead of
+ * fixed. It now walks the route's own mapping version, so these tests deliberately place required enemies in a
+ * *different* mapping version of the same dungeon to prove the scoping.
+ */
+#[Group('DungeonRoute')]
+final class DungeonRouteHasKilledAllRequiredEnemiesTest extends PublicTestCase
+{
+    #[Test]
+    public function hasKilledAllRequiredEnemies_givenNoRequiredEnemiesInMappingVersion_returnsTrue(): void
+    {
+        // Arrange
+        $route = $this->createRouteWithOwnMappingVersion();
+
+        try {
+            $this->createEnemy($route->mappingVersion, required: false);
+
+            // Act
+            $result = $route->fresh()->hasKilledAllRequiredEnemies();
+
+            // Assert
+            $this->assertTrue($result);
+        } finally {
+            $this->cleanup($route);
+        }
+    }
+
+    #[Test]
+    public function hasKilledAllRequiredEnemies_givenRequiredEnemyNotKilled_returnsFalse(): void
+    {
+        // Arrange
+        $route = $this->createRouteWithOwnMappingVersion();
+
+        try {
+            $this->createEnemy($route->mappingVersion, required: true);
+
+            // Act
+            $result = $route->fresh()->hasKilledAllRequiredEnemies();
+
+            // Assert
+            $this->assertFalse($result);
+        } finally {
+            $this->cleanup($route);
+        }
+    }
+
+    #[Test]
+    public function hasKilledAllRequiredEnemies_givenRequiredEnemyKilled_returnsTrue(): void
+    {
+        // Arrange
+        $route = $this->createRouteWithOwnMappingVersion();
+
+        try {
+            $enemy = $this->createEnemy($route->mappingVersion, required: true);
+            KillZone::factory()
+                ->withEnemies($enemy)
+                ->create(['dungeon_route_id' => $route->id, 'floor_id' => $enemy->floor_id]);
+
+            // Act
+            $result = $route->fresh()->hasKilledAllRequiredEnemies();
+
+            // Assert
+            $this->assertTrue($result);
+        } finally {
+            $this->cleanup($route);
+        }
+    }
+
+    #[Test]
+    public function hasKilledAllRequiredEnemies_givenRequiredEnemyOnlyInOtherMappingVersion_returnsTrue(): void
+    {
+        // Arrange - this is the #3666 regression: a required enemy belonging to a *different* mapping version of the
+        // same dungeon must not be held against this route. The route's own map does not even contain this enemy.
+        $route      = $this->createRouteWithOwnMappingVersion();
+        $otherMappingVersion = $this->createMappingVersion($route);
+
+        try {
+            $this->createEnemy($otherMappingVersion, required: true);
+
+            // Act
+            $result = $route->fresh()->hasKilledAllRequiredEnemies();
+
+            // Assert
+            $this->assertTrue($result);
+        } finally {
+            $this->cleanup($route);
+            Enemy::query()->where('mapping_version_id', $otherMappingVersion->id)->delete();
+            MappingVersion::query()->where('id', $otherMappingVersion->id)->delete();
+        }
+    }
+
+    #[Test]
+    public function hasKilledAllRequiredEnemies_givenUnkilledTeemingOnlyRequiredEnemyOnNonTeemingRoute_returnsTrue(): void
+    {
+        // Arrange - a 'visible' enemy only spawns on teeming keys, so it cannot be required of a non-teeming route
+        $route = $this->createRouteWithOwnMappingVersion(['teeming' => false]);
+
+        try {
+            $this->createEnemy($route->mappingVersion, required: true, teeming: Enemy::TEEMING_VISIBLE);
+
+            // Act
+            $result = $route->fresh()->hasKilledAllRequiredEnemies();
+
+            // Assert
+            $this->assertTrue($result);
+        } finally {
+            $this->cleanup($route);
+        }
+    }
+
+    #[Test]
+    public function hasKilledAllRequiredEnemies_givenUnkilledTeemingOnlyRequiredEnemyOnTeemingRoute_returnsFalse(): void
+    {
+        // Arrange
+        $route = $this->createRouteWithOwnMappingVersion(['teeming' => true]);
+
+        try {
+            $this->createEnemy($route->mappingVersion, required: true, teeming: Enemy::TEEMING_VISIBLE);
+
+            // Act
+            $result = $route->fresh()->hasKilledAllRequiredEnemies();
+
+            // Assert
+            $this->assertFalse($result);
+        } finally {
+            $this->cleanup($route);
+        }
+    }
+
+    #[Test]
+    public function hasKilledAllRequiredEnemies_givenUnkilledTeemingHiddenRequiredEnemyOnTeemingRoute_returnsTrue(): void
+    {
+        // Arrange - a 'hidden' enemy is despawned on teeming keys, so it cannot be required of a teeming route.
+        // Note this is Enemy::TEEMING_HIDDEN - both the commented out PHP and the live JS checked for the string
+        // 'invisible', which is not a value this column ever holds.
+        $route = $this->createRouteWithOwnMappingVersion(['teeming' => true]);
+
+        try {
+            $this->createEnemy($route->mappingVersion, required: true, teeming: Enemy::TEEMING_HIDDEN);
+
+            // Act
+            $result = $route->fresh()->hasKilledAllRequiredEnemies();
+
+            // Assert
+            $this->assertTrue($result);
+        } finally {
+            $this->cleanup($route);
+        }
+    }
+
+    /**
+     * Creates a route on a mapping version of its own, so that enemies created for it cannot collide with the
+     * seeded mapping data of the dungeon it happens to land on.
+     *
+     * @param array<string, mixed> $overrides
+     */
+    private function createRouteWithOwnMappingVersion(array $overrides = []): DungeonRoute
+    {
+        $route = DungeonRoute::factory()->create(array_merge(['teeming' => false], $overrides));
+
+        $route->update(['mapping_version_id' => $this->createMappingVersion($route)->id]);
+
+        return $route->fresh();
+    }
+
+    /**
+     * A brand new, empty mapping version for the route's dungeon, based on the one the route currently points at.
+     */
+    private function createMappingVersion(DungeonRoute $route): MappingVersion
+    {
+        $current = $route->mappingVersion;
+
+        return MappingVersion::create([
+            'game_version_id'                 => $current->game_version_id,
+            'dungeon_id'                      => $route->dungeon_id,
+            'version'                         => $current->version + 1,
+            'enemy_forces_required'           => $current->enemy_forces_required,
+            'enemy_forces_required_teeming'   => $current->enemy_forces_required_teeming,
+            'enemy_forces_shrouded'           => $current->enemy_forces_shrouded,
+            'enemy_forces_shrouded_zul_gamux' => $current->enemy_forces_shrouded_zul_gamux,
+            'timer_max_seconds'               => $current->timer_max_seconds,
+        ]);
+    }
+
+    private function createEnemy(MappingVersion $mappingVersion, bool $required, ?string $teeming = null): Enemy
+    {
+        return Enemy::create([
+            'mapping_version_id' => $mappingVersion->id,
+            'floor_id'           => $mappingVersion->dungeon->floors->first()->id,
+            'npc_id'             => null,
+            'teeming'            => $teeming,
+            'required'           => $required,
+            'lat'                => 0,
+            'lng'                => 0,
+        ]);
+    }
+
+    /**
+     * Enemy and MappingVersion are SeederModels, whose delete() is silently refused - clean them up through the
+     * query builder instead.
+     */
+    private function cleanup(DungeonRoute $route): void
+    {
+        $mappingVersionId = $route->mapping_version_id;
+
+        $route->killZones()->each(static fn(KillZone $killZone) => $killZone->delete());
+        $route->delete();
+
+        Enemy::query()->where('mapping_version_id', $mappingVersionId)->delete();
+        MappingVersion::query()->where('id', $mappingVersionId)->delete();
+    }
+}

--- a/tests/Feature/Policy/DungeonRoutePolicyTest.php
+++ b/tests/Feature/Policy/DungeonRoutePolicyTest.php
@@ -9,6 +9,7 @@ use App\Models\Mapping\MappingVersion;
 use App\Models\PublishedState;
 use App\Models\User;
 use App\Policies\DungeonRoutePolicy;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
@@ -545,8 +546,12 @@ final class DungeonRoutePolicyTest extends PublicTestCase
     private function giveRouteAnUnkilledRequiredEnemy(DungeonRoute $route): int
     {
         $current = $route->mappingVersion;
+        $now     = Carbon::now()->toDateTimeString();
 
-        $mappingVersion = MappingVersion::create([
+        // Inserted quietly, as MappingService::copyMappingVersionToDungeon() does - MappingVersion's `created` hook
+        // clones the entire previous mapping into the new version, which would drag the dungeon's own seeded
+        // (possibly `required`) enemies in with it and make this test depend on the dungeon the factory picked.
+        $mappingVersion = MappingVersion::findOrFail(MappingVersion::insertGetId([
             'game_version_id'                 => $current->game_version_id,
             'dungeon_id'                      => $route->dungeon_id,
             'version'                         => $current->version + 1,
@@ -555,7 +560,9 @@ final class DungeonRoutePolicyTest extends PublicTestCase
             'enemy_forces_shrouded'           => $current->enemy_forces_shrouded,
             'enemy_forces_shrouded_zul_gamux' => $current->enemy_forces_shrouded_zul_gamux,
             'timer_max_seconds'               => $current->timer_max_seconds,
-        ]);
+            'created_at'                      => $now,
+            'updated_at'                      => $now,
+        ]));
 
         Enemy::create([
             'mapping_version_id' => $mappingVersion->id,

--- a/tests/Feature/Policy/DungeonRoutePolicyTest.php
+++ b/tests/Feature/Policy/DungeonRoutePolicyTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Policy;
 
 use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\Enemy;
 use App\Models\Laratrust\Role;
+use App\Models\Mapping\MappingVersion;
 use App\Models\PublishedState;
 use App\Models\User;
 use App\Policies\DungeonRoutePolicy;
@@ -217,6 +219,51 @@ final class DungeonRoutePolicyTest extends PublicTestCase
             $this->assertTrue($result->allowed());
         } finally {
             $route->delete();
+            $owner->delete();
+        }
+    }
+
+    #[Test]
+    public function publish_givenOwnerOfRouteMissingRequiredEnemies_returnsDenied(): void
+    {
+        // Arrange
+        $owner            = User::factory()->create();
+        $route            = $this->createRoute($owner);
+        $mappingVersionId = null;
+
+        try {
+            $mappingVersionId = $this->giveRouteAnUnkilledRequiredEnemy($route);
+
+            // Act
+            $result = $this->policy->publish($owner, $route->fresh(), PublishedState::WORLD);
+
+            // Assert
+            $this->assertTrue($result->denied());
+        } finally {
+            $this->cleanupRouteMappingVersion($route, $mappingVersionId);
+            $owner->delete();
+        }
+    }
+
+    #[Test]
+    public function publish_givenOwnerOfRouteMissingRequiredEnemiesUnpublishing_returnsAllowed(): void
+    {
+        // Arrange - a route may always be made *less* visible, otherwise a route that was already published when its
+        // mapping gained a required enemy would be stuck published with no way for its author to take it down.
+        $owner            = User::factory()->create();
+        $route            = $this->createRoute($owner);
+        $mappingVersionId = null;
+
+        try {
+            $mappingVersionId = $this->giveRouteAnUnkilledRequiredEnemy($route);
+
+            // Act
+            $result = $this->policy->publish($owner, $route->fresh(), PublishedState::UNPUBLISHED);
+
+            // Assert
+            $this->assertTrue($result->allowed());
+        } finally {
+            $this->cleanupRouteMappingVersion($route, $mappingVersionId);
             $owner->delete();
         }
     }
@@ -489,6 +536,56 @@ final class DungeonRoutePolicyTest extends PublicTestCase
             'expires_at'         => null,
             'published_state_id' => PublishedState::ALL[PublishedState::WORLD],
         ], $overrides));
+    }
+
+    /**
+     * Moves the route onto an empty mapping version of its own holding a single required enemy that the route does
+     * not kill, and returns that mapping version's id so the caller can clean it up.
+     */
+    private function giveRouteAnUnkilledRequiredEnemy(DungeonRoute $route): int
+    {
+        $current = $route->mappingVersion;
+
+        $mappingVersion = MappingVersion::create([
+            'game_version_id'                 => $current->game_version_id,
+            'dungeon_id'                      => $route->dungeon_id,
+            'version'                         => $current->version + 1,
+            'enemy_forces_required'           => $current->enemy_forces_required,
+            'enemy_forces_required_teeming'   => $current->enemy_forces_required_teeming,
+            'enemy_forces_shrouded'           => $current->enemy_forces_shrouded,
+            'enemy_forces_shrouded_zul_gamux' => $current->enemy_forces_shrouded_zul_gamux,
+            'timer_max_seconds'               => $current->timer_max_seconds,
+        ]);
+
+        Enemy::create([
+            'mapping_version_id' => $mappingVersion->id,
+            'floor_id'           => $mappingVersion->dungeon->floors->first()->id,
+            'npc_id'             => null,
+            'teeming'            => null,
+            'required'           => true,
+            'lat'                => 0,
+            'lng'                => 0,
+        ]);
+
+        $route->update(['mapping_version_id' => $mappingVersion->id, 'teeming' => false]);
+
+        return $mappingVersion->id;
+    }
+
+    /**
+     * Enemy and MappingVersion are SeederModels, whose delete() is silently refused - clean them up through the
+     * query builder instead.
+     */
+    private function cleanupRouteMappingVersion(DungeonRoute $route, ?int $mappingVersionId): void
+    {
+        $route->delete();
+
+        if ($mappingVersionId === null) {
+            return;
+        }
+
+        Enemy::query()->where('mapping_version_id', $mappingVersionId)->delete();
+        MappingVersion::query()->where('id', $mappingVersionId)->delete();
     }
 
     private function adminUser(): User


### PR DESCRIPTION
:robot: Closes #3666

## The bug

`DungeonRoutePolicy::publish()` guarded on `DungeonRoute::hasKilledAllRequiredEnemies()`, whose body was entirely commented out and unconditionally returned `true`. The issue offered "restore it" or "remove it" as equally fine options — but the reason it was commented out is that **restoring it as written makes routes unpublishable**, so this MR fixes the underlying bug and restores the guard.

The original implementation walked `$this->dungeon->enemies` — a `hasManyThrough` over floors that is **not scoped to a mapping version**. It therefore demanded the route kill required enemies from *every* mapping version the dungeon ever had, including enemies that are not on the route's own map and can never be pulled. Measured on the seeded data:

```
BROKEN dungeons.bfa.atal_dazar.name              all=20  current=4
BROKEN dungeons.bfa.freehold.name                all=49  current=0
BROKEN dungeons.bfa.kings_rest.name              all=104 current=28
BROKEN dungeons.bfa.siege_of_boralus.name        all=5   current=0
BROKEN dungeons.bfa.temple_of_sethraliss.name    all=41  current=8
BROKEN dungeons.bfa.the_motherlode.name          all=8   current=0
BROKEN dungeons.bfa.the_underrot.name            all=48  current=6
BROKEN dungeons.bfa.waycrest_manor.name          all=8   current=0
BROKEN dungeons.bfa.mechagon_workshop.name       all=9   current=0
BROKEN dungeons.sl.tazavesh_streets_of_wonder.name all=1 current=0
10 dungeons publish-blocked by stale required enemies, 3 have legit current required enemies, 142 clean
```

Waycrest Manor is the clearest case: 8 required enemies exist, **all** in an old mapping version, and its current mapping version has **zero** — so every Waycrest route was permanently unpublishable.

## Changes

- **Scope the check to the route's own mapping version** (`$this->mappingVersion->enemies`). This is the actual fix.
- **Fix the teeming comparison.** Both the commented-out PHP and the *live* JS tested `teeming === 'invisible'`, but the column only ever holds `null`, `'visible'` or `'hidden'` (`Enemy::TEEMING_ALL`) — the branch meant to excuse a teeming-despawned enemy was dead code, so such an enemy was wrongly demanded of teeming routes.
- **Always allow making a route *less* visible.** The `publish` gate also covers unpublishing, so the guard as-written would trap an already-published route whose mapping later gained a required enemy — its author could never take it down. The policy now takes the target state and only blocks moves *to* a published state.
- **Apply the guard to scheduled publishes**, which bypass the policy entirely (`DungeonRouteService::publishScheduledDungeonRoutes()`), following the existing skip-and-log pattern there.
- **Restore the editor UI.** Rather than disabling the whole select (which would also block unpublishing), the publish select now disables only its *publishing* options and explains why via a tooltip. This lives in `publish.js`, which owns the select and builds its options, instead of the commented-out `edit.js` code that raced option construction.
- `isEnemyKilled()` now shares one killed-enemy-id map instead of rescanning every kill zone per enemy.
- `mapping_version_id` is a nullable column; the PHPDoc claimed non-null `int`. Corrected (PHPStan stays clean, no cascade).

## Verification

- New `DungeonRouteHasKilledAllRequiredEnemiesTest` (7 tests) and 2 new policy tests; **confirmed they fail against the original `dungeon->enemies` implementation** and pass with the fix.
- New Vitest suite for the JS method (8 tests) pinning all three teeming values; **confirmed the teeming-hidden test fails with the old `'invisible'` string**.
- Full JS suite green (372 tests). PHPStan clean. Ran the check over 300 real seeded routes: 35 publishable / 1 legitimately blocked (a demo route that genuinely skips one required enemy), where before the fix every one of them returned `true` unconditionally.
- Three `--group=DungeonRoute` failures ("given inactive dungeon") are pre-existing and reproduce on a clean tree — the local seed has no inactive dungeon.

### Visual verification

Share modal with an unkilled required enemy, dropdown open. Before (master JS) — everything selectable; after — publishing options greyed out, **Unpublished still selectable**, tooltip explains why.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3666-publish-before.png) | ![after](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3666-publish-after.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rMbTdvtFZbbuPGNpohE85
