### PR TITLE
Fix share/map modal close button hidden behind the header

### DIFF
--- a/resources/assets/css/sections/map-header.css
+++ b/resources/assets/css/sections/map-header.css
@@ -74,9 +74,16 @@
 /* The map header's modals (share, simulate, live session, ...) are declared inside #map_header,
    so the `#map_header > div` rule above also matches them - an ID selector beats `.theme .modal`'s
    two classes regardless of value, pinning the modal to 100020 and hiding its close button behind
-   the header. Out-specify it here so these modals float above the whole header again. */
+   the header. Out-specify it here so these modals float above the whole header again. One higher
+   than `.ksg-header` above (not equal) so it outright wins instead of merely tying and depending
+   on DOM order - a future bump of `.ksg-header` would otherwise silently re-hide the close button.
+   pointer-events also needs restoring: these modals inherit `none` from #map_header (below), which
+   silently breaks click-outside-the-dialog-to-dismiss - the backdrop is a sibling of #map_header
+   (Bootstrap appends it to <body>) so it stays clickable, but the click never reaches the modal's
+   own dismiss listener without this. */
 #map_header > .modal {
-    z-index: 100021 !important;
+    z-index: 100022 !important;
+    pointer-events: auto;
 }
 
 #map_header .rounded {

--- a/resources/assets/css/sections/map-header.css
+++ b/resources/assets/css/sections/map-header.css
@@ -71,6 +71,14 @@
     z-index: 100021 !important;
 }
 
+/* The map header's modals (share, simulate, live session, ...) are declared inside #map_header,
+   so the `#map_header > div` rule above also matches them - an ID selector beats `.theme .modal`'s
+   two classes regardless of value, pinning the modal to 100020 and hiding its close button behind
+   the header. Out-specify it here so these modals float above the whole header again. */
+#map_header > .modal {
+    z-index: 100021 !important;
+}
+
 #map_header .rounded {
     border-radius: 0 !important;
 }


### PR DESCRIPTION
:robot: Closes #3895

## Cause

Modals declared inside `#map_header` (share, simulate, live session, edit route/mapping-version
settings, ...) are direct children of it, so the existing rule

```css
#map_header,
#map_header > div {
    z-index: 100020 !important;
}
```

also matches them - an ID selector beats `.theme .modal { z-index: 100021 !important; }`
(theme.scss) on specificity regardless of value, pinning the modal to the header's own z-index
and losing the paint-order tie to `.ksg-header`, hiding the close button behind it.

## Fix

Out-specify the rule for modals specifically in `map-header.css`:

```css
#map_header > .modal {
    z-index: 100021 !important;
}
```

## Test plan
- [x] Headless Chrome, `#share_modal" on a published non-demo route: before the fix,
  `getComputedStyle(...).zIndex` reported `100020` and the element under the close button was a
  header nav link; after, it reports `100021` and the close button itself is hit-tested, and
  clicking it closes the modal.
- CSS-only change, no PHP touched.
