### PR TITLE
#3873 Fire deleting hooks for ChallengeModeRun, KillZone and MapIcon on mass deletes

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxKillZoneController.php
+++ b/app/Http/Controllers/Ajax/AjaxKillZoneController.php
@@ -449,7 +449,11 @@ class AjaxKillZoneController extends Controller
                 $killZones       = $dungeonRoute->killZones;
                 $pridefulEnemies = $dungeonRoute->pridefulEnemies;
 
-                $dungeonRoute->killZones()->delete();
+                // Deleted one at a time - a mass delete on the relation skips KillZone::deleting, which
+                // is what cleans up the kill zone's enemies and spells
+                foreach ($killZones as $killZone) {
+                    $killZone->delete();
+                }
                 $dungeonRoute->pridefulEnemies()->delete();
 
                 if (Auth::check()) {

--- a/app/Models/DungeonRoute/DungeonRoute.php
+++ b/app/Models/DungeonRoute/DungeonRoute.php
@@ -1481,7 +1481,9 @@ class DungeonRoute extends Model implements TracksPageViewInterface
                 'livesessions',
             ]);
 
-            $dungeonRoute->setConnection('combatlog')->challengeModeRun()->delete();
+            // A mass delete on the relation skips ChallengeModeRun::deleting, which is what cleans up
+            // challenge_mode_run_data - fetch and delete the single row instead so the hook fires
+            $dungeonRoute->setConnection('combatlog')->challengeModeRun()->first()?->delete();
             $dungeonRoute->setConnection(null);
 
             // Delete thumbnails
@@ -1523,7 +1525,11 @@ class DungeonRoute extends Model implements TracksPageViewInterface
                 $killZone->delete();
             }
 
-            $dungeonRoute->mapicons()->delete();
+            // A mass delete on the relation skips MapIcon::deleting (via HasLinkedAwakenedObelisk),
+            // which is what cleans up map_object_to_awakened_obelisk_links
+            foreach ($dungeonRoute->mapicons()->get() as $mapIcon) {
+                $mapIcon->delete();
+            }
             $dungeonRoute->pridefulEnemies()->delete();
             // External
             $dungeonRoute->ratings()->delete();

--- a/app/Models/DungeonRoute/DungeonRoute.php
+++ b/app/Models/DungeonRoute/DungeonRoute.php
@@ -1479,6 +1479,7 @@ class DungeonRoute extends Model implements TracksPageViewInterface
                 'arrows',
                 'killZones',
                 'livesessions',
+                'mapicons',
             ]);
 
             // A mass delete on the relation skips ChallengeModeRun::deleting, which is what cleans up
@@ -1527,7 +1528,7 @@ class DungeonRoute extends Model implements TracksPageViewInterface
 
             // A mass delete on the relation skips MapIcon::deleting (via HasLinkedAwakenedObelisk),
             // which is what cleans up map_object_to_awakened_obelisk_links
-            foreach ($dungeonRoute->mapicons()->get() as $mapIcon) {
+            foreach ($dungeonRoute->mapicons as $mapIcon) {
                 $mapIcon->delete();
             }
             $dungeonRoute->pridefulEnemies()->delete();

--- a/app/Models/Mapping/MappingVersion.php
+++ b/app/Models/Mapping/MappingVersion.php
@@ -692,7 +692,11 @@ class MappingVersion extends Model
                 $enemyPatrol->delete();
             }
 
-            $mappingVersion->mapIcons()->delete();
+            // A mass delete on the relation skips MapIcon::deleting (via HasLinkedAwakenedObelisk),
+            // which is what cleans up map_object_to_awakened_obelisk_links
+            foreach ($mappingVersion->mapIcons()->get() as $mapIcon) {
+                $mapIcon->delete();
+            }
             $mappingVersion->mountableAreas()->delete();
             $mappingVersion->enemyForcesCheckpoints()->delete();
             $mappingVersion->floorUnions()->delete();

--- a/app/Models/Mapping/MappingVersion.php
+++ b/app/Models/Mapping/MappingVersion.php
@@ -694,7 +694,7 @@ class MappingVersion extends Model
 
             // A mass delete on the relation skips MapIcon::deleting (via HasLinkedAwakenedObelisk),
             // which is what cleans up map_object_to_awakened_obelisk_links
