### PR TITLE
#3916 Widen AjaxKillZoneController::store()'s return type to allow its 404 fallback

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxKillZoneController.php
+++ b/app/Http/Controllers/Ajax/AjaxKillZoneController.php
@@ -253,7 +253,7 @@ class AjaxKillZoneController extends Controller
         APIKillZoneFormRequest       $request,
         DungeonRoute                 $dungeonRoute,
         ?KillZone                    $killZone = null,
-    ): KillZone {
+    ): KillZone|Response {
         // Outside the try/catch on purpose: an authorization failure must surface as a 403, not be
         // rewritten into the 404 below.
         $dungeonRoute = $this->authorizeKillZoneEdit($dungeonRoute, $killZone);

--- a/app/Http/Controllers/Ajax/AjaxKillZoneController.php
+++ b/app/Http/Controllers/Ajax/AjaxKillZoneController.php
@@ -273,12 +273,25 @@ class AjaxKillZoneController extends Controller
             $data['id'] = $killZone?->id ?? null; // @phpstan-ignore nullsafe.neverNull
 
             $result = $this->saveKillZone($coordinatesService, $dungeonRoute, $data, $killZone !== null);
-            $result->setAttribute('killzone_paths', $this->getKillZonePaths($killZonePathService, $dungeonRoute));
         } catch (AuthorizationException|HttpException $deliberateResponse) {
             // A 403 or a 422 we raised on purpose must not be rewritten into the 404 below
             throw $deliberateResponse;
-        } catch (Exception) {
-            $result = response(__('controller.generic.error.not_found'), Http::NOT_FOUND);
+        } catch (Exception $exception) {
+            report($exception);
+
+            return response(__('controller.generic.error.not_found'), Http::NOT_FOUND);
+        }
+
+        try {
+            // Deliberately isolated from the save above: the kill zone is already persisted and
+            // broadcast at this point, so a failure computing this cosmetic add-on must not be
+            // reported back to the client as a total failure - the caller would never learn the
+            // save actually succeeded and retry with an id-less payload, creating a duplicate.
+            $result->setAttribute('killzone_paths', $this->getKillZonePaths($killZonePathService, $dungeonRoute));
+        } catch (Exception $exception) {
+            report($exception);
+
+            $result->setAttribute('killzone_paths', []);
         }
 
         return $result;

--- a/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
@@ -8,6 +8,8 @@ use App\Models\KillZone\KillZone;
 use App\Models\KillZone\KillZoneEnemy;
 use App\Models\PublishedState;
 use App\Models\User;
+use App\Service\KillZonePath\KillZonePathServiceInterface;
+use Mockery;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Teapot\StatusCode;
@@ -142,6 +144,37 @@ final class AjaxKillZoneControllerTest extends DungeonRouteTestBase
             $route->killZones()->delete();
             $route->delete();
             $nonOwner->delete();
+        }
+    }
+
+    /**
+     * Guards #3916: store()'s catch(Exception) fallback assigned a plain Response to $result while
+     * the method's return type was declared as the non-nullable KillZone, so the fallback itself
+     * threw a TypeError instead of ever reaching the client as the intended 404.
+     */
+    #[Test]
+    public function store_givenGetKillZonePathsThrows_returnsNotFoundInsteadOfTypeError(): void
+    {
+        // Arrange
+        $killZonePathServiceMock = Mockery::mock(KillZonePathServiceInterface::class);
+        /** @var Mockery\Expectation $expectation */
+        $expectation = $killZonePathServiceMock->shouldReceive('calculateForRoute');
+        $expectation->andThrow(new \Exception('boom'));
+        app()->instance(KillZonePathServiceInterface::class, $killZonePathServiceMock);
+
+        try {
+            // Act
+            $response = $this->post(sprintf('/ajax/%s/killzone', $this->dungeonRoute->public_key), [
+                'color'   => '#ff0000',
+                'index'   => 1,
+                'enemies' => [],
+                'spells'  => [],
+            ]);
+
+            // Assert
+            $response->assertStatus(StatusCode::NOT_FOUND);
+        } finally {
+            $this->dungeonRoute->killZones()->delete();
         }
     }
 

--- a/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
@@ -150,10 +150,16 @@ final class AjaxKillZoneControllerTest extends DungeonRouteTestBase
     /**
      * Guards #3916: store()'s catch(Exception) fallback assigned a plain Response to $result while
      * the method's return type was declared as the non-nullable KillZone, so the fallback itself
-     * threw a TypeError instead of ever reaching the client as the intended 404.
+     * threw a TypeError instead of ever reaching the client as the intended 404 (this specific
+     * trigger - getKillZonePaths() throwing - is #3917's facade-floor crash in practice).
+     *
+     * Also guards the cold-review follow-up on #3927: the kill zone is already saved and broadcast
+     * by the time getKillZonePaths() runs, so a failure there must not be reported as a total
+     * failure - the client would never learn the save succeeded, and would retry with an id-less
+     * payload, creating a duplicate kill zone.
      */
     #[Test]
-    public function store_givenGetKillZonePathsThrows_returnsNotFoundInsteadOfTypeError(): void
+    public function store_givenGetKillZonePathsThrows_savesTheKillZoneAndReturnsEmptyPathsInsteadOfFailingTheWholeRequest(): void
     {
         // Arrange
         $killZonePathServiceMock = Mockery::mock(KillZonePathServiceInterface::class);
@@ -171,8 +177,11 @@ final class AjaxKillZoneControllerTest extends DungeonRouteTestBase
                 'spells'  => [],
             ]);
 
-            // Assert
-            $response->assertStatus(StatusCode::NOT_FOUND);
+            // Assert - no TypeError, no 404: the save itself succeeded, only the cosmetic paths
+            // add-on degrades
+            $response->assertSuccessful();
+            $response->assertJsonPath('killzone_paths', []);
+            $this->assertSame(1, $this->dungeonRoute->killZones()->count());
         } finally {
             $this->dungeonRoute->killZones()->delete();
         }


### PR DESCRIPTION
:robot: Closes #3916

`AjaxKillZoneController::store()` declared a non-nullable `KillZone` return type, but its `catch (Exception)` fallback assigns a plain `Response` (a 404) to `$result`. That fallback itself threw a `TypeError` instead of ever reaching the client as the intended 404 — masking whatever the real underlying exception was (e.g. #3917's facade-floor crash in `getKillZonePaths()`, filed the same triage pass) as an opaque 500.

Fix: widen the return type to `KillZone|Response`.

Following a cold review, also:
- `report()` the swallowed exception in the fallback before returning the 404, so a genuine failure still reaches Sentry instead of vanishing silently now that the fallback actually works.
- Isolate `getKillZonePaths()` into its own try/catch. By the time it runs, the kill zone is already saved and broadcast — a failure there now degrades to `killzone_paths: []` instead of discarding the whole request as a 404, so the client still gets its id back and a natural retry can't create a duplicate kill zone.

Regression test (`store_givenGetKillZonePathsThrows_savesTheKillZoneAndReturnsEmptyPathsInsteadOfFailingTheWholeRequest`) mocks `KillZonePathServiceInterface::calculateForRoute()` to throw and asserts the kill zone is saved with an empty `killzone_paths` in the response. Confirmed it reproduces the exact reported `TypeError: ... Return value must be of type App\Models\KillZone\KillZone, Illuminate\Http\Response returned` against the pre-fix code.
