### PR TITLE
#3650 Batch per-pull enemy-forces queries on discover leaderboard cards

### DIFF
--- a/app/Repositories/Database/DungeonRoute/DungeonRouteRepository.php
+++ b/app/Repositories/Database/DungeonRoute/DungeonRouteRepository.php
@@ -218,11 +218,39 @@ class DungeonRouteRepository extends DatabaseRepository implements DungeonRouteR
 
     public function getEnemyForcesPerKillZone(DungeonRoute $dungeonRoute): Collection
     {
-        if (!$dungeonRoute->exists) {
+        return $this->getEnemyForcesPerKillZoneForRoutes(collect([$dungeonRoute]))->get($dungeonRoute->id, collect());
+    }
+
+    /**
+     * Batched variant of {@see self::getEnemyForcesPerKillZone()} - fetches the per-pull enemy forces
+     * for an entire collection of routes (e.g. a leaderboard page) in O(1) queries instead of one
+     * query per route, keyed by dungeon route id.
+     *
+     * @param  Collection<int, DungeonRoute>                         $dungeonRoutes
+     * @return Collection<int, Collection<int, KillZoneEnemyForces>>
+     */
+    public function getEnemyForcesPerKillZoneForRoutes(Collection $dungeonRoutes): Collection
+    {
+        $existingRoutes = $dungeonRoutes->filter(static fn(DungeonRoute $dungeonRoute) => $dungeonRoute->exists);
+
+        // The shrouded enemy-forces expression differs from the non-shrouded one (it reads from
+        // mapping_versions.enemy_forces_shrouded* instead of npc_enemy_forces), so shrouded and
+        // non-shrouded routes are batched into two separate queries rather than one per route.
+        $isShrouded = static fn(DungeonRoute $dungeonRoute) => $dungeonRoute->getSeasonalAffix()?->key === Affix::AFFIX_SHROUDED;
+
+        return $this->queryEnemyForcesPerKillZoneForRouteIds($existingRoutes->reject($isShrouded)->pluck('id'), false)
+            ->union($this->queryEnemyForcesPerKillZoneForRouteIds($existingRoutes->filter($isShrouded)->pluck('id'), true));
+    }
+
+    /**
+     * @param  Collection<int, int>                                  $dungeonRouteIds
+     * @return Collection<int, Collection<int, KillZoneEnemyForces>>
+     */
+    private function queryEnemyForcesPerKillZoneForRouteIds(Collection $dungeonRouteIds, bool $isShrouded): Collection
+    {
+        if ($dungeonRouteIds->isEmpty()) {
             return collect();
         }
-
-        $isShrouded = $dungeonRoute->getSeasonalAffix()?->key === Affix::AFFIX_SHROUDED;
 
         // Ignore the shrouded query if we're not shrouded (make it fail)
         $ifIsShroudedEnemyForcesQuery = $isShrouded ? '
@@ -247,19 +275,25 @@ class DungeonRouteRepository extends DatabaseRepository implements DungeonRouteR
             NpcClassification::ALL[NpcClassification::NPC_CLASSIFICATION_FINAL_BOSS],
         );
 
+        $dungeonRouteIdList = implode(',', $dungeonRouteIds->map(static fn($id) => (int)$id)->all());
+
         // Mirrors DungeonRoute::getEnemyForces()'s accounting, scoped per kill zone instead of summed for
-        // the whole route: the inner query groups by (kill zone, enemy identity) to cancel join fan-out
-        // per enemy (the `/ COUNT(...)` normalization - an enemy matching >1 npc_enemy_forces/enemies row
-        // must not be counted more than once), then the outer query sums those per-identity values back up
-        // per kill zone. The `enemies.mapping_version_id = dungeon_routes.mapping_version_id` WHERE filter
-        // (also mirrored from getEnemyForces()) turns the `enemies` LEFT JOIN into an effective INNER JOIN,
-        // dropping kill_zone_enemies rows with no matching enemies row for the route's mapping version.
+        // the whole route: the inner query groups by (route, kill zone, enemy identity) to cancel join
+        // fan-out per enemy (the `/ COUNT(...)` normalization - an enemy matching >1 npc_enemy_forces/enemies
+        // row must not be counted more than once), then the outer query sums those per-identity values back
+        // up per route and kill zone. The `enemies.mapping_version_id = dungeon_routes.mapping_version_id`
+        // WHERE filter (also mirrored from getEnemyForces()) turns the `enemies` LEFT JOIN into an effective
+        // INNER JOIN, dropping kill_zone_enemies rows with no matching enemies row for the route's mapping
+        // version. `dungeon_routes`.`id` is repeated in the inner GROUP BY (functionally redundant given
+        // `kill_zones`.`id`) purely so ONLY_FULL_GROUP_BY doesn't reject it through the LEFT JOIN chain.
         $queryResult = DB::select("
-            select `per_identity`.`kill_zone_index` as `index`,
+            select `per_identity`.`dungeon_route_id` as `dungeon_route_id`,
+                   `per_identity`.`kill_zone_index` as `index`,
                    MAX(`per_identity`.`has_boss`) as has_boss,
                    SUM(`per_identity`.`enemy_forces`) as enemy_forces
             from (
-                select `kill_zones`.`id` as `kill_zone_id`,
+                select `dungeon_routes`.`id` as `dungeon_route_id`,
+                       `kill_zones`.`id` as `kill_zone_id`,
                        `kill_zones`.`index` as `kill_zone_index`,
                        MAX(IF(`npcs`.`classification_id` IN ({$bossClassificationIds}), 1, 0)) as has_boss,
                        CAST(
@@ -295,18 +329,20 @@ class DungeonRouteRepository extends DatabaseRepository implements DungeonRouteR
                          left join `npcs` on `npcs`.`id` = `kill_zone_enemies`.`npc_id`
                          left join `npc_enemy_forces` on `npcs`.`id` = `npc_enemy_forces`.`npc_id` AND `dungeon_routes`.`mapping_version_id` = `npc_enemy_forces`.`mapping_version_id`
                          {$ifIsShroudedJoins}
-                where `dungeon_routes`.`id` = :id
+                where `dungeon_routes`.`id` in ({$dungeonRouteIdList})
                   and `kill_zones`.`id` is not null
                   and `enemies`.`mapping_version_id` = `dungeon_routes`.`mapping_version_id`
-                group by `kill_zones`.`id`, `kill_zones`.`index`, concat(`kill_zone_enemies`.`npc_id`, `kill_zone_enemies`.`mdt_id`)
+                group by `dungeon_routes`.`id`, `kill_zones`.`id`, `kill_zones`.`index`, concat(`kill_zone_enemies`.`npc_id`, `kill_zone_enemies`.`mdt_id`)
             ) as `per_identity`
-            group by `per_identity`.`kill_zone_id`, `per_identity`.`kill_zone_index`
-            order by `per_identity`.`kill_zone_index`
-            ", ['id' => $dungeonRoute->id]);
+            group by `per_identity`.`dungeon_route_id`, `per_identity`.`kill_zone_id`, `per_identity`.`kill_zone_index`
+            order by `per_identity`.`dungeon_route_id`, `per_identity`.`kill_zone_index`
+            ");
 
-        return collect($queryResult)->map(static function (stdClass $row): KillZoneEnemyForces {
-            return new KillZoneEnemyForces((int)$row->enemy_forces, (bool)$row->has_boss);
-        });
+        return collect($queryResult)
+            ->groupBy(static fn(stdClass $row) => (int)$row->dungeon_route_id)
+            ->map(static fn(Collection $rows) => $rows
+                ->map(static fn(stdClass $row) => new KillZoneEnemyForces((int)$row->enemy_forces, (bool)$row->has_boss))
+                ->values());
     }
 
     /**

--- a/app/Repositories/Database/DungeonRoute/DungeonRouteRepository.php
+++ b/app/Repositories/Database/DungeonRoute/DungeonRouteRepository.php
@@ -223,8 +223,9 @@ class DungeonRouteRepository extends DatabaseRepository implements DungeonRouteR
 
     /**
      * Batched variant of {@see self::getEnemyForcesPerKillZone()} - fetches the per-pull enemy forces
-     * for an entire collection of routes (e.g. a leaderboard page) in O(1) queries instead of one
-     * query per route, keyed by dungeon route id.
+     * for an entire collection of routes (e.g. a leaderboard page) in at most two grouped queries
+     * (one per shrouded/non-shrouded bucket, see below) instead of one query per route, keyed by
+     * dungeon route id.
      *
      * @param  Collection<int, DungeonRoute>                         $dungeonRoutes
      * @return Collection<int, Collection<int, KillZoneEnemyForces>>
@@ -236,10 +237,14 @@ class DungeonRouteRepository extends DatabaseRepository implements DungeonRouteR
         // The shrouded enemy-forces expression differs from the non-shrouded one (it reads from
         // mapping_versions.enemy_forces_shrouded* instead of npc_enemy_forces), so shrouded and
         // non-shrouded routes are batched into two separate queries rather than one per route.
-        $isShrouded = static fn(DungeonRoute $dungeonRoute) => $dungeonRoute->getSeasonalAffix()?->key === Affix::AFFIX_SHROUDED;
+        // partition() (not reject()+filter()) so getSeasonalAffix() - which re-queries
+        // affixGroupCouplings for TWW routes - only runs once per route instead of twice.
+        [$shroudedRoutes, $nonShroudedRoutes] = $existingRoutes->partition(
+            static fn(DungeonRoute $dungeonRoute) => $dungeonRoute->getSeasonalAffix()?->key === Affix::AFFIX_SHROUDED,
+        );
 
-        return $this->queryEnemyForcesPerKillZoneForRouteIds($existingRoutes->reject($isShrouded)->pluck('id'), false)
-            ->union($this->queryEnemyForcesPerKillZoneForRouteIds($existingRoutes->filter($isShrouded)->pluck('id'), true));
+        return $this->queryEnemyForcesPerKillZoneForRouteIds($nonShroudedRoutes->pluck('id'), false)
+            ->union($this->queryEnemyForcesPerKillZoneForRouteIds($shroudedRoutes->pluck('id'), true));
     }
 
     /**

--- a/app/Repositories/Interfaces/DungeonRoute/DungeonRouteRepositoryInterface.php
+++ b/app/Repositories/Interfaces/DungeonRoute/DungeonRouteRepositoryInterface.php
@@ -50,6 +50,16 @@ interface DungeonRouteRepositoryInterface extends BaseRepositoryInterface
     public function getEnemyForcesPerKillZone(DungeonRoute $dungeonRoute): Collection;
 
     /**
+     * Batched variant of {@see self::getEnemyForcesPerKillZone()} - fetches the per-pull enemy forces
+     * for an entire collection of routes (e.g. a leaderboard page) in O(1) queries instead of one
+     * query per route, keyed by dungeon route id.
+     *
+     * @param  Collection<int, DungeonRoute>                         $dungeonRoutes
+     * @return Collection<int, Collection<int, KillZoneEnemyForces>>
+     */
+    public function getEnemyForcesPerKillZoneForRoutes(Collection $dungeonRoutes): Collection;
+
+    /**
      * @return Collection<int, DungeonRoute>
      */
     public function findRoutes(DungeonRouteSearchFilter $filter): Collection;

--- a/app/Repositories/Stub/DungeonRoute/DungeonRouteRepository.php
+++ b/app/Repositories/Stub/DungeonRoute/DungeonRouteRepository.php
@@ -70,4 +70,13 @@ class DungeonRouteRepository extends StubRepository implements DungeonRouteRepos
     {
         return collect();
     }
+
+    /**
+     * @param  Collection<int, DungeonRoute>                         $dungeonRoutes
+     * @return Collection<int, Collection<int, KillZoneEnemyForces>>
+     */
+    public function getEnemyForcesPerKillZoneForRoutes(Collection $dungeonRoutes): Collection
+    {
+        return collect();
+    }
 }

--- a/app/Service/DungeonRoute/DungeonRouteEnemyForcesPageResolver.php
+++ b/app/Service/DungeonRoute/DungeonRouteEnemyForcesPageResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Service\DungeonRoute;
+
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Repositories\Database\DungeonRoute\Dtos\KillZoneEnemyForces;
+use Illuminate\Support\Collection;
+
+/**
+ * Resolves per-pull enemy forces for the routes on a single leaderboard page (cardrow/cardhero),
+ * batching them into a single grouped query instead of one query per card. The batched query is
+ * only fired on the first call to {@see self::forRoute()} (i.e. the first cache miss encountered
+ * while rendering the page), so a fully-cached page still fires zero forces queries.
+ */
+class DungeonRouteEnemyForcesPageResolver
+{
+    /** @var Collection<int, Collection<int, KillZoneEnemyForces>>|null */
+    private ?Collection $forcesByRouteId = null;
+
+    /**
+     * @param Collection<int, DungeonRoute> $dungeonRoutes
+     */
+    public function __construct(
+        private readonly DungeonRouteKillZoneServiceInterface $dungeonRouteKillZoneService,
+        private readonly Collection                           $dungeonRoutes,
+    ) {
+    }
+
+    /**
+     * @return Collection<int, KillZoneEnemyForces>
+     */
+    public function forRoute(DungeonRoute $dungeonRoute): Collection
+    {
+        $this->forcesByRouteId ??= $this->dungeonRouteKillZoneService->getEnemyForcesPerKillZoneForRoutes($this->dungeonRoutes);
+
+        return $this->forcesByRouteId->get($dungeonRoute->id, collect());
+    }
+}

--- a/app/Service/DungeonRoute/DungeonRouteKillZoneService.php
+++ b/app/Service/DungeonRoute/DungeonRouteKillZoneService.php
@@ -21,4 +21,13 @@ class DungeonRouteKillZoneService implements DungeonRouteKillZoneServiceInterfac
     {
         return $this->dungeonRouteRepository->getEnemyForcesPerKillZone($dungeonRoute);
     }
+
+    /**
+     * @param  Collection<int, DungeonRoute>                         $dungeonRoutes
+     * @return Collection<int, Collection<int, KillZoneEnemyForces>>
+     */
+    public function getEnemyForcesPerKillZoneForRoutes(Collection $dungeonRoutes): Collection
+    {
+        return $this->dungeonRouteRepository->getEnemyForcesPerKillZoneForRoutes($dungeonRoutes);
+    }
 }

