### PR TITLE
#3912 Fall back to enemy_forces when a teeming NPC has no enemy_forces_teeming override

### DIFF
--- a/app/Service/MDT/Import/PullImporter.php
+++ b/app/Service/MDT/Import/PullImporter.php
@@ -289,9 +289,12 @@ class PullImporter
                 $npcEnemyForces = $enemyForcesByNpcIds->get($enemy->npc->id);
 
                 if ($npcEnemyForces !== null) {
+                    // enemy_forces_teeming may be null (no teeming-specific override for this NPC) - fall back
+                    // to the regular value, matching the IFNULL(enemy_forces_teeming, enemy_forces) convention
+                    // used everywhere else this column is read (e.g. KillZone::getSkippableEnemyForces()).
                     $importStringPulls->addEnemyForces(
                         $importStringPulls->isRouteTeeming() ?
-                            $npcEnemyForces->enemy_forces_teeming :
+                            $npcEnemyForces->enemy_forces_teeming ?? $npcEnemyForces->enemy_forces :
                             $npcEnemyForces->enemy_forces,
                     );
                 } else {

--- a/tests/Feature/App/Service/MDT/MDTImportStringServicePullsTest.php
+++ b/tests/Feature/App/Service/MDT/MDTImportStringServicePullsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\App\Service\MDT;
 
 use App\Models\KillZone\KillZone;
+use App\Models\Npc\NpcEnemyForces;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -74,6 +75,65 @@ class MDTImportStringServicePullsTest extends MDTImportStringServiceTestBase
             $this->assertCount(1, $importedRoute->killZones);
             $this->assertCount(2, $importedRoute->killZones->first()->killZoneEnemies);
         } finally {
+            $importedRoute?->delete();
+            $dungeonRoute?->delete();
+        }
+    }
+
+    #[Test]
+    #[Group('MDTImportStringServicePulls')]
+    public function getDungeonRoute_givenTeemingRouteAndEnemyWithoutEnemyForcesTeemingOverride_fallsBackToEnemyForces(): void
+    {
+        $dungeonRoute               = null;
+        $importedRoute              = null;
+        $npcEnemyForces             = null;
+        $originalEnemyForcesTeeming = null;
+
+        try {
+            // Arrange - getSafeMdtEnemies() shuffles its results, and not every safe enemy's npc has an
+            // NpcEnemyForces row (e.g. shrouded-only npcs), so pull a larger candidate pool and use the
+            // first one that actually has a row to flip null on.
+            $dungeonRoute = $this->getMDTCompatibleDungeonRouteWithSafeEnemies(enemyCount: 10, attributes: ['teeming' => true]);
+            $safeEnemies  = $this->getSafeMdtEnemies($dungeonRoute, limit: 10);
+
+            $enemy = null;
+            foreach ($safeEnemies as $candidate) {
+                $npcEnemyForces = NpcEnemyForces::query()
+                    ->where('mapping_version_id', $dungeonRoute->mapping_version_id)
+                    ->where('npc_id', $candidate->npc_id)
+                    ->first();
+
+                if ($npcEnemyForces !== null) {
+                    $enemy = $candidate;
+
+                    break;
+                }
+            }
+
+            $this->assertNotNull($enemy, 'Expected at least one safe MDT enemy with an NpcEnemyForces row for this mapping version');
+
+            // enemy_forces_teeming can be null for an npc that has no teeming-specific override (#3912) -
+            // PullImporter must fall back to enemy_forces instead of passing null into addEnemyForces(int).
+            $originalEnemyForcesTeeming = $npcEnemyForces->enemy_forces_teeming;
+            $npcEnemyForces->update(['enemy_forces_teeming' => null]);
+
+            KillZone::factory()->withEnemies($enemy)->create([
+                'dungeon_route_id' => $dungeonRoute->id,
+                'index'            => 1,
+                'description'      => null,
+            ]);
+
+            $encodedString = $this->exportDungeonRouteToString($dungeonRoute);
+
+            // Act
+            $importedRoute = $this->importStringToDungeonRoute($encodedString);
+            $importedRoute->load(['killZones.killZoneEnemies']);
+
+            // Assert
+            $this->assertCount(1, $importedRoute->killZones);
+            $this->assertCount(1, $importedRoute->killZones->first()->killZoneEnemies);
+        } finally {
+            $npcEnemyForces?->update(['enemy_forces_teeming' => $originalEnemyForcesTeeming]);
             $importedRoute?->delete();
             $dungeonRoute?->delete();
         }


### PR DESCRIPTION
Closes #3912

:robot: `PullImporter::parseMdtNpcClonesInPull()` passed `NpcEnemyForces::enemy_forces_teeming` directly into `ImportStringPulls::addEnemyForces(int $amount)` for teeming routes. That column is `int|null` (no teeming-specific override for the npc) - confirmed via Sentry (`PHP-LARAVEL-RV`/`PHP-LARAVEL-RT`, both fingerprints of the same bug, all 6 events at `PullImporter.php:292`) that this null reaches production and raises an uncaught `TypeError` on `POST /ajax/mdt/details`.

Every other reader of this column already falls back to `enemy_forces` when it's null (`KillZone::getSkippableEnemyForces()`, `DungeonRoute`, `DungeonRouteRepository` all use `IFNULL(enemy_forces_teeming, enemy_forces)` in SQL) - `PullImporter` now does the same with `?? $npcEnemyForces->enemy_forces`.

## Test plan
- [x] Added `MDTImportStringServicePullsTest::getDungeonRoute_givenTeemingRouteAndEnemyWithoutEnemyForcesTeemingOverride_fallsBackToEnemyForces` - forces a real seeded `NpcEnemyForces` row's `enemy_forces_teeming` to `null`, exports/imports a teeming route through that npc, asserts it doesn't throw. Verified it reproduces the crash on the pre-fix code (`git stash` the fix, rerun - `TypeError`) and passes after.
- [x] Ran the new test 5x in a row to rule out flakiness from `getSafeMdtEnemies()`'s shuffle
- [x] `composer run fix` - no changes
- [x] `composer run analyse` - no errors