### PR TITLE
#3875 Scope Team::getAvailableTags() by owning team context

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -454,6 +454,8 @@ class Team extends Model
     public function getAvailableTags(): EloquentCollection
     {
         return Tag::where('tag_category_id', TagCategory::ALL[TagCategory::DUNGEON_ROUTE_TEAM])
+            ->where('context_class', self::class)
+            ->where('context_id', $this->id)
             ->whereIn('model_id', $this->dungeonRoutes->pluck('id'))
             ->get();
     }

--- a/tests/Feature/App/Models/TeamTest.php
+++ b/tests/Feature/App/Models/TeamTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature\App\Models;
+
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\Tags\Tag;
+use App\Models\Tags\TagCategory;
+use App\Models\Team;
+use App\Models\TeamUser;
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Team')]
+final class TeamTest extends PublicTestCase
+{
+    #[Test]
+    public function getAvailableTags_givenOwnTeamsTaggedRoute_returnsTheTag(): void
+    {
+        $author = null;
+        $team   = null;
+        $route  = null;
+        $tag    = null;
+
+        try {
+            // Arrange
+            $author = User::factory()->create();
+            $team   = $this->createTeam();
+            $team->addMember($author, TeamUser::ROLE_MEMBER);
+            $route = DungeonRoute::factory()->create([
+                'author_id' => $author->id,
+                'team_id'   => $team->id,
+            ]);
+            $tag = $this->createTeamTag($team, $route);
+
+            // Act
+            $availableTags = $team->getAvailableTags();
+
+            // Assert
+            $this->assertTrue($availableTags->contains('id', $tag->id));
+        } finally {
+            $this->cleanUp($tag, $route, $team, $author);
+        }
+    }
+
+    #[Test]
+    public function getAvailableTags_givenAnotherTeamsTagOnASharedRoute_excludesIt(): void
+    {
+        // A route can move between teams (or be re-tagged) while an old tag from a previous team
+        // still points at it. getAvailableTags() must not surface that other team's tag as if it
+        // were this team's own.
+        $author    = null;
+        $team      = null;
+        $otherTeam = null;
+        $route     = null;
+        $ownTag    = null;
+        $otherTag  = null;
+
+        try {
+            // Arrange
+            $author    = User::factory()->create();
+            $team      = $this->createTeam();
+            $otherTeam = $this->createTeam();
+            $team->addMember($author, TeamUser::ROLE_MEMBER);
+            $route = DungeonRoute::factory()->create([
+                'author_id' => $author->id,
+                'team_id'   => $team->id,
+            ]);
+            $ownTag   = $this->createTeamTag($team, $route);
+            $otherTag = $this->createTeamTag($otherTeam, $route);
+
+            // Act
+            $availableTags = $team->getAvailableTags();
+
+            // Assert
+            $this->assertTrue($availableTags->contains('id', $ownTag->id));
+            $this->assertFalse($availableTags->contains('id', $otherTag->id));
+        } finally {
+            $this->cleanUp($otherTag, null, $otherTeam, null);
+            $this->cleanUp($ownTag, $route, $team, $author);
+        }
+    }
+
+    private function createTeamTag(Team $team, DungeonRoute $dungeonRoute): Tag
+    {
+        return Tag::create([
+            'context_id'      => $team->id,
+            'context_class'   => Team::class,
+            'tag_category_id' => TagCategory::ALL[TagCategory::DUNGEON_ROUTE_TEAM],
+            'model_id'        => $dungeonRoute->id,
+            'model_class'     => DungeonRoute::class,
+            'name'            => sprintf('test-team-tag-%s', fake()->uuid()),
+            'color'           => null,
+        ]);
+    }
+
+    private function createTeam(): Team
+    {
+        return Team::create([
+            'public_key'   => fake()->unique()->uuid(),
+            'name'         => sprintf('test-team-%s', fake()->uuid()),
+            'description'  => 'Created by TeamTest',
+            'invite_code'  => fake()->unique()->uuid(),
+            'default_role' => TeamUser::ROLE_MEMBER,
+        ]);
+    }
+
+    private function cleanUp(?Tag $tag, ?DungeonRoute $route, ?Team $team, ?User $user): void
+    {
+        if ($tag !== null) {
+            Tag::where('id', $tag->id)->delete();
+        }
+
+        if ($route !== null) {
+            DungeonRoute::where('id', $route->id)->delete();
+        }
+
+        if ($team !== null) {
+            TeamUser::where('team_id', $team->id)->delete();
+            Team::where('id', $team->id)->delete();
+        }
+
+        $user?->delete();
+    }
+}


### PR DESCRIPTION
:robot: Closes #3875

`Team::getAvailableTags()` filtered tags only by `model_id` (the tagged `DungeonRoute`), not by the tag's owning-team context (`context_class`/`context_id`). If a route is shared by or moves between teams, another team's `DUNGEON_ROUTE_TEAM` tag on that same route would leak into this team's available list.

Fixes it the same way #3867 fixed the sibling `boot()`/`removeMember()` call sites: also scope by `context_class = Team::class` and `context_id = $this->id`.

## Test plan
- [x] New `TeamTest::getAvailableTags_givenOwnTeamsTaggedRoute_returnsTheTag`
- [x] New `TeamTest::getAvailableTags_givenAnotherTeamsTagOnASharedRoute_excludesIt`
- [x] `composer run fix` / `composer run analyse` clean

## Cold review
1 finding — pre-existing gap where `whereIn('model_id', ...)` never matches tag *definitions* (`model_id IS NULL`), unrelated to this fix's `context_class`/`context_id` scoping. Filed as follow-up #3881 rather than fixed here.
