### PR TITLE
#3887 Fix publish_givenOwner_returnsAllowed staying flaky after #3888

### DIFF
--- a/tests/Feature/Policy/DungeonRoutePolicyTest.php
+++ b/tests/Feature/Policy/DungeonRoutePolicyTest.php
@@ -221,8 +221,12 @@ final class DungeonRoutePolicyTest extends PublicTestCase
             // was picked.
             $mappingVersionId = $this->giveRouteAnEmptyMappingVersion($route);
 
-            // Act
-            $result = $this->policy->publish($owner, $route);
+            // Act - ->fresh() is required: giveRouteAnEmptyMappingVersion() only updates the mapping_version_id
+            // column, it doesn't clear $route's already-cached `mappingVersion` relation (accessed internally via
+            // $route->mappingVersion), so hasKilledAllRequiredEnemies()'s loadMissing() would silently keep using
+            // the stale, pre-swap mapping version without this - see the sibling
+            // publish_givenOwnerOfRouteMissingRequiredEnemies_returnsDenied test for the same pattern.
+            $result = $this->policy->publish($owner, $route->fresh());
 
             // Assert
             $this->assertTrue($result->allowed());


### PR DESCRIPTION
Closes #3887

:robot: Follow-up to #3888, which merged but did **not** actually fix the flakiness — PR #3872 hit the exact same failure again right after rebasing onto #3888's merge.

Root cause of the miss: `giveRouteAnEmptyMappingVersion()` (added in #3888) only updates the `mapping_version_id` column via `$route->update(...)`. It doesn't clear `$route`'s already-cached `mappingVersion` relation — the helper itself accesses it first (`$current = $route->mappingVersion`), which caches it on the model. `DungeonRoutePolicy::publish()` → `hasKilledAllRequiredEnemies()` calls `loadMissing('mappingVersion.enemies')`, which is a no-op once the relation is already loaded — so it silently kept using the **stale, pre-swap** mapping version. The test's outcome still depended on whether the factory's originally-picked dungeon happened to carry a required enemy, i.e. the exact bug #3888 was meant to close.

Fix: call `$route->fresh()` before passing it to `publish()`, mirroring the pattern the sibling `publish_givenOwnerOfRouteMissingRequiredEnemies_returnsDenied` test already uses for the same reason (it was already correct — #3888 just didn't copy it over).

This time I verified against the actual failure mode rather than trusting isolated-test passes: ran the full `feature-other` CI group locally (`--exclude-group=Controller --exclude-group=APICombatLog --exclude-group=MapTiles`), 875/875 passing. That's what let the original bug slip through — the test passes reliably in isolation and only fails as part of the full suite.

Cold review skipped under the trivial-change rule (single test file, 6 insertions/2 deletions, no schema/auth/UI change, covered by the very test it fixes — and this time actually verified under full-suite conditions).
