### PR TITLE
#3866 Drop a team's tags when a member leaves and when the team is deleted

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Override;
 
@@ -373,8 +374,34 @@ class Team extends Model
                     $member->patreonAdFreeGiveaway->delete();
                 }
 
-                $this->dungeonRoutes()->where('team_id', $this->id)->where('author_id', $member->id)->update(['team_id' => null]);
-                $result = TeamUser::where('team_id', $this->id)->where('user_id', $member->id)->delete();
+                // Unassigning the routes and dropping their tags has to be all-or-nothing: this used
+                // to be a single UPDATE, and the catch below swallows failures, so without a
+                // transaction a throw partway through would leave the tags permanently deleted
+                // while the routes stayed on the team - a state nothing else can repair
+                $result = DB::transaction(function () use ($member): bool {
+                    // Resolve the routes before unassigning them - once team_id is nulled they can
+                    // no longer be found by this query
+                    $dungeonRouteIds = $this->dungeonRoutes()
+                        ->where('team_id', $this->id)
+                        ->where('author_id', $member->id)
+                        ->pluck('dungeon_routes.id')
+                        ->toArray();
+
+                    DungeonRoute::whereIn('id', $dungeonRouteIds)->update(['team_id' => null]);
+
+                    // A route leaving the team loses that team's tags with it, the same way
+                    // removeRoute() drops them. The update() above bypasses model events, so
+                    // nothing else cleans these up and they would be stranded on a route that is no
+                    // longer part of this team. Scoped to this team's own tags so a tag belonging
+                    // to a different team is left alone.
+                    Tag::where('tag_category_id', TagCategory::ALL[TagCategory::DUNGEON_ROUTE_TEAM])
+                        ->where('context_class', self::class)
+                        ->where('context_id', $this->id)
+                        ->whereIn('model_id', $dungeonRouteIds)
+                        ->delete();
+
+                    return (bool)TeamUser::where('team_id', $this->id)->where('user_id', $member->id)->delete();
+                });
             } catch (Exception) {
                 logger()->error('Unable to remove member from team', [
                     'team' => $this,
@@ -483,9 +510,12 @@ class Team extends Model
                     $teamMember->patreonAdFreeGiveaway->delete();
                 }
             }
-            // Delete all tags team tags belonging to our routes
+            // Delete this team's tags by context rather than by the routes it currently holds: a
+            // route that an earlier removeMember() unassigned is no longer in dungeonRoutes, so
+            // filtering on that left its tag behind pointing at a team row about to disappear
             Tag::where('tag_category_id', TagCategory::ALL[TagCategory::DUNGEON_ROUTE_TEAM])
-                ->whereIn('model_id', $team->dungeonRoutes->pluck('id')->toArray())
+                ->where('context_class', self::class)
+                ->where('context_id', $team->id)
                 ->delete();
             // Remove all users associated with this team
             TeamUser::where('team_id', $team->id)->delete();

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -26,9 +26,10 @@ class TagPolicy
         } elseif ($tag->context_class === Team::class) {
             // If we're editing a team tag, and the user is part of this team, we can edit it.
             // find() rather than findOrFail(): a team tag can outlive its team. Team::removeMember()
-            // unassigns a leaving author's routes without dropping their team tags, and the team's
-            // deleting hook only clears tags for routes still assigned to it - so context_id can
-            // dangle, and findOrFail() would 404 every caller instead of denying them.
+            // and the team's deleting hook now clean up a leaving/removed member's team tags going
+            // forward (#3866), but rows orphaned before that fix shipped can still have a
+            // context_id that dangles, and findOrFail() would 404 every caller instead of denying
+            // them.
             $result = Team::find($tag->context_id)?->isUserMember($user) ?? false;
         }
 

--- a/tests/Feature/App/Models/TeamTest.php
+++ b/tests/Feature/App/Models/TeamTest.php
@@ -137,6 +137,207 @@ final class TeamTest extends PublicTestCase
         }
     }
 
