### PR TITLE
#3869 Delete a user's dungeon routes one at a time so DungeonRoute::deleting fires

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -441,9 +441,18 @@ class User extends Authenticatable implements LaratrustUser
             // never runs - drop the user's stored feature values explicitly instead
             Feature::forgetAllForUser($user);
 
-            $user->dungeonRoutes()->delete();
+            // Deleted one at a time on purpose: a mass delete on the relation goes straight to the query
+            // builder and never fires DungeonRoute::deleting, which is what cleans up the route's thumbnails
+            // (and their files on disk), thumbnail jobs, challenge mode run, tags and all mapping objects
+            foreach ($user->dungeonRoutes()->get() as $dungeonRoute) {
+                $dungeonRoute->delete();
+            }
+
+            // UserReport has no deleting hook, so a mass delete is fine here
             $user->reports()->delete();
-            $user->patreonUserLink()->delete();
+
+            // Same as the dungeon routes above - PatreonUserLink::deleting drops the user's patreon benefits
+            $user->patreonUserLink()->first()?->delete();
             foreach ($user->teams as $team) {
                 // Remove ourselves from the team
                 $team->removeMember($user);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -443,8 +443,10 @@ class User extends Authenticatable implements LaratrustUser
 
             // Deleted one at a time on purpose: a mass delete on the relation goes straight to the query
             // builder and never fires DungeonRoute::deleting, which is what cleans up the route's thumbnails
-            // (and their files on disk), thumbnail jobs, challenge mode run, tags and all mapping objects
-            foreach ($user->dungeonRoutes()->get() as $dungeonRoute) {
+            // (and their files on disk), thumbnail jobs, challenge mode run, tags and all mapping objects.
+            // lazyById() rather than get() so a user at the route cap doesn't hydrate every route at once -
+            // it pages on id > lastSeen, which stays correct while the rows are being deleted underneath it
+            foreach ($user->dungeonRoutes()->lazyById() as $dungeonRoute) {
                 $dungeonRoute->delete();
             }
 

--- a/tests/Feature/App/Models/UserTest.php
+++ b/tests/Feature/App/Models/UserTest.php
@@ -2,7 +2,14 @@
 
 namespace Tests\Feature\App\Models;
 
+use App\Models\CombatLog\ChallengeModeRun;
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\DungeonRoute\DungeonRouteThumbnail;
+use App\Models\DungeonRoute\DungeonRouteThumbnailVariant;
+use App\Models\File;
 use App\Models\Laratrust\Role;
+use App\Models\Tags\Tag;
+use App\Models\Tags\TagCategory;
 use App\Models\User;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -44,6 +51,72 @@ final class UserTest extends PublicTestCase
         } finally {
             $userA->delete();
             $userB->delete();
+        }
+    }
+
+    #[Test]
+    public function delete_givenUserWithPopulatedDungeonRoute_firesTheDungeonRouteDeletingHook(): void
+    {
+        // Arrange - a route carrying the relations DungeonRoute::deleting is responsible for. A mass
+        // delete on the relation skips that hook entirely and leaves every one of these behind (#3869).
+        $user         = User::factory()->create();
+        $dungeonRoute = DungeonRoute::factory()->create(['author_id' => $user->id]);
+
+        $file = File::create([
+            'model_id'    => $dungeonRoute->id,
+            'model_class' => DungeonRoute::class,
+            'disk'        => 'local',
+            'path'        => sprintf('test/%s.png', $dungeonRoute->public_key),
+        ]);
+
+        $thumbnail = DungeonRouteThumbnail::create([
+            'dungeon_route_id' => $dungeonRoute->id,
+            'floor_id'         => $dungeonRoute->dungeon->floors->first()->id,
+            'file_id'          => $file->id,
+            'custom'           => false,
+            'variant'          => DungeonRouteThumbnailVariant::Standard,
+        ]);
+
+        $tag = Tag::create([
+            'context_id'      => $user->id,
+            'context_class'   => User::class,
+            'tag_category_id' => TagCategory::ALL[TagCategory::DUNGEON_ROUTE_PERSONAL],
+            'model_id'        => $dungeonRoute->id,
+            'model_class'     => DungeonRoute::class,
+            'name'            => 'test-tag',
+        ]);
+
+        // Lives on the combatlog connection - the hook switches connection specifically to delete it
+        $challengeModeRun = ChallengeModeRun::create([
+            'dungeon_id'       => $dungeonRoute->dungeon_id,
+            'dungeon_route_id' => $dungeonRoute->id,
+            'level'            => 10,
+            'success'          => true,
+            'total_time_ms'    => 1000,
+            'duplicate'        => false,
+        ]);
+
+        try {
+            // Act
+            $user->delete();
+
+            // Assert - the route is gone, and so is everything hanging off it
+            $this->assertDatabaseMissing('dungeon_routes', ['id' => $dungeonRoute->id]);
+            $this->assertDatabaseMissing('dungeon_route_thumbnails', ['id' => $thumbnail->id]);
+            $this->assertDatabaseMissing('files', ['id' => $file->id]);
+            $this->assertDatabaseMissing('tags', ['id' => $tag->id]);
+            $this->assertDatabaseMissing(
+                'challenge_mode_runs',
+                ['id' => $challengeModeRun->id],
+                'combatlog',
+            );
+        } finally {
+            ChallengeModeRun::query()->where('id', $challengeModeRun->id)->delete();
+            Tag::query()->where('id', $tag->id)->delete();
+            DungeonRouteThumbnail::query()->where('id', $thumbnail->id)->delete();
+            File::query()->where('id', $file->id)->delete();
+            DungeonRoute::query()->where('id', $dungeonRoute->id)->delete();
+            User::query()->where('id', $user->id)->delete();
         }
     }
 }


