### PR TITLE
Remove unused lazysizes dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
                 "intro.js": "github:Wotuu/intro.js",
                 "js-cookie": "^3.0.8",
                 "lang.js": "^1.1.14",
-                "lazysizes": "^5.3.2",
                 "leaflet": "^1.9.4",
                 "leaflet-ant-path": "^1.3.0",
                 "leaflet-contextmenu": "^1.4.0",
@@ -3031,11 +3030,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/lazysizes": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/lazysizes/-/lazysizes-5.3.2.tgz",
-            "integrity": "sha512-22UzWP+Vedi/sMeOr8O7FWimRVtiNJV2HCa+V8+peZOw6QbswN9k58VUhd7i6iK5bw5QkYrF01LJbeJe0PV8jg=="
         },
         "node_modules/leaflet": {
             "version": "1.9.4",
@@ -6324,11 +6318,6 @@
             "integrity": "sha512-8w0fAGSNt6THfbNyqdKc29bhfeNpJg13CGx2fcLgoX0/f0mTJm/AIkYTTakmcr9pc42ZB68cSoE00j4/xNaFGQ==",
             "dev": true,
             "requires": {}
-        },
-        "lazysizes": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/lazysizes/-/lazysizes-5.3.2.tgz",
-            "integrity": "sha512-22UzWP+Vedi/sMeOr8O7FWimRVtiNJV2HCa+V8+peZOw6QbswN9k58VUhd7i6iK5bw5QkYrF01LJbeJe0PV8jg=="
         },
         "leaflet": {
             "version": "1.9.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
         "intro.js": "github:Wotuu/intro.js",
         "js-cookie": "^3.0.8",
         "lang.js": "^1.1.14",
-        "lazysizes": "^5.3.2",
         "leaflet": "^1.9.4",
         "leaflet-ant-path": "^1.3.0",
         "leaflet-contextmenu": "^1.4.0",

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -122,7 +122,6 @@ window.Grapick = require('grapick');
 window.simplebar = require('simplebar');
 window.Draggable = require('@shopify/draggable');
 require('bootstrap5-toggle/js/bootstrap5-toggle.jquery.min.js');
-window.lazysizes = require('lazysizes');
 // Self-owned noUiSlider-backed range slider (#3596); replaces the unmaintained ion-rangeslider plugin
 require('./range-slider');
 


### PR DESCRIPTION
:robot: Closes #3892

Follow-up from #3595 (lightslider migration). `lazysizes` was listed in `package.json` and required in `resources/assets/js/bootstrap.js`, but no `.lazyload` class exists anywhere in the codebase, so it never activated.

## Changes
- Remove `lazysizes` from `package.json` / `package-lock.json`
- Remove the `require('lazysizes')` line from `bootstrap.js`

## Test plan
- [x] `npm install` + `npm run production` build succeeds with no errors
- [x] Confirmed no `.lazyload` class references anywhere in `resources/`