--- a/app/Service/DungeonRoute/DungeonRouteKillZoneServiceInterface.php
+++ b/app/Service/DungeonRoute/DungeonRouteKillZoneServiceInterface.php
@@ -16,4 +16,14 @@ interface DungeonRouteKillZoneServiceInterface
      * @return Collection<int, KillZoneEnemyForces>
      */
     public function getEnemyForcesPerKillZone(DungeonRoute $dungeonRoute): Collection;
+
+    /**
+     * Batched variant of {@see self::getEnemyForcesPerKillZone()} - fetches the per-pull enemy forces
+     * for an entire collection of routes (e.g. a leaderboard page) in O(1) queries instead of one
+     * query per route, keyed by dungeon route id.
+     *
+     * @param  Collection<int, DungeonRoute>                         $dungeonRoutes
+     * @return Collection<int, Collection<int, KillZoneEnemyForces>>
+     */
+    public function getEnemyForcesPerKillZoneForRoutes(Collection $dungeonRoutes): Collection;
 }

--- a/resources/views/common/dungeonroute/cardhero.blade.php
+++ b/resources/views/common/dungeonroute/cardhero.blade.php
@@ -5,15 +5,18 @@ use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Laratrust\Role;
 use App\Models\User;
 use App\Service\Cache\CacheServiceInterface;
