### PR TITLE
Guard heatmap timer-fraction filter against timer_max_seconds=0

### DIFF
--- a/app/Service/CombatLogEvent/Dtos/CombatLogEventFilter.php
+++ b/app/Service/CombatLogEvent/Dtos/CombatLogEventFilter.php
@@ -513,7 +513,7 @@ class CombatLogEventFilter implements Arrayable
 
         if ($heatmapDataFilter->getTimerFractionMin() !== null && $heatmapDataFilter->getTimerFractionMax() !== null) {
             $timerSeconds = $heatmapDataFilter->getDungeon()->getCurrentMappingVersion()->timer_max_seconds;
-            if ($timerSeconds === null) { // @phpstan-ignore identical.alwaysFalse
+            if ($timerSeconds <= 0) {
                 throw new InvalidArgumentException('Mapping version does not have a timer max seconds value');
             }
 

--- a/app/Service/CombatLogEvent/Dtos/CombatLogEventFilter.php
+++ b/app/Service/CombatLogEvent/Dtos/CombatLogEventFilter.php
@@ -517,8 +517,11 @@ class CombatLogEventFilter implements Arrayable
                 throw new InvalidArgumentException('Mapping version does not have a timer max seconds value');
             }
 
-            $combatLogEventFilter->setDurationMin((int)(($heatmapDataFilter->getTimerFractionMin() * 60) / $timerSeconds));
-            $combatLogEventFilter->setDurationMax((int)(($heatmapDataFilter->getTimerFractionMax() * 60) / $timerSeconds));
+            // durationMin/Max are minutes (see toArray()'s duration_ms * 60000 below), and a
+            // fraction of the dungeon's timer converts to seconds as fraction * timerSeconds, so
+            // divide by 60 - not the other way around, which silently truncated every duration to 0
+            $combatLogEventFilter->setDurationMin((int)(($heatmapDataFilter->getTimerFractionMin() * $timerSeconds) / 60));
+            $combatLogEventFilter->setDurationMax((int)(($heatmapDataFilter->getTimerFractionMax() * $timerSeconds) / 60));
         }
 
         return $combatLogEventFilter;

--- a/tests/Feature/App/Service/CombatLogEvent/Dtos/CombatLogEventFilterTest.php
+++ b/tests/Feature/App/Service/CombatLogEvent/Dtos/CombatLogEventFilterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\App\Service\CombatLogEvent\Dtos;
+
+use App;
+use App\Models\CombatLog\CombatLogEventDataType;
+use App\Models\CombatLog\CombatLogEventEventType;
+use App\Service\CombatLogEvent\Dtos\CombatLogEventFilter;
+use App\Service\RaiderIO\Dtos\HeatmapDataFilter;
+use App\Service\Season\SeasonAffixGroupServiceInterface;
+use App\Service\Season\SeasonServiceInterface;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Traits\ProvidesDungeon;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('CombatLogEvent')]
+final class CombatLogEventFilterTest extends PublicTestCase
+{
+    use ProvidesDungeon;
+
+    /**
+     * A mapping version's `timer_max_seconds` column is NOT NULL DEFAULT 0 - fromHeatmapDataFilter()
+     * divides by it when the caller requested a timer-fraction range, so a mapping version that still
+     * carries the column's default of 0 must raise a clean InvalidArgumentException rather than a
+     * DivisionByZeroError (PHP-LARAVEL-8J).
+     */
+    #[Test]
+    public function fromHeatmapDataFilter_givenMappingVersionTimerMaxSecondsIsZero_throwsInvalidArgumentException(): void
+    {
+        // Arrange
+        [$dungeon, $mappingVersion] = $this->findDungeon();
+
+        $originalTimerMaxSeconds           = $mappingVersion->timer_max_seconds;
+        $mappingVersion->timer_max_seconds = 0;
+        $mappingVersion->save();
+
+        try {
+            $heatmapDataFilter = new HeatmapDataFilter(
+                $dungeon,
+                CombatLogEventEventType::NpcDeath,
+                CombatLogEventDataType::PlayerPosition,
+            );
+            $heatmapDataFilter->setTimerFractionMin(0.0);
+            $heatmapDataFilter->setTimerFractionMax(1.0);
+
+            // Assert
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage('Mapping version does not have a timer max seconds value');
+
+            // Act
+            CombatLogEventFilter::fromHeatmapDataFilter(
+                App::make(SeasonServiceInterface::class),
+                App::make(SeasonAffixGroupServiceInterface::class),
+                $heatmapDataFilter,
+            );
+        } finally {
+            $mappingVersion->timer_max_seconds = $originalTimerMaxSeconds;
+            $mappingVersion->save();
+        }
+    }
+}

