### PR TITLE
#3911 Fix /ajax/routes 500 when the datatables 'search' param is absent

### DIFF
--- a/app/Logic/Datatables/ColumnHandler/DatatablesColumnHandler.php
+++ b/app/Logic/Datatables/ColumnHandler/DatatablesColumnHandler.php
@@ -84,13 +84,14 @@ abstract class DatatablesColumnHandler
             $order = $order[0] ?? null;
         }
         $generalSearch = $request->input('search.value');
+        $generalSearch = is_string($generalSearch) ? $generalSearch : null;
 
         // Find the column we should handle
         $column = null;
         // Find the index too; needed to handle sorting later on
         $columnIndex = -1;
         foreach ($columns as $index => $value) {
-            if ($value['name'] === $this->columnName) {
+            if (($value['name'] ?? null) === $this->columnName) {
                 $column      = $value;
                 $columnIndex = $index;
                 break;

--- a/app/Logic/Datatables/ColumnHandler/DatatablesColumnHandler.php
+++ b/app/Logic/Datatables/ColumnHandler/DatatablesColumnHandler.php
@@ -83,7 +83,7 @@ abstract class DatatablesColumnHandler
         if (is_array($order)) {
             $order = $order[0] ?? null;
         }
-        $generalSearch = ($request->get('search'))['value'];
+        $generalSearch = $request->input('search.value');
 
         // Find the column we should handle
         $column = null;

--- a/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
@@ -59,6 +59,33 @@ final class AjaxDungeonRouteControllerTest extends AjaxPublicTestCase
     }
 
     #[Test]
+    public function get_givenSearchParameterIsMissing_returnsOk(): void
+    {
+        // Arrange - a caller (e.g. a bare curl request) that omits the datatables 'search'
+        // parameter entirely, rather than sending 'search[value]=""'
+        $query = http_build_query([
+            'draw'    => 1,
+            'start'   => 0,
+            'length'  => 25,
+            'columns' => [
+                [
+                    'data'       => 0,
+                    'name'       => 'title',
+                    'searchable' => 'true',
+                    'orderable'  => 'true',
+                    'search'     => ['value' => '', 'regex' => 'false'],
+                ],
+            ],
+        ]);
+
+        // Act
+        $response = $this->get(sprintf('/ajax/routes?%s', $query));
+
+        // Assert
+        $response->assertOk();
+    }
+
+    #[Test]
     public function get_givenRequirementsParameterIsTheStringUndefined_returnsOk(): void
     {
         // Arrange - same failure mode as the tags parameter above: a requirements select that

--- a/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxDungeonRouteControllerTest.php
@@ -61,7 +61,7 @@ final class AjaxDungeonRouteControllerTest extends AjaxPublicTestCase
     #[Test]
     public function get_givenSearchParameterIsMissing_returnsOk(): void
     {
-        // Arrange - a caller (e.g. a bare curl request) that omits the datatables 'search'
+        // Arrange - a well-formed request that omits the top-level datatables 'search'
         // parameter entirely, rather than sending 'search[value]=""'
         $query = http_build_query([
             'draw'    => 1,
@@ -76,6 +76,33 @@ final class AjaxDungeonRouteControllerTest extends AjaxPublicTestCase
                     'search'     => ['value' => '', 'regex' => 'false'],
                 ],
             ],
+        ]);
+
+        // Act
+        $response = $this->get(sprintf('/ajax/routes?%s', $query));
+
+        // Assert
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function get_givenSearchValueIsAnArray_returnsOk(): void
+    {
+        // Arrange - a caller sending 'search[value][]=...' instead of a scalar 'search[value]'
+        $query = http_build_query([
+            'draw'    => 1,
+            'start'   => 0,
+            'length'  => 25,
+            'columns' => [
+                [
+                    'data'       => 0,
+                    'name'       => 'title',
+                    'searchable' => 'true',
+                    'orderable'  => 'true',
+                    'search'     => ['value' => '', 'regex' => 'false'],
+                ],
+            ],
+            'search' => ['value' => ['not', 'a', 'string'], 'regex' => 'false'],
         ]);
 
         // Act


### PR DESCRIPTION
:robot: Closes #3911

`DatatablesColumnHandler::applyToBuilder()` indexed into `$request->get('search')['value']` unconditionally, which throws "Trying to access array offset on null" when a caller omits the `search` parameter entirely (e.g. a bare `curl` request) instead of sending `search[value]=""`.

Fix: read it via `$request->input('search.value')`, coerced to `null` when it isn't a string (e.g. `search[value][]=...`).

Also hardened the adjacent, unguarded `$value['name']` column lookup a few lines below (same method) to be null-safe, since a cold review found it 500s the same way for a column entry missing `name`. The `SimpleColumnHandler` `searchable`/`orderable` reads are a similar pattern repeated across several column handlers — left as a follow-up rather than widening this PR's scope.

Added regression tests:
- `get_givenSearchParameterIsMissing_returnsOk`
- `get_givenSearchValueIsAnArray_returnsOk`

Both reproduce the exact reported failure modes against the pre-fix code and pass after.
