### PR TITLE
Guard route-attributes filter against a non-array search value

### DIFF
--- a/app/Logic/Datatables/ColumnHandler/DungeonRoutes/DungeonRouteAffixesColumnHandler.php
+++ b/app/Logic/Datatables/ColumnHandler/DungeonRoutes/DungeonRouteAffixesColumnHandler.php
@@ -32,6 +32,11 @@ class DungeonRouteAffixesColumnHandler extends DatatablesColumnHandler
                 $generalSearch,
     ): void {
         $affixIds = $columnData['search']['value'] ?? [];
+        // A select that isn't rendered for the current view sends the literal string 'undefined'
+        // instead of omitting the param
+        if (!is_array($affixIds)) {
+            $affixIds = [];
+        }
         if (!empty($affixIds)) {
             $subBuilder->whereHas('affixes', static function ($query) use (&$affixIds) {
                 /** @var $query Builder */

--- a/app/Logic/Datatables/ColumnHandler/DungeonRoutes/DungeonRouteAttributesColumnHandler.php
+++ b/app/Logic/Datatables/ColumnHandler/DungeonRoutes/DungeonRouteAttributesColumnHandler.php
@@ -28,6 +28,11 @@ class DungeonRouteAttributesColumnHandler extends DatatablesColumnHandler
                 $generalSearch,
     ): void {
         $routeAttributeIds = $columnData['search']['value'] ?? null;
+        // A select that isn't rendered for the current view sends the literal string 'undefined'
+        // instead of omitting the param
+        if (!is_array($routeAttributeIds)) {
+            $routeAttributeIds = [];
+        }
         // If filtering or ordering
         if (!empty($routeAttributeIds) || $order !== null) {
             // $builder->leftJoin('dungeon_route_attributes', 'dungeon_route_attributes.dungeon_route_id', '=', 'dungeon_routes.id');

--- a/resources/assets/js/custom/inline/dungeonroute/table.js
+++ b/resources/assets/js/custom/inline/dungeonroute/table.js
@@ -54,8 +54,12 @@ class DungeonrouteTable extends InlineCode {
         $(this.options.filterButtonSelector).unbind('click').bind('click', function () {
             // Build the search parameters
             let dungeonId = $(self.options.dungeonSelectId).val();
-            let affixes = $(self.options.affixSelectId).val();
-            let attributes = $(self.options.attributesSelectId).val();
+            // .val() on a zero-element jQuery collection (e.g. a select that doesn't exist for
+            // this table's view) returns undefined, which would otherwise be sent to the server
+            // as the literal search value 'undefined' instead of an empty array. See the same
+            // guard on requirements/tags below.
+            let affixes = $(self.options.affixSelectId).val() || [];
+            let attributes = $(self.options.attributesSelectId).val() || [];
 
             // Find wherever the columns are we're looking for, then filter using them
             // https://stackoverflow.com/questions/32598279/how-to-get-name-of-datatable-column

--- a/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
@@ -88,6 +88,44 @@ final class AjaxDungeonRouteControllerTest extends AjaxPublicTestCase
     }
 
     #[Test]
+    public function get_givenRouteAttributesColumnSearchValueIsTheStringUndefined_returnsOk(): void
+    {
+        // Arrange - same failure mode as the tags/requirements parameters above, but for the
+        // routeattributes.name DataTables column's own search value: a route-attributes select
+        // that isn't rendered for the current view sends the literal string 'undefined' instead
+        // of an array of attribute ids, which DungeonRouteAttributesColumnHandler::applyFilter()
+        // passed straight into array_diff()'s second (array) argument
+        $query = http_build_query([
+            'draw'    => 1,
+            'start'   => 0,
+            'length'  => 25,
+            'columns' => [
+                [
+                    'data'       => 0,
+                    'name'       => 'title',
+                    'searchable' => 'true',
+                    'orderable'  => 'true',
+                    'search'     => ['value' => '', 'regex' => 'false'],
+                ],
+                [
+                    'data'       => 1,
+                    'name'       => 'routeattributes.name',
+                    'searchable' => 'true',
+                    'orderable'  => 'true',
+                    'search'     => ['value' => 'undefined', 'regex' => 'false'],
+                ],
+            ],
+            'search' => ['value' => '', 'regex' => 'false'],
+        ]);
+
+        // Act
+        $response = $this->get(sprintf('/ajax/routes?%s', $query));
+
+        // Assert
+        $response->assertOk();
+    }
+
+    #[Test]
     public function get_givenDungeonHasNewerMappingVersionThanTheRoute_returnsDungeonLatestMappingVersionIdOfTheDungeonsNewestVersion(): void
     {
         // Arrange

--- a/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
@@ -126,6 +126,43 @@ final class AjaxDungeonRouteControllerTest extends AjaxPublicTestCase
     }
 
     #[Test]
+    public function get_givenAffixesColumnSearchValueIsTheStringUndefined_returnsOk(): void
+    {
+        // Arrange - same failure mode as the routeattributes.name column above, but for the
+        // affixes.id column: an affixes select that isn't rendered for the current view sends the
+        // literal string 'undefined' instead of an array of affix ids, which
+        // DungeonRouteAffixesColumnHandler::applyFilter() passed straight into whereIn()
+        $query = http_build_query([
+            'draw'    => 1,
+            'start'   => 0,
+            'length'  => 25,
+            'columns' => [
+                [
+                    'data'       => 0,
+                    'name'       => 'title',
+                    'searchable' => 'true',
+                    'orderable'  => 'true',
+                    'search'     => ['value' => '', 'regex' => 'false'],
+                ],
+                [
+                    'data'       => 1,
+                    'name'       => 'affixes.id',
+                    'searchable' => 'true',
+                    'orderable'  => 'true',
+                    'search'     => ['value' => 'undefined', 'regex' => 'false'],
+                ],
+            ],
+            'search' => ['value' => '', 'regex' => 'false'],
+        ]);
+
+        // Act
+        $response = $this->get(sprintf('/ajax/routes?%s', $query));
+
+        // Assert
+        $response->assertOk();
+    }
+
+    #[Test]
     public function get_givenDungeonHasNewerMappingVersionThanTheRoute_returnsDungeonLatestMappingVersionIdOfTheDungeonsNewestVersion(): void
     {
         // Arrange


### PR DESCRIPTION
:robot: Closes #3910

## Summary
- `DungeonRouteAttributesColumnHandler::applyFilter()` passed the DataTables column's `search.value` straight into `array_diff()`'s second argument. When the front-end route-attributes select isn't rendered for the current view, jQuery's `.val()` on the missing element sends the literal string `'undefined'` instead of an array of attribute ids (same failure mode already handled for the `tags`/`requirements` query params in `AjaxDungeonRouteController`), which raised `TypeError: array_diff(): Argument #2 must be of type array, string given` on `GET /ajax/routes` (Sentry `PHP-LARAVEL-PD`, 256 events, 3 users, ongoing since 2026-07-16).
- Fix: coerce a non-array `$routeAttributeIds` to `[]` before use, matching the existing pattern for `tags`/`requirements`.
- Front-end fix (added after review): `DungeonrouteTable`'s filter-button click handler (`resources/assets/js/custom/inline/dungeonroute/table.js`) read `$(self.options.affixSelectId).val()` and `$(self.options.attributesSelectId).val()` with no fallback, so a missing select sends `undefined` as the search value in the first place — exactly the pattern the `requirementsSelectId`/`tagsSelectId` reads a few lines down already guard against (`.val() || []`), with a comment explaining why. Added the same `|| []` guard to `affixes`/`attributes` so the client stops sending `'undefined'` at all; the backend guard stays as defense in depth regardless (public-ish endpoint, and other future callers).

Fixes PHP-LARAVEL-PD

## Test plan
- [x] New regression test (`get_givenRouteAttributesColumnSearchValueIsTheStringUndefined_returnsOk`) reproduces the exact reported TypeError without the fix, and passes with it.
- [x] Full `AjaxDungeonRouteControllerTest.php` suite green (8 tests).
- [x] `composer run fix` — no drift.
- [x] `composer run analyse` — no errors.
- [x] Full Vitest suite green (440 tests) after the front-end guard.

---
:robot: Note: the second commit (`f14965c1e`, `DungeonRouteAffixesColumnHandler`) implements the cold reviewer's own suggestion from its finding on this PR and was not separately re-reviewed.