--- a/tests/Feature/App/Service/CombatLogEvent/Dtos/CombatLogEventFilterTest.php
+++ b/tests/Feature/App/Service/CombatLogEvent/Dtos/CombatLogEventFilterTest.php
@@ -60,4 +60,44 @@ final class CombatLogEventFilterTest extends PublicTestCase
             $mappingVersion->save();
         }
     }
+
+    /**
+     * The fraction-to-minutes conversion was inverted ((fraction * 60) / timerSeconds instead of
+     * (fraction * timerSeconds) / 60), which - for any real dungeon timer - truncated every
+     * duration bound to 0 via the (int) cast, silently collapsing the requested filter range.
+     */
+    #[Test]
+    public function fromHeatmapDataFilter_givenTimerFractionRange_computesDurationBoundsInMinutes(): void
+    {
+        // Arrange - a 1800 second (30 minute) timer, filtering the middle half of the run
+        [$dungeon, $mappingVersion] = $this->findDungeon();
+
+        $originalTimerMaxSeconds           = $mappingVersion->timer_max_seconds;
+        $mappingVersion->timer_max_seconds = 1800;
+        $mappingVersion->save();
+
+        try {
+            $heatmapDataFilter = new HeatmapDataFilter(
+                $dungeon,
+                CombatLogEventEventType::NpcDeath,
+                CombatLogEventDataType::PlayerPosition,
+            );
+            $heatmapDataFilter->setTimerFractionMin(0.25);
+            $heatmapDataFilter->setTimerFractionMax(0.75);
+
+            // Act
+            $combatLogEventFilter = CombatLogEventFilter::fromHeatmapDataFilter(
+                App::make(SeasonServiceInterface::class),
+                App::make(SeasonAffixGroupServiceInterface::class),
+                $heatmapDataFilter,
+            );
+
+            // Assert - 0.25 * 1800s / 60 = 7.5 minutes, 0.75 * 1800s / 60 = 22.5 minutes
+            $this->assertSame(7, $combatLogEventFilter->getDurationMin());
+            $this->assertSame(22, $combatLogEventFilter->getDurationMax());
+        } finally {
+            $mappingVersion->timer_max_seconds = $originalTimerMaxSeconds;
+            $mappingVersion->save();
+        }
+    }
 }


### PR DESCRIPTION
:robot: Closes #3913

## Summary
- `CombatLogEventFilter::fromHeatmapDataFilter()` divides by a mapping version's `timer_max_seconds` when the caller supplies a timer-fraction range, guarded by `if ($timerSeconds === null)`. `timer_max_seconds` is a non-nullable `int` column with a `NOT NULL DEFAULT 0` (already documented as a known divide-by-zero hazard in `MappingServiceCreateNewMappingVersionFromMDTMappingTest`), so the `=== null` check could never trip — PHPStan even had a `@phpstan-ignore identical.alwaysFalse` on it acknowledging the dead code. A mapping version that still carries the column default of `0` (e.g. one of the MoP Challenge Mode dungeons, per a recent event's payload) hit `DivisionByZeroError` on `POST /ajax/heatmap/data` instead of the intended `InvalidArgumentException` (Sentry `PHP-LARAVEL-8J`, 270 events, 2 users, ongoing since 2026-02-10 — the highest-volume unfixed crash found in this triage pass).
- Fix: check `$timerSeconds <= 0` instead of `=== null`, and drop the now-meaningful comparison's `@phpstan-ignore`.

Fixes PHP-LARAVEL-8J

## Test plan
- [x] New regression test (`CombatLogEventFilterTest::fromHeatmapDataFilter_givenMappingVersionTimerMaxSecondsIsZero_throwsInvalidArgumentException`) reproduces the exact reported `DivisionByZeroError` without the fix, and passes (asserting the intended `InvalidArgumentException`) with it.
- [x] `composer run fix` — no drift.
- [x] `composer run analyse` — no errors.

---
:robot: Cold review also caught that the block this PR hardens had an inverted fraction→minutes conversion — fixed in a second commit (`f2890d382`) with its own regression test. Separately, this PR intentionally still lets `InvalidArgumentException` surface as a 500 on `POST /ajax/heatmap/data` for affected dungeons (matching what #3913 asked for) rather than adding graceful degradation in the controller — that's a product call on desired behavior (silently drop the filter vs. surface an error), left as a follow-up rather than expanded scope here.