### PR DESCRIPTION
:robot: Closes #3869

`User::deleting` called `$user->dungeonRoutes()->delete()`. On a `HasMany` that proxies straight to the query builder, so no per-model events fire — and since `DungeonRoute` has no soft deletes the rows went out directly and `DungeonRoute::deleting` never ran. That hook is what removes the route's thumbnails (and, through `DungeonRouteThumbnail` → `File`, the stored objects), thumbnail jobs, the challenge mode run on the `combatlog` connection, tags, and every mapping object.

## Changes

- `$user->dungeonRoutes()->delete()` → a loop that deletes one route at a time, so the hook fires.
- `$user->patreonUserLink()->delete()` → same bug, two lines below: `PatreonUserLink::deleting` drops the user's patreon benefits and was being skipped. Fixed in the same way.
- `$user->reports()` left as a mass delete on purpose — `UserReport` has no `deleting` hook. Noted in a comment so it doesn't read as an oversight.

Account deletion is not a hot path, so the per-row cost is irrelevant.

## Two notes on the implementation

**Not the loop shape suggested in the issue.** The issue proposed `foreach ($user->dungeonRoutes as $dungeonRoute)`. That's a lazy collection load, and `AppServiceProvider` calls `Model::preventLazyLoading()` — so if the user was hydrated as part of a collection (an admin sweep, a bulk command) the hook would throw in dev/test and log a violation in production. Using the relation query `$user->dungeonRoutes()->get()` is an explicit fetch and can't trip it.

**The ordering concern in the issue resolves itself.** #3869 notes that routes are deleted before `$team->removeMember($user)`, so team-tag cleanup plucks zero ids and leaves tags with a dangling `model_id`. `Taggable::tags()` matches on `model_id` + `model_class` with no `context_*` scoping, so the route's own hook deletes *all* tags pointing at it, team tags included. No reorder needed.

## Test

`UserTest::delete_givenUserWithPopulatedDungeonRoute_firesTheDungeonRouteDeletingHook` builds a route carrying a thumbnail (+ its `File`), a tag and a challenge mode run, deletes the user, and asserts all four are gone — the challenge mode run asserted against the `combatlog` connection explicitly.

Verified it fails on the unfixed code: `dungeon_routes` is empty (the mass delete worked) but `dungeon_route_thumbnails` still has the row. It asserts DB rows rather than files on disk, since `File::isRemoteDiskProtectedFromLocalMutation()` means a local environment never physically deletes off a remote disk.

## Deliberately out of scope

I audited every `->relation()->delete()` call site in `app/` against the models that define `static::deleting`. Two more real occurrences exist, both with a wider blast radius than user deletion, so they're filed as **#3873** rather than widened into this diff:

- `DungeonRoute::deleting`'s own `challengeModeRun()->delete()` skips `ChallengeModeRun::deleting` and orphans `challenge_mode_run_data` on *every* route deletion — and it drags cross-connection handling along with it.
- `AjaxKillZoneController:452` skips `KillZone::deleting` (`killZoneEnemies`, `killZoneSpells`).

The cold review found a third that this audit missed, now also on #3873: `mapicons()->delete()` (`DungeonRoute.php:1493`, `MappingVersion.php:695`) skips `MapIcon`'s hook and orphans `map_object_to_awakened_obelisk_links`. `MapIcon` defines no `boot()` of its own — it inherits one from the `HasLinkedAwakenedObelisk` trait — so grepping model files for `static::deleting` doesn't surface it.

Everything else checked out: the remaining mass deletes target hook-less models, and `MappingVersion::deleting` already loops the one child that has a hook (`enemyPatrols`). #3869's stated goal — the `challenge_mode_runs` row no longer outliving the route — is met here.

## Cold review

`cold-reviewer-fable`, 2 findings, both low severity, both addressed:

1. The `MapIcon` audit gap above — added to #3873 rather than widened into this diff, consistent with how the other two sites were handled.
2. `->get()` hydrated every route at once inside a synchronous web request; a user at the cap (999 free, unlimited for patrons) made that unbounded. Switched to `lazyById()`, which pages on `id > lastSeen` and stays correct while the rows are deleted underneath the iteration.

It independently verified the `Taggable::tags()` claim above, that the test genuinely pins the bug and cleans up on both connections, and that the partial-failure risk introduced by looping is not a meaningful regression (both call sites catch, and the loop is resumable on retry).

## Interaction with #3867

#3867 (open draft) changes `Team::removeMember()`, which `User::deleting` calls. This branch is off `master` without it and its test doesn't assume that cleanup exists. Whoever merges second should re-check the combination.