-            foreach ($mappingVersion->mapIcons()->get() as $mapIcon) {
+            foreach ($mappingVersion->mapIcons as $mapIcon) {
                 $mapIcon->delete();
             }
             $mappingVersion->mountableAreas()->delete();

--- a/tests/Feature/App/Model/Mapping/MappingVersionDeletingCascadesMapIconLinkedObeliskTest.php
+++ b/tests/Feature/App/Model/Mapping/MappingVersionDeletingCascadesMapIconLinkedObeliskTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\App\Model\Mapping;
+
+use App\Models\Dungeon;
+use App\Models\MapIcon;
+use App\Models\MapIconType;
+use App\Models\MapObjectToAwakenedObeliskLink;
+use App\Models\Mapping\MappingVersion;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Guards #3873: {@see MappingVersion::boot()}'s `deleting` listener used to mass-delete its
+ * {@see MapIcon} relation via the query builder, which never fires `MapIcon::deleting` (added by
+ * the `HasLinkedAwakenedObelisk` trait) and silently orphaned any linked obelisk row.
+ */
+#[Group('MappingVersion')]
+final class MappingVersionDeletingCascadesMapIconLinkedObeliskTest extends PublicTestCase
+{
+    #[Test]
+    public function delete_givenMappingVersionWithMapIconLinkedToAnAwakenedObelisk_deletesTheLinkThroughItsOwnDeletingHook(): void
+    {
+        // Arrange
+        /** @var Dungeon $dungeon */
+        $dungeon = Dungeon::whereNotNull('challenge_mode_id')->firstOrFail();
+
+        $existingMappingVersion = $dungeon->getCurrentMappingVersion();
+
+        $mappingVersion = MappingVersion::create([
+            'game_version_id'                 => $existingMappingVersion->game_version_id,
+            'dungeon_id'                      => $dungeon->id,
+            'version'                         => $existingMappingVersion->version + 1000,
+            'enemy_forces_required'           => $existingMappingVersion->enemy_forces_required,
+            'enemy_forces_required_teeming'   => $existingMappingVersion->enemy_forces_required_teeming,
+            'enemy_forces_shrouded'           => $existingMappingVersion->enemy_forces_shrouded,
+            'enemy_forces_shrouded_zul_gamux' => $existingMappingVersion->enemy_forces_shrouded_zul_gamux,
+            'timer_max_seconds'               => $existingMappingVersion->timer_max_seconds,
+            'facade_enabled'                  => false,
+        ]);
+
+        $mapIcon = MapIcon::factory()->create([
+            'mapping_version_id' => $mappingVersion->id,
+            'dungeon_route_id'   => null,
+            'floor_id'           => $dungeon->floors->first()->id,
+            'map_icon_type_id'   => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_AWAKENED_OBELISK_ENTROPIC],
+        ]);
+
+        $link = MapObjectToAwakenedObeliskLink::create([
+            'source_map_object_id'           => $mapIcon->id,
+            'source_map_object_class_name'   => MapIcon::class,
+            'target_map_icon_type_id'        => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_AWAKENED_OBELISK_DEFILED],
+            'target_map_icon_seasonal_index' => 0,
+        ]);
+
+        try {
+            // Act
+            $mappingVersion->delete();
+
+            // Assert
+            $this->assertDatabaseMissing('map_icons', ['id' => $mapIcon->id]);
+            $this->assertDatabaseMissing('map_object_to_awakened_obelisk_links', ['id' => $link->id]);
+        } finally {
+            MapObjectToAwakenedObeliskLink::query()->where('id', $link->id)->delete();
+            MapIcon::query()->where('id', $mapIcon->id)->delete();
+            MappingVersion::query()->where('id', $mappingVersion->id)->delete();
+        }
+    }
+}

