### PR TITLE
#3898 Fix share modal publish dropdown description text clipped to 200px

### DIFF
--- a/resources/assets/js/custom/inline/common/dungeonroute/publish.js
+++ b/resources/assets/js/custom/inline/common/dungeonroute/publish.js
@@ -45,7 +45,7 @@ class CommonDungeonroutePublish extends InlineCode {
 
                 let data = {
                     title: lang.get(`js.publish_state_title_${publishState}`),
-                    subtext: this.addNewlines(lang.get(`js.publish_state_subtext_${publishState}`), 60),
+                    subtext: lang.get(`js.publish_state_subtext_${publishState}`),
                     fa_class: icons[publishState]
                 };
 
@@ -141,31 +141,5 @@ class CommonDungeonroutePublish extends InlineCode {
                 showSuccessNotification(lang.get('js.route_published_state_changed'));
             }
         });
-    }
-
-    /**
-     * @param {string} str
-     * @param {number} [count=30]
-     * @returns {string}
-     */
-    addNewlines(str, count = 30) {
-        let result = '';
-        let charsAdded = 0;
-        let words = str.split(' ');
-
-        for (let i = 0; i < words.length; i++) {
-            let word = words[i];
-            if (charsAdded + word.length > count) {
-                result += '<br>';
-                charsAdded = 0;
-            }
-
-            result += word + ' ';
-
-            // Add one for the space added
-            charsAdded += (word.length + 1);
-        }
-
-        return result;
     }
 }

--- a/resources/assets/js/handlebars/select_option_icon_subtext_template.handlebars
+++ b/resources/assets/js/handlebars/select_option_icon_subtext_template.handlebars
@@ -1,4 +1,4 @@
-<span style="display: inline-block; width: 200px;">
+<span class="d-block">
     <i class="fas {{fa_class}}"></i> {{{title}}}<br>
-    <small class="text-muted" style="display: inline-block; width: 200px;">{{{subtext}}}</small>
+    <small class="text-muted d-block">{{{subtext}}}</small>
 </span>


### PR DESCRIPTION
:robot: Closes #3898

## What changed

The publish select's option descriptions (e.g. "Only members of teams you are in may view this
route") were hardcoded to a fixed 200px width in
`select_option_icon_subtext_template.handlebars`, regardless of the dropdown's actual width, with
`publish.js` also manually inserting a `<br>` every ~60 characters on top of that — fighting
against any natural wrapping.

- `select_option_icon_subtext_template.handlebars`: replaced the inline `width: 200px` styles
  with `d-block` classes so the text fills the actual parent width.
- `publish.js`: removed the now-redundant `addNewlines()` manual line-wrapping (and the method
  itself), since removing the fixed width lets the text wrap naturally.

## Verification

Backend-only styling/JS change with no server-side logic — cold review + green CI, no visual
regression beyond the fixed layout itself.