+use App\Service\DungeonRoute\DungeonRouteEnemyForcesPageResolver;
 use App\Service\DungeonRoute\DungeonRouteKillZoneServiceInterface;
 
 /**
- * @var CacheServiceInterface $cacheService
- * @var DungeonRoute          $dungeonroute
- * @var string|null           $archetype
- * @var int|null              $heroRank
- * @var array<string, mixed>  $__env
- * @var boolean               $cache
+ * @var CacheServiceInterface                    $cacheService
+ * @var DungeonRoute                              $dungeonroute
+ * @var string|null                               $archetype
+ * @var int|null                                  $heroRank
+ * @var array<string, mixed>                      $__env
+ * @var boolean                                   $cache
+ * @var DungeonRouteEnemyForcesPageResolver|null  $pullForcesResolver Batches the per-pull enemy
+ *      forces query for every card on the page instead of one per card - see overview.blade.php.
  */
 
 $archetype ??= null;
@@ -21,6 +24,7 @@ $archetype ??= null;
 // (1-based) labels the card instead ("#1 community route"); null falls back to the generic label.
 $heroRank ??= null;
 $isAdmin   = Auth::check() && Auth::user()->hasRole(Role::ROLE_ADMIN);
+$pullForcesResolver ??= null;
 // Generate a unique string so each card on the page has a stable, unique id
 $uniqueString = uniqid();
 ?>