--- a/tests/Feature/App/Models/DungeonRoute/DungeonRouteDeletingCascadesMassDeleteSkippedHooksTest.php
+++ b/tests/Feature/App/Models/DungeonRoute/DungeonRouteDeletingCascadesMassDeleteSkippedHooksTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\App\Models\DungeonRoute;
+
+use App\Models\CombatLog\ChallengeModeRun;
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\MapIcon;
+use App\Models\MapIconType;
+use App\Models\MapObjectToAwakenedObeliskLink;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Guards #3873: {@see DungeonRoute::boot()}'s `deleting` listener used to mass-delete its
+ * {@see ChallengeModeRun} and {@see MapIcon} relations via the query builder, which never fires
+ * those models' own `deleting` hooks and silently orphaned their child rows.
+ */
+#[Group('DungeonRoute')]
+final class DungeonRouteDeletingCascadesMassDeleteSkippedHooksTest extends PublicTestCase
+{
+    #[Test]
+    public function delete_givenRouteWithChallengeModeRun_deletesItThroughItsOwnDeletingHook(): void
+    {
+        // Arrange
+        $dungeonRoute = DungeonRoute::factory()->create();
+
+        $challengeModeRun = ChallengeModeRun::create([
+            'dungeon_id'       => $dungeonRoute->dungeon_id,
+            'dungeon_route_id' => $dungeonRoute->id,
+            'level'            => 10,
+            'success'          => true,
+            'total_time_ms'    => 1000,
+            'duplicate'        => false,
+        ]);
+
+        try {
+            // Act
+            $dungeonRoute->delete();
+
+            // Assert
+            $this->assertDatabaseMissing(
+                'challenge_mode_runs',
+                ['id' => $challengeModeRun->id],
+                'combatlog',
+            );
+        } finally {
+            ChallengeModeRun::query()->where('id', $challengeModeRun->id)->delete();
+            DungeonRoute::query()->where('id', $dungeonRoute->id)->delete();
+        }
+    }
+
+    #[Test]
+    public function delete_givenRouteWithMapIconLinkedToAnAwakenedObelisk_deletesTheLinkThroughItsOwnDeletingHook(): void
+    {
+        // Arrange
+        $dungeonRoute = DungeonRoute::factory()->create();
+
+        $mapIcon = MapIcon::factory()->create([
+            'mapping_version_id' => null,
+            'dungeon_route_id'   => $dungeonRoute->id,
+            'floor_id'           => $dungeonRoute->dungeon->floors->first()->id,
+            'map_icon_type_id'   => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_AWAKENED_OBELISK_ENTROPIC],
+        ]);
+
+        $link = MapObjectToAwakenedObeliskLink::create([
+            'source_map_object_id'           => $mapIcon->id,
+            'source_map_object_class_name'   => MapIcon::class,
+            'target_map_icon_type_id'        => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_AWAKENED_OBELISK_DEFILED],
+            'target_map_icon_seasonal_index' => 0,
+        ]);
+
+        try {
+            // Act
+            $dungeonRoute->delete();
+
+            // Assert
+            $this->assertDatabaseMissing('map_icons', ['id' => $mapIcon->id]);
+            $this->assertDatabaseMissing('map_object_to_awakened_obelisk_links', ['id' => $link->id]);
+        } finally {
+            MapObjectToAwakenedObeliskLink::query()->where('id', $link->id)->delete();
+            MapIcon::query()->where('id', $mapIcon->id)->delete();
+            DungeonRoute::query()->where('id', $dungeonRoute->id)->delete();
+        }
+    }
+}

--- a/tests/Feature/App/Models/DungeonRoute/DungeonRouteDeletingCascadesMassDeleteSkippedHooksTest.php
+++ b/tests/Feature/App/Models/DungeonRoute/DungeonRouteDeletingCascadesMassDeleteSkippedHooksTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\App\Models\DungeonRoute;
 
 use App\Models\CombatLog\ChallengeModeRun;
+use App\Models\CombatLog\ChallengeModeRunData;
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\MapIcon;
 use App\Models\MapIconType;
@@ -34,6 +35,16 @@ final class DungeonRouteDeletingCascadesMassDeleteSkippedHooksTest extends Publi
             'duplicate'        => false,
         ]);
 
+        // ChallengeModeRun::deleting is the hook a mass delete on the relation would skip - it's
+        // responsible for cleaning this row up, so assert on it rather than on challenge_mode_runs
+        // itself (that row is deleted by the mass delete either way, hook or no hook)
+        $challengeModeRunData = ChallengeModeRunData::create([
+            'challenge_mode_run_id' => $challengeModeRun->id,
+            'run_id'                => 'test-run-id',
+            'correlation_id'        => 'test-correlation-id',
+            'processed'             => false,
+        ]);
+
         try {
             // Act
             $dungeonRoute->delete();
@@ -44,7 +55,13 @@ final class DungeonRouteDeletingCascadesMassDeleteSkippedHooksTest extends Publi
                 ['id' => $challengeModeRun->id],
                 'combatlog',
             );
