### PR TITLE
Authorize team tag creation against TeamPolicy

### DIFF
--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -223,9 +223,13 @@ class TeamController extends Controller
 
     /**
      * Creates a tag from the tag manager
+     *
+     * @throws AuthorizationException
      */
     public function createTag(TagFormRequest $request, Team $team): RedirectResponse
     {
+        Gate::authorize('edit', $team);
+
         $error = [];
 
         $tagCategoryId = TagCategory::ALL[TagCategory::DUNGEON_ROUTE_TEAM];

--- a/tests/Feature/Controller/Team/TeamControllerTest.php
+++ b/tests/Feature/Controller/Team/TeamControllerTest.php
@@ -2,9 +2,13 @@
 
 namespace Tests\Feature\Controller\Team;
 
+use App\Models\Laratrust\Role;
+use App\Models\Tags\Tag;
+use App\Models\Tags\TagCategory;
 use App\Models\Team;
 use App\Models\TeamUser;
 use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -117,5 +121,75 @@ final class TeamControllerTest extends PublicTestCase
         // Assert
         $response->assertRedirect(route('team.edit', $this->team));
         $response->assertStatus(301);
+    }
+
+    #[Test]
+    public function createTag_givenTeamMember_createsTheTag(): void
+    {
+        $tagName = sprintf('test-team-tag-%s', fake()->uuid());
+
+        try {
+            // Act
+            $response = $this->post(route('team.tag.create', $this->team), ['tag_name_new' => $tagName]);
+
+            // Assert
+            $response->assertRedirect();
+            $this->assertDatabaseHas('tags', [
+                'context_id'      => $this->team->id,
+                'context_class'   => Team::class,
+                'tag_category_id' => TagCategory::ALL[TagCategory::DUNGEON_ROUTE_TEAM],
+                'name'            => $tagName,
+            ]);
+        } finally {
+            Tag::where('name', $tagName)->delete();
+        }
+    }
+
+    #[Test]
+    public function createTag_givenNonMember_returnsForbidden(): void
+    {
+        // The tag manager posts to a team resolved from the URL by its public key. Nothing else in
+        // this method looks at who is asking, so without the gate any authenticated user who knows
+        // a team's public key can add a tag definition to that team's tag manager.
+        $outsider = null;
+        $tagName  = sprintf('test-team-tag-%s', fake()->uuid());
+
+        try {
+            // Arrange - the route group is behind 'role:user|admin', so a roleless factory user
+            // would be rejected by that middleware and never reach the gate under test
+            $outsider = User::factory()->create();
+            $outsider->addRole(Role::ROLE_USER);
+
+            // Act
+            $response = $this->actingAs($outsider)
+                ->post(route('team.tag.create', $this->team), ['tag_name_new' => $tagName]);
+
+            // Assert
+            $response->assertForbidden();
+            $this->assertDatabaseMissing('tags', ['name' => $tagName]);
+        } finally {
+            Tag::where('name', $tagName)->delete();
+            $outsider?->delete();
+        }
+    }
+
+    #[Test]
+    public function createTag_givenGuest_redirectsToLogin(): void
+    {
+        $tagName = sprintf('test-team-tag-%s', fake()->uuid());
+
+        try {
+            // Arrange - setUp() logs in as user 1, so undo that to actually be a guest
+            Auth::logout();
+
+            // Act
+            $response = $this->post(route('team.tag.create', $this->team), ['tag_name_new' => $tagName]);
+
+            // Assert
+            $response->assertRedirect(route('login'));
+            $this->assertDatabaseMissing('tags', ['name' => $tagName]);
+        } finally {
+            Tag::where('name', $tagName)->delete();
+        }
     }
 }


### PR DESCRIPTION
:robot: `TeamController::createTag()` was the only write method in the class that did not consult `TeamPolicy` before acting on the route-bound `$team`. Its siblings do:

- `edit()` — `Gate::authorize('edit', $team)`
- `update()` — `Gate::authorize('edit', $team)`
- `delete()` — `Gate::authorize('delete', $team)`
- `createTag()` — nothing

`TagFormRequest::authorize()` returns `true`, so the form request was not carrying the check either. Nothing in the method body looks at who is asking — the team comes from the URL, and `Tag::saveFromRequest()` writes a `DUNGEON_ROUTE_TEAM` tag definition (`model_id = NULL`) scoped to `context_id = $team->id`.

This adds the missing `Gate::authorize('edit', $team)`, matching `update()`. `TeamPolicy::edit()` already existed and is `$team->isUserMember($user)`, so no policy changes were needed — the ability was simply never invoked from this route.

## Reach

The route sits behind `auth` + `role:user|admin`, so this was never guest-reachable. What it allowed was any *logged-in* user who knows a team's public key to add a tag definition to that team's tag manager. `Team::resolveRouteBinding()` matches on `public_key`, which is not enumerable, so this is low severity rather than open season — but membership is the intended boundary and it was not being enforced.

No behaviour change for legitimate use: the tag manager only renders on `team.edit`, which already gates on the same ability, so every real caller is a member and passes.

## Tests

Three tests added to `tests/Feature/Controller/Team/TeamControllerTest.php`:

| Test | Asserts |
|---|---|
| `createTag_givenTeamMember_createsTheTag` | redirect, tag row written for the team |
| `createTag_givenNonMember_returnsForbidden` | 403, no tag row |
| `createTag_givenGuest_redirectsToLogin` | redirect to login, no tag row |

Verified the tests actually pin the fix: with the `Gate::authorize` line reverted, `createTag_givenNonMember_returnsForbidden` fails (302 instead of 403) and the other two still pass.

One trap worth recording — the non-member test initially passed **with the gate reverted**, because a plain `User::factory()->create()` carries no role and the `role:user|admin` middleware 403s it before the controller ever runs. The outsider now gets `Role::ROLE_USER` explicitly, so the 403 under test comes from the gate rather than from the middleware. Any future test asserting 403 on a `web` route behind that group needs the same treatment.

## Scope

Found while working #3673, which is now the standing issue for this recurring check (route-bound model parameter reaching a write path with no `Gate::authorize`). Deliberately does **not** close it.

Two other candidates the same pass turned up, both resolved as non-findings and recorded here so they are not re-investigated:

- `AjaxProfileController::addAdFreeGiveaway()` — no gate, unlike its sibling `removeAdFreeGiveaway()`. Not a gap: `PatreonAdFreeGiveaway::getCountLeft()` returns `0` for anyone without the `AD_FREE_TEAM_MEMBERS` benefit, so the 422 is the authorization. Gifting to an arbitrary user is the feature, not the bug.
- `AjaxDungeonRouteController::favorite()` / `unfavorite()` — no gate, while `rate()` gates on `rate`. Whether favouriting a route you cannot view should be refused is a product call, not a cleanup, so it is left alone rather than guessed at.

`AjaxUserReportController` (anonymous reports by design) and the Wowhead webhooks (guarded by `config('app.debug')`) are clear. The whole `/api/v1` surface is covered by `ApiAuthentication` in the `api` middleware group, which `route:list` renders as an unexpanded `api` and so looks unauthenticated at a glance — it is not.