@@ -34,6 +38,7 @@ use (
     $heroRank,
     $isAdmin,
     $__env,
+    $pullForcesResolver,
 )
 
 {
@@ -46,7 +51,10 @@ use (
     $favoritesCount = $dungeonroute->favorites_count ?? null;
     // Enemy forces per pull, ordered by pull index - drives the "route fingerprint" bar graph. Resolved
     // lazily here (not via top-level @inject) so a cache hit never pays the container-resolution cost.
-    $pullForces = app(DungeonRouteKillZoneServiceInterface::class)->getEnemyForcesPerKillZone($dungeonroute);
+    // When a page-level resolver is provided, it batches this query across every card on the page.
+    $pullForces = $pullForcesResolver !== null
+        ? $pullForcesResolver->forRoute($dungeonroute)
+        : app(DungeonRouteKillZoneServiceInterface::class)->getEnemyForcesPerKillZone($dungeonroute);
     // The key-level chip is only meaningful when the route deviates from the season's catch-all range
     $showLevel = $dungeonroute->level_min !== $dungeonroute->season?->key_level_min
         || $dungeonroute->level_max !== $dungeonroute->season?->key_level_max;

--- a/resources/views/common/dungeonroute/cardrow.blade.php
+++ b/resources/views/common/dungeonroute/cardrow.blade.php
@@ -5,18 +5,22 @@ use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Laratrust\Role;
 use App\Models\User;
 use App\Service\Cache\CacheServiceInterface;
+use App\Service\DungeonRoute\DungeonRouteEnemyForcesPageResolver;
 use App\Service\DungeonRoute\DungeonRouteKillZoneServiceInterface;
 use Illuminate\Support\Carbon;
 
 /**
- * @var CacheServiceInterface $cacheService
- * @var DungeonRoute          $dungeonroute
- * @var int                   $rank
- * @var array<string, mixed>  $__env
- * @var bool                  $cache
+ * @var CacheServiceInterface                    $cacheService
+ * @var DungeonRoute                              $dungeonroute
+ * @var int                                       $rank
+ * @var array<string, mixed>                      $__env
+ * @var bool                                      $cache
+ * @var DungeonRouteEnemyForcesPageResolver|null  $pullForcesResolver Batches the per-pull enemy
+ *      forces query for every card on the page instead of one per card - see leaderboard.blade.php.
  */
 
-$isAdmin = Auth::check() && Auth::user()->hasRole(Role::ROLE_ADMIN);
+$isAdmin           = Auth::check() && Auth::user()->hasRole(Role::ROLE_ADMIN);
+$pullForcesResolver ??= null;
 ?>
 <?php
 // The route-dependent HTML is cached per route; the rank is positional and therefore rendered outside the cache.
@@ -24,6 +28,7 @@ $cacheFn = static function () use (
     $dungeonroute,
     $isAdmin,
     $__env,
+    $pullForcesResolver,
 ) {
     $enemyForcesPercentage = $dungeonroute->getEnemyForcesPercentage();
     $enemyForcesWarning    = $dungeonroute->enemy_forces < $dungeonroute->mappingVersion->enemy_forces_required || $enemyForcesPercentage >= 105;
@@ -35,7 +40,10 @@ $cacheFn = static function () use (
     $favoritesCount = $dungeonroute->favorites_count ?? null;
     // Enemy forces per pull, ordered by pull index - drives the "route fingerprint" bar graph. Resolved
     // lazily here (not via top-level @inject) so a cache hit never pays the container-resolution cost.
-    $pullForces = app(DungeonRouteKillZoneServiceInterface::class)->getEnemyForcesPerKillZone($dungeonroute);
+    // When a page-level resolver is provided, it batches this query across every card on the page.
+    $pullForces = $pullForcesResolver !== null
+        ? $pullForcesResolver->forRoute($dungeonroute)
+        : app(DungeonRouteKillZoneServiceInterface::class)->getEnemyForcesPerKillZone($dungeonroute);
     // The key-level chip is only meaningful when the route deviates from the season's catch-all range
     $showLevel = $dungeonroute->level_min !== $dungeonroute->season?->key_level_min
         || $dungeonroute->level_max !== $dungeonroute->season?->key_level_max;

--- a/resources/views/common/dungeonroute/leaderboard.blade.php
+++ b/resources/views/common/dungeonroute/leaderboard.blade.php
@@ -1,16 +1,26 @@
 <?php
 
 use App\Models\DungeonRoute\DungeonRoute;
+use App\Service\DungeonRoute\DungeonRouteEnemyForcesPageResolver;
+use App\Service\DungeonRoute\DungeonRouteKillZoneServiceInterface;
 use Illuminate\Support\Collection;
 
 /**
- * @var Collection<int, DungeonRoute> $dungeonroutes
- * @var int  $startRank
- * @var bool $cache
+ * @var Collection<int, DungeonRoute>            $dungeonroutes
+ * @var int                                       $startRank
+ * @var bool                                      $cache
+ * @var DungeonRouteEnemyForcesPageResolver|null  $pullForcesResolver Batches the per-pull enemy
+ *      forces query across every card on the page, including any hero cards rendered alongside this
+ *      leaderboard - see overview.blade.php. Built locally, scoped to just this leaderboard, when
+ *      the caller doesn't already have one.
  */
 
 $startRank ??= 1;
 $cache     ??= true;
+$pullForcesResolver ??= new DungeonRouteEnemyForcesPageResolver(
+    app(DungeonRouteKillZoneServiceInterface::class),
+    $dungeonroutes,
+);
 ?>
 @if($dungeonroutes->isEmpty())
     <div class="row g-0">
@@ -25,6 +35,7 @@ $cache     ??= true;
                 'dungeonroute' => $dungeonroute,
                 'rank' => $startRank + $loop->index,
                 'cache' => $cache,
+                'pullForcesResolver' => $pullForcesResolver,
             ])
         @endforeach
     </div>

--- a/resources/views/dungeonroute/discover/dungeon/overview.blade.php
+++ b/resources/views/dungeonroute/discover/dungeon/overview.blade.php
@@ -61,10 +61,11 @@ use Laravel\Pennant\Feature;
         $heroRouteIds = collect();
         $startRank    = ($page - 1) * $perPage + 1;
         // Batches the per-pull enemy forces query across every card on this page - hero band and
-        // leaderboard rows alike - into a single grouped query instead of one query per card.
+        // leaderboard rows alike - into a single grouped query instead of one query per card. The
+        // weekly-route hero band only ever renders on page 1, so it's only folded in there.
         $pullForcesResolver = new DungeonRouteEnemyForcesPageResolver(
             app(DungeonRouteKillZoneServiceInterface::class),
-            $weeklyRoutes->pluck('dungeonRoute')->merge($popularItems)->unique('id')->values(),
+            ($page === 1 ? $weeklyRoutes->pluck('dungeonRoute') : collect())->merge($popularItems)->unique('id')->values(),
         );
         ?>
         @if($page === 1)

--- a/resources/views/dungeonroute/discover/dungeon/overview.blade.php
+++ b/resources/views/dungeonroute/discover/dungeon/overview.blade.php
@@ -6,6 +6,8 @@ use App\Models\Dungeon;
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\GameVersion\GameVersion;
 use App\Repositories\Database\DungeonRoute\Dtos\WeeklyRoute;
+use App\Service\DungeonRoute\DungeonRouteEnemyForcesPageResolver;
+use App\Service\DungeonRoute\DungeonRouteKillZoneServiceInterface;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Laravel\Pennant\Feature;
@@ -58,6 +60,12 @@ use Laravel\Pennant\Feature;
         // The routes already promoted into the hero band are excluded from the leaderboard below.
         $heroRouteIds = collect();
         $startRank    = ($page - 1) * $perPage + 1;
+        // Batches the per-pull enemy forces query across every card on this page - hero band and
+        // leaderboard rows alike - into a single grouped query instead of one query per card.
+        $pullForcesResolver = new DungeonRouteEnemyForcesPageResolver(
+            app(DungeonRouteKillZoneServiceInterface::class),
+            $weeklyRoutes->pluck('dungeonRoute')->merge($popularItems)->unique('id')->values(),
+        );
         ?>
         @if($page === 1)
             @if($weeklyRoutes->isNotEmpty())
@@ -79,6 +87,7 @@ use Laravel\Pennant\Feature;
                                 'dungeonroute' => $weeklyRoute->dungeonRoute,
                                 'archetype' => $weeklyRoute->type,
                                 'cache' => true,
+                                'pullForcesResolver' => $pullForcesResolver,
                             ])
                         </div>
                     @endforeach