+            $this->assertDatabaseMissing(
+                'challenge_mode_run_data',
+                ['id' => $challengeModeRunData->id],
+                'combatlog',
+            );
         } finally {
+            ChallengeModeRunData::query()->where('id', $challengeModeRunData->id)->delete();
             ChallengeModeRun::query()->where('id', $challengeModeRun->id)->delete();
             DungeonRoute::query()->where('id', $dungeonRoute->id)->delete();
         }

--- a/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
@@ -256,6 +256,45 @@ final class AjaxKillZoneControllerTest extends DungeonRouteTestBase
     }
 
     /**
+     * Guards #3873: deleteAll() used to mass-delete the killZones relation via the query builder,
+     * which never fires {@see KillZone::deleting} and silently orphaned its killZoneEnemies rows.
+     */
+    #[Test]
+    public function deleteAll_givenKillZoneWithEnemies_deletesItThroughItsOwnDeletingHook(): void
+    {
+        // Arrange
+        /** @var Enemy $enemy */
+        $enemy    = Enemy::where('mapping_version_id', $this->dungeonRoute->mapping_version_id)->inRandomOrder()->first();
+        $killZone = KillZone::factory()->create([
+            'dungeon_route_id' => $this->dungeonRoute->id,
+            'floor_id'         => null,
+            'lat'              => null,
+            'lng'              => null,
+            'color'            => '#000000',
+            'index'            => 1,
+        ]);
+        $killZoneEnemy = KillZoneEnemy::create([
+            'kill_zone_id' => $killZone->id,
+            'enemy_id'     => $enemy->id,
+        ]);
+
+        try {
+            // Act
+            $response = $this->delete(sprintf('/ajax/%s/killzone', $this->dungeonRoute->public_key), [
+                'confirm' => 'yes',
+            ]);
+
+            // Assert
+            $response->assertOk();
+            $this->assertDatabaseMissing('kill_zones', ['id' => $killZone->id]);
+            $this->assertDatabaseMissing('kill_zone_enemies', ['id' => $killZoneEnemy->id]);
+        } finally {
+            KillZoneEnemy::query()->where('id', $killZoneEnemy->id)->delete();
+            KillZone::query()->where('id', $killZone->id)->delete();
+        }
+    }
+
+    /**
      * A published, non-sandbox route authored by user 1. Sandbox routes (expires_at set, which the
      * factory does by default) are editable by anyone by design, so expires_at must be null for an
      * authorization assertion to mean anything.


### PR DESCRIPTION
Closes #3873

:robot: Follow-up to #3869/#3872, confirmed-sites audit. `$model->relation()->delete()` proxies to the query builder, so it never fires the target model's own `deleting` hook. Fixed the three confirmed sites:

- `DungeonRoute::boot()`'s `deleting` listener: `challengeModeRun()->delete()` → `->first()?->delete()`, so `ChallengeModeRun::deleting` (cleans up `challenge_mode_run_data`) fires on every route deletion, not just user deletion.
- `DungeonRoute::boot()`'s `deleting` listener and `MappingVersion::boot()`'s `deleting` listener: `mapicons()->delete()` / `mapIcons()->delete()` → loop over `->get()`, so `MapIcon::deleting` (added by the `HasLinkedAwakenedObelisk` trait, cleans up `map_object_to_awakened_obelisk_links`) fires.
- `AjaxKillZoneController::deleteAll()`: `killZones()->delete()` → loop over the already-fetched `$killZones` collection, so `KillZone::deleting` (cleans up `killZoneEnemies`/`killZoneSpells`) fires.

`pridefulEnemies`/`enemyPatrols`/etc. were left as-is — confirmed in the issue's audit as targeting models with no `deleting` hook.

## Test plan
- [x] New tests assert the previously-orphaned child rows are gone after each cascade
- [x] `composer run fix` / `composer run analyse` clean
- [x] `php artisan test --group=DungeonRoute --group=KillZone --group=MappingVersion` green (3 pre-existing unrelated failures confirmed present on master too)