+    #[Test]
+    public function removeMember_givenTheirOwnTaggedRoute_dropsTheTeamTagWithIt(): void
+    {
+        $author = null;
+        $team   = null;
+        $route  = null;
+        $tag    = null;
+
+        try {
+            // Arrange
+            $author = User::factory()->create();
+            $team   = $this->createTeam();
+            $team->addMember($author, TeamUser::ROLE_MEMBER);
+            $route = DungeonRoute::factory()->create([
+                'author_id' => $author->id,
+                'team_id'   => $team->id,
+            ]);
+            $tag = $this->createTeamTag($team, $route);
+
+            // Act
+            $team->removeMember($author);
+
+            // Assert - the route leaves the team, and the team's tag leaves with it
+            $this->assertNull($route->fresh()->team_id);
+            $this->assertDatabaseMissing('tags', ['id' => $tag->id]);
+        } finally {
+            $this->cleanUp($tag, $route, $team, $author);
+        }
+    }
+
+    #[Test]
+    public function removeMember_givenAnotherMembersTaggedRoute_leavesThatRouteAlone(): void
+    {
+        // removeMember() only unassigns routes the leaving member authored, so the tag cleanup has
+        // to be scoped to exactly those routes rather than to everything the team holds.
+        $leaver    = null;
+        $staying   = null;
+        $team      = null;
+        $ownRoute  = null;
+        $themRoute = null;
+        $ownTag    = null;
+        $themTag   = null;
+
+        try {
+            // Arrange
+            $leaver  = User::factory()->create();
+            $staying = User::factory()->create();
+            $team    = $this->createTeam();
+            $team->addMember($leaver, TeamUser::ROLE_MEMBER);
+            $team->addMember($staying, TeamUser::ROLE_MEMBER);
+
+            $ownRoute  = DungeonRoute::factory()->create(['author_id' => $leaver->id, 'team_id' => $team->id]);
+            $themRoute = DungeonRoute::factory()->create(['author_id' => $staying->id, 'team_id' => $team->id]);
+            $ownTag    = $this->createTeamTag($team, $ownRoute);
+            $themTag   = $this->createTeamTag($team, $themRoute);
+
+            // Act
+            $team->removeMember($leaver);
+
+            // Assert
+            $this->assertDatabaseMissing('tags', ['id' => $ownTag->id]);
+            $this->assertDatabaseHas('tags', ['id' => $themTag->id]);
+            $this->assertSame($team->id, $themRoute->fresh()->team_id);
+        } finally {
+            $this->cleanUp($ownTag, $ownRoute, null, $leaver);
+            $this->cleanUp($themTag, $themRoute, $team, $staying);
+        }
+    }
+
+    #[Test]
+    public function removeMember_givenAnotherTeamsTagOnTheSameRoute_leavesItAlone(): void
+    {
+        // The delete is scoped by context_class/context_id as well as by route, so a tag left on the
+        // route by a team the route used to belong to must survive this team's cleanup. Without both
+        // where() clauses the other team's tag would be collateral.
+        $author    = null;
+        $team      = null;
+        $otherTeam = null;
+        $route     = null;
+        $ownTag    = null;
+        $otherTag  = null;
+
+        try {
+            // Arrange
+            $author    = User::factory()->create();
+            $team      = $this->createTeam();
+            $otherTeam = $this->createTeam();
+            $team->addMember($author, TeamUser::ROLE_MEMBER);
+            $route = DungeonRoute::factory()->create([
+                'author_id' => $author->id,
+                'team_id'   => $team->id,
+            ]);
+            $ownTag   = $this->createTeamTag($team, $route);
+            $otherTag = $this->createTeamTag($otherTeam, $route);
+
+            // Act
+            $team->removeMember($author);
+
+            // Assert
+            $this->assertDatabaseMissing('tags', ['id' => $ownTag->id]);
+            $this->assertDatabaseHas('tags', ['id' => $otherTag->id]);
+        } finally {
+            $this->cleanUp($otherTag, null, $otherTeam, null);
+            $this->cleanUp($ownTag, $route, $team, $author);
+        }
+    }
+
+    #[Test]
+    public function removeMember_givenAnUnassignedTagDefinition_leavesItAlone(): void
+    {
+        // The team lives on when a member leaves, so its tag definitions have to survive - only the
+        // leaving member's own tag assignments go. This is the counterpart to
+        // deleting_givenAnUnassignedTagDefinition_dropsItToo and pins the split between the two.
+        $author = null;
+        $team   = null;
+        $route  = null;
+        $tag    = null;
+        $def    = null;
+
+        try {
+            // Arrange
+            $author = User::factory()->create();
+            $team   = $this->createTeam();
+            $team->addMember($author, TeamUser::ROLE_MEMBER);
+            $route = DungeonRoute::factory()->create([
+                'author_id' => $author->id,
+                'team_id'   => $team->id,
+            ]);
+            $tag = $this->createTeamTag($team, $route);
+            $def = $this->createTeamTagDefinition($team);
+
+            // Act
+            $team->removeMember($author);
+
+            // Assert
+            $this->assertDatabaseMissing('tags', ['id' => $tag->id]);
+            $this->assertDatabaseHas('tags', ['id' => $def->id]);
+        } finally {
+            $this->cleanUp($def, null, null, null);
+            $this->cleanUp($tag, $route, $team, $author);
+        }
+    }
+
+    #[Test]
+    public function deleting_givenATagStrandedByAnEarlierRemoveMember_stillDropsIt(): void
+    {
+        // The hook used to clear tags by the routes the team currently holds. A route unassigned by
+        // removeMember() is no longer among them, so its tag survived the team's deletion with a
+        // context_id pointing at a row that no longer existed.
+        $author = null;
+        $team   = null;
+        $route  = null;
+        $tag    = null;
+
+        try {
+            // Arrange - build the stranded tag directly, so this test still pins the hook even if
+            // removeMember() ever stops cleaning up
+            $author = User::factory()->create();
+            $team   = $this->createTeam();
+            $route  = DungeonRoute::factory()->create(['author_id' => $author->id]);
+            $tag    = $this->createTeamTag($team, $route);
+
+            $this->assertCount(0, $team->dungeonRoutes()->get(), 'Arrange failed: route must not be on the team');
+
+            // Act
+            $team->delete();
+            $team = null;
+
+            // Assert
+            $this->assertDatabaseMissing('tags', ['id' => $tag->id]);
+        } finally {
+            $this->cleanUp($tag, $route, $team, $author);
+        }
+    }
+
+    #[Test]
+    public function deleting_givenAnUnassignedTagDefinition_dropsItToo(): void
+    {
+        // TeamController::createTag() stores a team's tag definitions through Tag::saveFromRequest(),
+        // which writes model_id = NULL. NULL never matches a SQL IN list, so the old
+        // whereIn('model_id', ...) hook left every definition behind - rows whose context_id pointed
+        // at a team that no longer existed. Scoping by context is what picks them up.
+        $team = null;
+        $tag  = null;
+
+        try {
+            // Arrange
+            $team = $this->createTeam();
+            $tag  = $this->createTeamTagDefinition($team);
+
+            // Act
+            $team->delete();
+            $team = null;
+
+            // Assert
+            $this->assertDatabaseMissing('tags', ['id' => $tag->id]);
+        } finally {
+            $this->cleanUp($tag, null, $team, null);
+        }
+    }
+
     private function createTeamTag(Team $team, DungeonRoute $dungeonRoute): Tag
     {
         return Tag::create([

--- a/tests/Feature/Controller/Ajax/AjaxTagControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxTagControllerTest.php
@@ -124,12 +124,17 @@ final class AjaxTagControllerTest extends PublicTestCase
     }
 
     #[Test]
-    public function delete_givenTeamTagStrandedOnOwnRouteAfterLeavingTheTeam_deletesIt(): void
+    public function delete_givenTeamTagOnOwnRouteWhileNotATeamMember_deletesIt(): void
     {
-        // Team::removeMember() unassigns a leaving author's routes but does NOT drop their team tags
-        // (unlike removeRoute(), which does), so the tag is left behind on a route the user still
-        // owns while they are no longer a member. Without the fallback to the route's own
-        // permissions the author could never clear it.
+        // Team::removeMember() now drops a leaving member's team tags atomically as part of the
+        // same transaction that unassigns their routes (see
+        // TeamTest::removeMember_givenTheirOwnTaggedRoute_dropsTheTeamTagWithIt), so a tag can no
+        // longer become stranded via "author leaves the team" the way it could when #3864 wrote
+        // this test. TagPolicy::edit()'s fallback to the route's own permissions is still needed
+        // though: it covers rows that were already orphaned before that fix shipped (see #3866),
+        // which this arranges directly - a team tag on a route whose author was
+        // never actually a member of the tag's team - to exercise the
+        // `Team::find(...)->isUserMember($user) === false` branch without relying on removeMember().
         $author = null;
         $team   = null;
         $route  = null;
@@ -139,15 +144,8 @@ final class AjaxTagControllerTest extends PublicTestCase
             // Arrange
             $author = User::factory()->create();
             $team   = $this->createTeam();
-            $team->addMember($author, TeamUser::ROLE_MEMBER);
-            $route = DungeonRoute::factory()->create([
-                'author_id' => $author->id,
-                'team_id'   => $team->id,
-            ]);
-            $tag = $this->createTeamTag($team, $route);
-
-            $team->removeMember($author);
-            $this->assertFalse($team->fresh()->isUserMember($author), 'Arrange failed: still a member');
+            $route  = DungeonRoute::factory()->create(['author_id' => $author->id]);
+            $tag    = $this->createTeamTag($team, $route);
 
             // Act
             $response = $this->actingAs($author)->delete(sprintf('/ajax/tag/%d', $tag->id));


### PR DESCRIPTION
:robot: Closes #3866

`Team::removeMember()` unassigned a leaving member's routes but left their `DUNGEON_ROUTE_TEAM` tags behind, while `Team::removeRoute()` — the other way a route leaves a team — drops them. The raw `update(['team_id' => null])` bypasses model events, so nothing downstream cleaned them up either, and the tag stayed on a route that was no longer part of the team.

The `deleting` hook had the matching gap: it cleared tags by the routes the team *currently* held, and a route unassigned by an earlier `removeMember()` is no longer among them — so its tag outlived the team row its `context_id` pointed at.

## Changes

**`removeMember()`** resolves the affected route ids *before* nulling `team_id` — once it is null the routes can no longer be found by that query — then deletes exactly those routes' tags for this team:

```php
Tag::where('tag_category_id', TagCategory::ALL[TagCategory::DUNGEON_ROUTE_TEAM])
    ->where('context_class', self::class)
    ->where('context_id', $this->id)
    ->whereIn('model_id', $dungeonRouteIds)
    ->delete();
```

Scoped to `context_id` as well as the route ids, so a tag belonging to a *different* team that the route happens to carry is left alone.

**The `deleting` hook** now clears by `context_id` rather than by current route membership, which also catches tags stranded by a `removeMember()` that happened before this fix.

## Tests

New `tests/Feature/App/Models/TeamTest.php`:

| Test | Asserts |
|---|---|
| `removeMember_givenTheirOwnTaggedRoute_dropsTheTeamTagWithIt` | route unassigned, tag gone |
| `removeMember_givenAnotherMembersTaggedRoute_leavesThatRouteAlone` | leaver's tag gone, staying member's tag and route untouched |
| `removeMember_givenAnotherTeamsTagOnTheSameRoute_leavesItAlone` | leaver's tag gone, a second team's tag on the same route untouched |
| `deleting_givenATagStrandedByAnEarlierRemoveMember_stillDropsIt` | stranded tag removed with the team |

The stranded-tag test builds the tag directly rather than by calling `removeMember()` first, so it keeps pinning the `deleting` hook even if `removeMember()`'s own cleanup is ever changed. The other-team test exists because cold review found the `context_class`/`context_id` scoping was otherwise unpinned — dropping both `where()` clauses left the rest of the suite green.

Each test fails with the change it covers reverted.

## Scope note

This does **not** make #3864's `TagPolicy::edit()` fallback redundant, and that fallback should not be reverted when this merges. It does nothing for rows already orphaned in production, which the policy fallback keeps manageable. A one-off cleanup for those is still open in #3866 as a low-urgency item.

It also does not stop *every* new orphan, which is a correction to what this PR body originally claimed. Cold review found that `User`'s deleting hook mass-deletes the account's routes (`$user->dungeonRoutes()->delete()`) **before** calling `removeMember()`, so this cleanup finds no routes to act on and account deletion still leaves tags behind — with a dangling `model_id` rather than a stale `context_id`. That is a separate and wider bug (the mass delete skips `DungeonRoute`'s whole `deleting` hook, so thumbnails, their files, and the challenge mode run are orphaned too), filed as #3869.
