### PR TITLE
#3893 Let a single scroll gesture reach the top of the page

### DIFF
--- a/resources/assets/js/custom/inline/common/general/siteheader.js
+++ b/resources/assets/js/custom/inline/common/general/siteheader.js
@@ -28,6 +28,13 @@ class CommonGeneralSiteheader extends InlineCode {
      */
     static MIN_SCROLLABLE_DISTANCE = 200;
 
+    /**
+     * How long scroll anchoring stays suppressed after the header starts growing back. Must
+     * outlast the CSS height/padding transition in header.css (0.2s), since the document keeps
+     * growing - and anchoring keeps re-evaluating - for its whole duration.
+     */
+    static SCROLL_ANCHOR_SUPPRESSION_MS = 400;
+
     activate() {
         super.activate();
 
@@ -81,8 +88,47 @@ class CommonGeneralSiteheader extends InlineCode {
             shouldShrinkHeader(window.scrollY, currentlyShrunk);
 
         if (shrunk !== currentlyShrunk) {
+            if (shrunk) {
+                // Shrinking wants the compensation - close any suppression window a recent
+                // unshrink left open, or the shrink runs without it
+                this._restoreScrollAnchoring();
+            } else {
+                this._suppressScrollAnchoring();
+            }
+
             this.shrinkTarget.classList.toggle('ksg-header--shrink', shrunk);
         }
+    }
+
+    /**
+     * Stop the browser from compensating for the header growing back (#3893).
+     *
+     * The bars stack in normal document flow since #3851, so unshrinking grows the document by
+     * the height the header regains - above the viewport. Scroll anchoring then adds that same
+     * height to the scroll position to keep the visible content stable, which eats the tail of
+     * an upward fling (already decelerating by then) and leaves the page short of the top.
+     *
+     * Deliberately not applied when the header shrinks: there the compensation is wanted, as it
+     * keeps the content the user is reading from jumping upwards mid-page.
+     */
+    _suppressScrollAnchoring() {
+        document.documentElement.style.overflowAnchor = 'none';
+
+        clearTimeout(this._scrollAnchorRestoreTimer);
+        this._scrollAnchorRestoreTimer = setTimeout(
+            this._restoreScrollAnchoring.bind(this),
+            CommonGeneralSiteheader.SCROLL_ANCHOR_SUPPRESSION_MS
+        );
+    }
+
+    /**
+     * Hand scroll anchoring back to the browser. Suppression is always temporary - leaving it on
+     * would stop the whole page from compensating for anything that resizes above the viewport,
+     * such as an image loading in.
+     */
+    _restoreScrollAnchoring() {
+        clearTimeout(this._scrollAnchorRestoreTimer);
+        document.documentElement.style.removeProperty('overflow-anchor');
     }
 }
 

--- a/resources/assets/js/custom/inline/common/general/siteheader.test.js
+++ b/resources/assets/js/custom/inline/common/general/siteheader.test.js
@@ -1,13 +1,14 @@
 // ---------------------------------------------------------------------------
 // CommonGeneralSiteheader is a global-script style class extending the bare
 // global `InlineCode`. The hysteresis decision is a pure function
-// (shouldShrinkHeader) so the flap-prevention logic is testable without DOM.
+// (shouldShrinkHeader) so the flap-prevention logic is testable without DOM;
+// the scroll-anchoring suppression needs one, but only a class on an element.
 // ---------------------------------------------------------------------------
 
 const {InlineCode}    = require('../../inlinecode');
 globalThis.InlineCode = InlineCode;
 
-const {shouldShrinkHeader} = require('./siteheader');
+const {CommonGeneralSiteheader, shouldShrinkHeader} = require('./siteheader');
 
 describe('shouldShrinkHeader', () => {
     it('shouldShrinkHeader_givenTopOfPageNotShrunk_returnsFalse', () => {
@@ -46,5 +47,145 @@ describe('shouldShrinkHeader', () => {
         // Assert: the nudged position stays inside the hysteresis band - no flap
         expect(shrunk).toBe(true);
         expect(afterNudge).toBe(true);
+    });
+});
+
+describe('CommonGeneralSiteheader scroll anchoring', () => {
+    /**
+     * Build an instance wired straight to a shrink target, bypassing activate() - that path
+     * needs a ResizeObserver and real layout, neither of which jsdom provides, and neither of
+     * which the anchoring decision depends on.
+     *
+     * @param {boolean} currentlyShrunk
+     * @returns {CommonGeneralSiteheader}
+     */
+    function makeSiteheader(currentlyShrunk) {
+        document.body.innerHTML = `<div id="site_header" class="ksg-header${currentlyShrunk ? ' ksg-header--shrink' : ''}"></div>`;
+
+        const siteheader = new CommonGeneralSiteheader('siteheader', 'common/general/siteheader', {});
+        siteheader.shrinkTarget = document.getElementById('site_header');
+
+        return siteheader;
+    }
+
+    /**
+     * @param {number} scrollY
+     */
+    function scrollTo(scrollY) {
+        window.scrollY = scrollY;
+        // Well past MIN_SCROLLABLE_DISTANCE, so the page always counts as scrollable
+        vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(5000);
+        window.innerHeight = 1000;
+    }
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.documentElement.style.removeProperty('overflow-anchor');
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('updateShrink_givenHeaderUnshrinks_suppressesScrollAnchoringForTheTransition', () => {
+        // Arrange: shrunk header, scrolled back to the top
+        const siteheader = makeSiteheader(true);
+        scrollTo(0);
+
+        // Act
+        siteheader._updateShrink();
+
+        // Assert: the class flipped and anchoring cannot move the scroll position meanwhile
+        expect(siteheader.shrinkTarget.classList.contains('ksg-header--shrink')).toBe(false);
+        expect(document.documentElement.style.overflowAnchor).toBe('none');
+    });
+
+    it('updateShrink_givenSuppressionWindowElapsed_restoresScrollAnchoring', () => {
+        // Arrange
+        const siteheader = makeSiteheader(true);
+        scrollTo(0);
+        siteheader._updateShrink();
+
+        // Act
+        vi.advanceTimersByTime(CommonGeneralSiteheader.SCROLL_ANCHOR_SUPPRESSION_MS);
+
+        // Assert: suppression is temporary - leaving it on would break anchoring site-wide
+        expect(document.documentElement.style.overflowAnchor).toBe('');
+    });
+
+    it('updateShrink_givenSuppressionWindowStillOpen_keepsScrollAnchoringSuppressed', () => {
+        // Arrange
+        const siteheader = makeSiteheader(true);
+        scrollTo(0);
+        siteheader._updateShrink();
+
+        // Act: the CSS transition (0.2s) must be fully covered
+        vi.advanceTimersByTime(CommonGeneralSiteheader.SCROLL_ANCHOR_SUPPRESSION_MS - 1);
+
+        // Assert
+        expect(document.documentElement.style.overflowAnchor).toBe('none');
+    });
+
+    it('updateShrink_givenHeaderShrinks_leavesScrollAnchoringAlone', () => {
+        // Arrange: unshrunk header, scrolled past the shrink threshold
+        const siteheader = makeSiteheader(false);
+        scrollTo(500);
+
+        // Act
+        siteheader._updateShrink();
+
+        // Assert: shrinking wants the compensation - it keeps mid-page content from jumping
+        expect(siteheader.shrinkTarget.classList.contains('ksg-header--shrink')).toBe(true);
+        expect(document.documentElement.style.overflowAnchor).toBe('');
+    });
+
+    it('updateShrink_givenShrinkWithinTheSuppressionWindow_restoresScrollAnchoringImmediately', () => {
+        // Arrange: unshrink at the top, then scroll straight back down past the shrink
+        // threshold before the suppression window has closed
+        const siteheader = makeSiteheader(true);
+        scrollTo(0);
+        siteheader._updateShrink();
+
+        // Act
+        scrollTo(500);
+        siteheader._updateShrink();
+
+        // Assert: the shrink must not inherit the open window - it needs the compensation
+        expect(siteheader.shrinkTarget.classList.contains('ksg-header--shrink')).toBe(true);
+        expect(document.documentElement.style.overflowAnchor).toBe('');
+    });
+
+    it('updateShrink_givenNoStateChange_leavesScrollAnchoringAlone', () => {
+        // Arrange: shrunk header inside the hysteresis band
+        const siteheader = makeSiteheader(true);
+        scrollTo(100);
+
+        // Act
+        siteheader._updateShrink();
+
+        // Assert
+        expect(siteheader.shrinkTarget.classList.contains('ksg-header--shrink')).toBe(true);
+        expect(document.documentElement.style.overflowAnchor).toBe('');
+    });
+
+    it('updateShrink_givenAShrinkUnshrinkCycleWithinTheWindow_givesTheSecondUnshrinkAFullWindow', () => {
+        // Arrange: unshrink, then shrink and unshrink again before the first timer would fire.
+        // (An unshrink can only follow another unshrink through a shrink, which restores - so
+        // this cycle is the only way a second suppression window is ever opened.)
+        const siteheader = makeSiteheader(true);
+        scrollTo(0);
+        siteheader._updateShrink();
+
+        vi.advanceTimersByTime(CommonGeneralSiteheader.SCROLL_ANCHOR_SUPPRESSION_MS - 10);
+        scrollTo(500);
+        siteheader._updateShrink();
+        scrollTo(0);
+        siteheader._updateShrink();
+
+        // Act: past the point the *first* timer would have fired
+        vi.advanceTimersByTime(20);
+
+        // Assert: a stale timer must not cut the second suppression window short
+        expect(document.documentElement.style.overflowAnchor).toBe('none');
     });
 });


### PR DESCRIPTION
:robot: Closes #3893

Scrolling from the bottom of a page to the top in a single gesture stopped short of the top,
needing a second scroll.

## Cause

Since #3851 the header bars stack in **normal document flow**, so the `.ksg-header--shrink`
toggle changes the *document* height:

| element | at rest | shrunk | delta |
| --- | --- | --- | --- |
| `.dungeon_context_header` | 99px | 64px | 35px |
| `.navbar-second` y-padding (x2) | 0.5rem | 0.25rem | 8px |

Unshrinking therefore grows the document by 43px **above the viewport**, and the browser's
scroll anchoring adds those 43px to `scrollY` to keep the visible content stable. That
compensation eats the tail of an upward fling, which is already decelerating, so the gesture
ends short of the top.

## Measurements

Measured in headless Chrome on a synthetic page reproducing the header shape (tall body, one
sticky header whose height changes in flow):

| condition | scroll position moved by |
| --- | --- |
| unshrink at `scrollY = 100` | **+43px** |
| unshrink at `scrollY = 0` | 0px — Chrome does not anchor while the scroller sits at the top |
| shrink at `scrollY = 141` | −43px |
| any of the above with `overflow-anchor: none` | 0px |

The `transition: height 0.2s ease` makes no difference to any of these, so it is kept.

## Fix

Suppress scroll anchoring for the duration of the expand transition, and hand it back
afterwards. The shrink/unshrink thresholds are untouched — `shouldShrinkHeader` is unchanged —
so nothing about when or how the header renders moves.

Suppression is deliberately **not** applied when the header shrinks: there the compensation is
wanted, since it is what keeps the content you are reading from jumping upwards as you scroll
down. An open suppression window is therefore closed again if a shrink follows an unshrink
within it.

## Verification

Real-page probe (`/affixes`), one **decelerating** wheel gesture from the bottom of the page.
The deceleration is the part that matters: a constant-speed gesture has leftover travel to
spend after the header expands, recovers from the bump, and hides the bug entirely.

| build | desktop (1600x1000) | mobile (375x700) |
| --- | --- | --- |
| master | **43px** | **8px** |
| this branch | **0px** | **0px** |

3 consecutive runs per cell on this branch, no page errors.

`npx vitest run .../siteheader.test.js` — 13 passed. Added jsdom coverage for the suppression
seam: applied on unshrink, not on shrink, restored after the window, window closed early when a
shrink follows, timer re-armed on a second unshrink.

No PHP changed. Header rendering is unchanged in both states (screenshots below).