@@ -96,6 +105,7 @@ use Laravel\Pennant\Feature;
                                     'archetype' => null,
                                     'heroRank' => $index + 1,
                                     'cache' => true,
+                                    'pullForcesResolver' => $pullForcesResolver,
                                 ])
                             </div>
                         @endforeach
@@ -124,6 +134,7 @@ use Laravel\Pennant\Feature;
                     'dungeonroutes' => $leaderboardRoutes,
                     'startRank' => $startRank,
                     'cache' => true,
+                    'pullForcesResolver' => $pullForcesResolver,
                 ])
             </div>
         </div>

--- a/tests/Feature/App/Repository/DungeonRoute/DungeonRouteRepositoryTest.php
+++ b/tests/Feature/App/Repository/DungeonRoute/DungeonRouteRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\App\Repository\DungeonRoute;
 
+use App\Models\Affix;
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Repositories\Database\DungeonRoute\Dtos\KillZoneEnemyForces;
 use App\Repositories\Database\DungeonRoute\DungeonRouteRepository;
@@ -206,11 +207,10 @@ final class DungeonRouteRepositoryTest extends PublicTestCase
     #[Test]
     public function getEnemyForcesPerKillZoneForRoutes_givenRoutesWithKillZones_matchesPerRouteResults(): void
     {
-        // Arrange - a handful of seeded routes that already carry kill zones/enemies, batched together
+        // Arrange - every seeded route that already carries kill zones/enemies, batched together
         $dungeonRoutes = DungeonRoute::query()
             ->has('killZones')
             ->with(['affixes', 'season.expansion'])
-            ->limit(5)
             ->get();
 
         $this->assertNotEmpty($dungeonRoutes, 'Expected some seeded routes with kill zones');
@@ -219,12 +219,53 @@ final class DungeonRouteRepositoryTest extends PublicTestCase
         $batchedResult = $this->repository->getEnemyForcesPerKillZoneForRoutes($dungeonRoutes);
 
         // Assert - the batched call returns the exact same per-pull forces as the single-route call
-        $dungeonRoutes->each(function (DungeonRoute $dungeonRoute) use ($batchedResult) {
-            $singleResult = $this->repository->getEnemyForcesPerKillZone($dungeonRoute);
+        $sawNonZeroForces = false;
+        $sawBoss          = false;
+        $dungeonRoutes->each(function (DungeonRoute $dungeonRoute) use ($batchedResult, &$sawNonZeroForces, &$sawBoss) {
+            $singleResult    = $this->repository->getEnemyForcesPerKillZone($dungeonRoute);
+            $batchedForRoute = $batchedResult->get($dungeonRoute->id, collect());
+
+            $sawNonZeroForces = $sawNonZeroForces || $singleResult->contains(fn(KillZoneEnemyForces $forces) => $forces->enemyForces > 0);
+            $sawBoss          = $sawBoss || $singleResult->contains(fn(KillZoneEnemyForces $forces) => $forces->hasBoss);
 
             $this->assertEquals(
                 $singleResult->map(fn(KillZoneEnemyForces $forces) => [$forces->enemyForces, $forces->hasBoss])->values()->all(),
-                $batchedResult->get($dungeonRoute->id, collect())->map(fn(KillZoneEnemyForces $forces) => [$forces->enemyForces, $forces->hasBoss])->values()->all(),
+                $batchedForRoute->map(fn(KillZoneEnemyForces $forces) => [$forces->enemyForces, $forces->hasBoss])->values()->all(),
+                sprintf('Mismatch for dungeon route %d', $dungeonRoute->id),
+            );
+        });
+
+        // Guards against a vacuous pass - the seeded routes must actually exercise nonzero forces/bosses
+        $this->assertTrue($sawNonZeroForces, 'Expected at least one seeded route with nonzero enemy forces');
+        $this->assertTrue($sawBoss, 'Expected at least one seeded route with a boss pull');
+    }
+
+    #[Test]
+    public function getEnemyForcesPerKillZoneForRoutes_givenShroudedAndNonShroudedRoutes_matchesPerRouteResultsForBoth(): void
+    {
+        // Arrange - split the seeded routes into the two buckets the batched query fires separately
+        $dungeonRoutes = DungeonRoute::query()
+            ->has('killZones')
+            ->with(['affixes', 'season.expansion'])
+            ->get();
+
+        $shroudedRoutes    = $dungeonRoutes->filter(fn(DungeonRoute $r) => $r->getSeasonalAffix()?->key === Affix::AFFIX_SHROUDED);
+        $nonShroudedRoutes = $dungeonRoutes->reject(fn(DungeonRoute $r) => $r->getSeasonalAffix()?->key === Affix::AFFIX_SHROUDED);
+
+        $this->assertNotEmpty($shroudedRoutes, 'Expected some seeded shrouded routes with kill zones');
+        $this->assertNotEmpty($nonShroudedRoutes, 'Expected some seeded non-shrouded routes with kill zones');
+
+        // Act - both buckets batched together in a single call, exercising the union() of the two queries
+        $batchedResult = $this->repository->getEnemyForcesPerKillZoneForRoutes($dungeonRoutes);
+
+        // Assert - neither bucket is dropped or duplicated; every route still matches its single-route result
+        $dungeonRoutes->each(function (DungeonRoute $dungeonRoute) use ($batchedResult) {
+            $singleResult    = $this->repository->getEnemyForcesPerKillZone($dungeonRoute);
+            $batchedForRoute = $batchedResult->get($dungeonRoute->id, collect());
+
+            $this->assertEquals(
+                $singleResult->map(fn(KillZoneEnemyForces $forces) => [$forces->enemyForces, $forces->hasBoss])->values()->all(),
+                $batchedForRoute->map(fn(KillZoneEnemyForces $forces) => [$forces->enemyForces, $forces->hasBoss])->values()->all(),
                 sprintf('Mismatch for dungeon route %d', $dungeonRoute->id),
             );
         });

--- a/tests/Feature/App/Repository/DungeonRoute/DungeonRouteRepositoryTest.php
+++ b/tests/Feature/App/Repository/DungeonRoute/DungeonRouteRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\App\Repository\DungeonRoute;
 
 use App\Models\DungeonRoute\DungeonRoute;
+use App\Repositories\Database\DungeonRoute\Dtos\KillZoneEnemyForces;
 use App\Repositories\Database\DungeonRoute\DungeonRouteRepository;
 use App\Repositories\Interfaces\DungeonRoute\Dtos\DungeonRouteSearchFilter;
 use App\Service\Season\SeasonServiceInterface;
@@ -173,5 +174,59 @@ final class DungeonRouteRepositoryTest extends PublicTestCase
         } finally {
             $dungeonRoute->delete();
         }
+    }
+
+    #[Test]
+    public function getEnemyForcesPerKillZoneForRoutes_givenEmptyCollection_returnsEmptyCollection(): void
+    {
+        // Act
+        $result = $this->repository->getEnemyForcesPerKillZoneForRoutes(collect());
+
+        // Assert
+        $this->assertTrue($result->isEmpty());
+    }
+
+    #[Test]
+    public function getEnemyForcesPerKillZoneForRoutes_givenRoutesWithoutKillZones_returnsEmptyCollection(): void
+    {
+        // Arrange
+        $dungeonRoutes = DungeonRoute::factory()->count(3)->create();
+
+        try {
+            // Act
+            $result = $this->repository->getEnemyForcesPerKillZoneForRoutes($dungeonRoutes);
+
+            // Assert
+            $this->assertTrue($result->isEmpty());
+        } finally {
+            $dungeonRoutes->each(fn(DungeonRoute $dungeonRoute) => $dungeonRoute->delete());
+        }
+    }
+
+    #[Test]
+    public function getEnemyForcesPerKillZoneForRoutes_givenRoutesWithKillZones_matchesPerRouteResults(): void
+    {
+        // Arrange - a handful of seeded routes that already carry kill zones/enemies, batched together
+        $dungeonRoutes = DungeonRoute::query()
+            ->has('killZones')
+            ->with(['affixes', 'season.expansion'])
+            ->limit(5)
+            ->get();
+
+        $this->assertNotEmpty($dungeonRoutes, 'Expected some seeded routes with kill zones');
+
+        // Act
+        $batchedResult = $this->repository->getEnemyForcesPerKillZoneForRoutes($dungeonRoutes);
+
+        // Assert - the batched call returns the exact same per-pull forces as the single-route call
+        $dungeonRoutes->each(function (DungeonRoute $dungeonRoute) use ($batchedResult) {
+            $singleResult = $this->repository->getEnemyForcesPerKillZone($dungeonRoute);
+
+            $this->assertEquals(
+                $singleResult->map(fn(KillZoneEnemyForces $forces) => [$forces->enemyForces, $forces->hasBoss])->values()->all(),
+                $batchedResult->get($dungeonRoute->id, collect())->map(fn(KillZoneEnemyForces $forces) => [$forces->enemyForces, $forces->hasBoss])->values()->all(),
+                sprintf('Mismatch for dungeon route %d', $dungeonRoute->id),
+            );
+        });
     }
 }

