### PR TITLE
#3881 Include unassigned tag definitions in Team::getAvailableTags()

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -11,6 +11,7 @@ use App\Models\Traits\HasTags;
 use App\Service\Cache\CacheServiceInterface;
 use Eloquent;
 use Exception;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -447,7 +448,8 @@ class Team extends Model
     }
 
     /**
-     * Gets all tags available for routes in this team.
+     * Gets all tags available for routes in this team, including tag definitions not yet applied
+     * to any route.
      *
      * @return EloquentCollection<int, Tag>
      */
@@ -456,7 +458,10 @@ class Team extends Model
         return Tag::where('tag_category_id', TagCategory::ALL[TagCategory::DUNGEON_ROUTE_TEAM])
             ->where('context_class', self::class)
             ->where('context_id', $this->id)
-            ->whereIn('model_id', $this->dungeonRoutes->pluck('id'))
+            ->where(function (Builder $query) {
+                $query->whereNull('model_id')
+                    ->orWhereIn('model_id', $this->dungeonRoutes->pluck('id'));
+            })
             ->get();
     }
 

--- a/tests/Feature/App/Models/TeamTest.php
+++ b/tests/Feature/App/Models/TeamTest.php
@@ -109,24 +109,31 @@ final class TeamTest extends PublicTestCase
     #[Test]
     public function getAvailableTags_givenAnotherTeamsUnassignedTagDefinition_excludesIt(): void
     {
+        // A team with no routes/tags of its own would make the negative assertion below pass
+        // vacuously (and wouldn't catch the whereNull()/orWhereIn() clause escaping its enclosing
+        // where() and collapsing the entire query into a no-op OR), so this team also gets its own
+        // definition to prove getAvailableTags() is actually finding *something*.
         $team      = null;
         $otherTeam = null;
+        $ownDef    = null;
         $otherDef  = null;
 
         try {
             // Arrange
             $team      = $this->createTeam();
             $otherTeam = $this->createTeam();
+            $ownDef    = $this->createTeamTagDefinition($team);
             $otherDef  = $this->createTeamTagDefinition($otherTeam);
 
             // Act
             $availableTags = $team->getAvailableTags();
 
             // Assert
+            $this->assertTrue($availableTags->contains('id', $ownDef->id));
             $this->assertFalse($availableTags->contains('id', $otherDef->id));
         } finally {
             $this->cleanUp($otherDef, null, $otherTeam, null);
-            $this->cleanUp(null, null, $team, null);
+            $this->cleanUp($ownDef, null, $team, null);
         }
     }
 

--- a/tests/Feature/App/Models/TeamTest.php
+++ b/tests/Feature/App/Models/TeamTest.php
@@ -82,6 +82,54 @@ final class TeamTest extends PublicTestCase
         }
     }
 
+    #[Test]
+    public function getAvailableTags_givenOwnTeamsUnassignedTagDefinition_returnsIt(): void
+    {
+        // TeamController::createTag() stores a team's tag definitions through Tag::saveFromRequest(),
+        // which writes model_id = NULL. A plain whereIn('model_id', ...) never matches NULL, so a
+        // tag definition never applied to a route would otherwise never show up in the autocomplete.
+        $team = null;
+        $def  = null;
+
+        try {
+            // Arrange
+            $team = $this->createTeam();
+            $def  = $this->createTeamTagDefinition($team);
+
+            // Act
+            $availableTags = $team->getAvailableTags();
+
+            // Assert
+            $this->assertTrue($availableTags->contains('id', $def->id));
+        } finally {
+            $this->cleanUp($def, null, $team, null);
+        }
+    }
+
+    #[Test]
+    public function getAvailableTags_givenAnotherTeamsUnassignedTagDefinition_excludesIt(): void
+    {
+        $team      = null;
+        $otherTeam = null;
+        $otherDef  = null;
+
+        try {
+            // Arrange
+            $team      = $this->createTeam();
+            $otherTeam = $this->createTeam();
+            $otherDef  = $this->createTeamTagDefinition($otherTeam);
+
+            // Act
+            $availableTags = $team->getAvailableTags();
+
+            // Assert
+            $this->assertFalse($availableTags->contains('id', $otherDef->id));
+        } finally {
+            $this->cleanUp($otherDef, null, $otherTeam, null);
+            $this->cleanUp(null, null, $team, null);
+        }
+    }
+
     private function createTeamTag(Team $team, DungeonRoute $dungeonRoute): Tag
     {
         return Tag::create([
@@ -91,6 +139,23 @@ final class TeamTest extends PublicTestCase
             'model_id'        => $dungeonRoute->id,
             'model_class'     => DungeonRoute::class,
             'name'            => sprintf('test-team-tag-%s', fake()->uuid()),
+            'color'           => null,
+        ]);
+    }
+
+    /**
+     * A tag definition as TeamController::createTag() stores it: owned by the team, not yet applied
+     * to any route, so model_id/model_class are NULL.
+     */
+    private function createTeamTagDefinition(Team $team): Tag
+    {
+        return Tag::create([
+            'context_id'      => $team->id,
+            'context_class'   => Team::class,
+            'tag_category_id' => TagCategory::ALL[TagCategory::DUNGEON_ROUTE_TEAM],
+            'model_id'        => null,
+            'model_class'     => null,
+            'name'            => sprintf('test-team-tag-def-%s', fake()->uuid()),
             'color'           => null,
         ]);
     }


### PR DESCRIPTION
:robot: Closes #3881

Stacked on #3880 — targets `master` per the stacked-PR convention (so CI actually runs), diff collapses to just this change once #3880 merges.

`Team::createTag()` (`Tag::saveFromRequest()`) stores a tag definition with `model_id = NULL` before it's ever applied to a route. `Team::getAvailableTags()` filtered with `whereIn('model_id', ...)`, and SQL's `IN (...)` never matches `NULL`, so a tag definition never showed up in the team's tag autocomplete (`resources/views/common/dungeonroute/table.blade.php`) until it happened to already be on a route — defeating the point of creating it standalone.

Now that #3880 scopes the query by `context_class`/`context_id`, it's safe to also include `model_id IS NULL` rows without reintroducing the cross-team leak #3875 fixed.

## Test plan
- [x] New `TeamTest::getAvailableTags_givenOwnTeamsUnassignedTagDefinition_returnsIt`
- [x] New `TeamTest::getAvailableTags_givenAnotherTeamsUnassignedTagDefinition_excludesIt`
- [x] `composer run fix` / `composer run analyse` clean