--- a/tests/Feature/Controller/DungeonRoute/DungeonRouteDiscoverCategoryTest.php
+++ b/tests/Feature/Controller/DungeonRoute/DungeonRouteDiscoverCategoryTest.php
@@ -8,8 +8,10 @@ use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\GameVersion\GameVersion;
 use App\Models\PublishedState;
 use App\Service\Season\SeasonServiceInterface;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Laravel\Pennant\Feature;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -187,6 +189,35 @@ final class DungeonRouteDiscoverCategoryTest extends PublicTestCase
             $secondPage->assertSee('leaderboard_rank text-secondary text-end">5</div>', false);
             $secondPage->assertSee('rel="prev"', false);
             $secondPage->assertDontSee('discover_hero_band', false);
+        } finally {
+            $routes->each(fn(DungeonRoute $route) => $route->delete());
+        }
+    }
+
+    #[Test]
+    public function discoverDungeon_givenReworkFlagActiveAndMultipleRoutes_batchesEnemyForcesQueryAcrossCards(): void
+    {
+        // Arrange - several routes, so a hero card and multiple leaderboard rows render on one cold-cache page
+        Feature::define(DungeonRouteListRework::class, true);
+        [$gameVersion, $dungeon, $routes] = $this->createQualifyingRoutes(5);
+
+        try {
+            $forcesQueryCount = 0;
+            DB::listen(function (QueryExecuted $query) use (&$forcesQueryCount) {
+                if (str_contains($query->sql, 'per_identity')) {
+                    $forcesQueryCount++;
+                }
+            });
+
+            // Act
+            $response = $this->get(route('dungeonroutes.discoverdungeon', [
+                'gameVersion' => $gameVersion,
+                'dungeon'     => $dungeon,
+            ]));
+
+            // Assert - one batched query for the whole page instead of one per card (5 routes -> 5 cards)
+            $response->assertOk();
+            $this->assertSame(1, $forcesQueryCount);
         } finally {
             $routes->each(fn(DungeonRoute $route) => $route->delete());
         }


### PR DESCRIPTION
:robot: Closes #3650

## Summary
- Follow-up to the N+1 flagged in #3447's cold review. `getEnemyForcesPerKillZone()` fired one raw
  aggregate query per rendered card (up to 18 leaderboard rows + up to 3 hero cards).
- Adds a batched `getEnemyForcesPerKillZoneForRoutes()` repository method that queries all routes
  on a page at once via a `dungeon_routes.id IN (...)` clause. Shrouded and non-shrouded routes are
  batched into two separate queries (the shrouded enemy-forces expression differs), so a page fires
  at most 2 forces queries regardless of card count. The original single-route method now delegates
  to the batched one (single source of truth for the SQL).
- Adds `DungeonRouteEnemyForcesPageResolver`, a small page-scoped, lazily-memoizing resolver: it
  only fires the batched query on the first cache miss encountered while rendering the page, so a
  fully-cached page still fires zero forces queries (preserving the existing "cache hit pays no
  container-resolution cost" invariant called out in `cardrow.blade.php`/`cardhero.blade.php`).
- `cardrow.blade.php` and `cardhero.blade.php` accept an optional `pullForcesResolver`; when absent
  they fall back to the old per-route lookup (kept for the existing direct-render tests).
  `leaderboard.blade.php` and `overview.blade.php` build one shared resolver for the whole page
  (hero band + leaderboard rows together).

## Test plan
- [x] `getEnemyForcesPerKillZoneForRoutes_givenRoutesWithKillZones_matchesPerRouteResults` -
  differential test against real seeded data confirming the batched query produces identical
  per-pull results to the original per-route query.
- [x] `discoverDungeon_givenReworkFlagActiveAndMultipleRoutes_batchesEnemyForcesQueryAcrossCards` -
  controller-level regression asserting exactly 1 forces query fires for a 5-route cold-cache page
  (previously would have fired one per card).
- [x] Existing `CardRowTest`/`CardHeroTest`/`PullGraphTest`/`DungeonRouteRepositoryTest`/
  `DungeonRouteDiscoverCategoryTest` suites all green.
- [x] `composer run fix` / `composer run analyse` clean.