### PR TITLE
#3917 Skip facade-floor kill zones when building the ingame path graph

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxKillZoneController.php
+++ b/app/Http/Controllers/Ajax/AjaxKillZoneController.php
@@ -165,6 +165,15 @@ class AjaxKillZoneController extends Controller
             // A location the user just placed is worth failing on, so they get feedback instead of
             // watching their marker silently disappear. 422 as a literal, like
             // abortIfDungeonRouteLimitReached() - Teapot's Http does not expose UNPROCESSABLE_ENTITY
+            //
+            // Floor union areas are expected to tile the entire facade map with no gaps, so this
+            // should never trigger - reported to diagnose which mapping version/floor unions do.
+            report(new Exception(sprintf(
+                'Facade location could not be converted to a real floor for mapping version %d, submitted floor %d',
+                $dungeonRoute->mappingVersion->id,
+                $submittedFloor->id,
+            )));
+
             abort(422, __('controller.killzone.error.facade_location_not_convertible'));
         }
 

--- a/app/Http/Controllers/Ajax/AjaxKillZoneController.php
+++ b/app/Http/Controllers/Ajax/AjaxKillZoneController.php
@@ -111,6 +111,7 @@ class AjaxKillZoneController extends Controller
     private function convertSubmittedFacadeLocation(
         CoordinatesServiceInterface $coordinatesService,
         DungeonRoute                $dungeonRoute,
+        KillZone                    $killZone,
         array                      &                       $data,
     ): ?LatLng {
         if (!isset($data['floor_id'], $data['lat'], $data['lng'])) {
@@ -147,12 +148,23 @@ class AjaxKillZoneController extends Controller
 
         // The location falls outside every floor union area, so it belongs to no real floor at all -
         // the dead space of the combined image (0.003% of it, measured across every facade dungeon).
-        // Refuse the save rather than persist a facade floor: every consumer downstream (ingame
-        // coordinate conversion, kill zone paths, MDT export) assumes a real floor, and silently
-        // dropping the location would throw away what the user just placed with no feedback.
+        // It may never be persisted: every consumer downstream (ingame coordinate conversion, kill
+        // zone paths, MDT export) assumes a real floor.
         if ($convertedFloor === null || $convertedFloor->facade) {
-            // 422 as a literal, like abortIfDungeonRouteLimitReached() - Teapot's Http does not
-            // expose UNPROCESSABLE_ENTITY
+            // A location the client is merely echoing back unchanged comes from a row corrupted
+            // before this fix, and refusing it would make that pull uneditable forever. Drop it and
+            // let the save land - the KillZonePathService guard covers the row until it is re-placed.
+            if (!$this->isNewLocationForKillZone($killZone, $data)) {
+                $data['floor_id'] = null;
+                $data['lat']      = null;
+                $data['lng']      = null;
+
+                return null;
+            }
+
+            // A location the user just placed is worth failing on, so they get feedback instead of
+            // watching their marker silently disappear. 422 as a literal, like
+            // abortIfDungeonRouteLimitReached() - Teapot's Http does not expose UNPROCESSABLE_ENTITY
             abort(422, __('controller.killzone.error.facade_location_not_convertible'));
         }
 
@@ -161,6 +173,24 @@ class AjaxKillZoneController extends Controller
         $data['lng']      = $convertedLatLng->getLng();
 
         return $submittedLatLng;
+    }
+
+    /**
+     * Whether the submitted location differs from the one the kill zone already holds, i.e. whether
+     * the user actually placed or moved the kill area rather than the client echoing back what it
+     * loaded. Compared with a tolerance because the coordinates round-trip through JSON as strings.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function isNewLocationForKillZone(KillZone $killZone, array $data): bool
+    {
+        if (!$killZone->exists || $killZone->floor_id === null) {
+            return true;
+        }
+
+        return (int)$killZone->floor_id !== (int)$data['floor_id'] ||
+            abs((float)$killZone->lat - (float)$data['lat']) > 0.0001 ||
+            abs((float)$killZone->lng - (float)$data['lng']) > 0.0001;
     }
 
     /**
@@ -190,7 +220,7 @@ class AjaxKillZoneController extends Controller
         $this->abortIfDungeonRouteLimitReached($dungeonroute, DungeonRouteLimitType::KillZones);
 
         // Must happen before the row is written - the database may never hold a facade floor
-        $submittedFacadeLatLng = $this->convertSubmittedFacadeLocation($coordinatesService, $dungeonroute, $data);
+        $submittedFacadeLatLng = $this->convertSubmittedFacadeLocation($coordinatesService, $dungeonroute, $killZone, $data);
 
         $beforeModel = clone $killZone;
 

--- a/app/Http/Controllers/Ajax/AjaxKillZoneController.php
+++ b/app/Http/Controllers/Ajax/AjaxKillZoneController.php
@@ -12,9 +12,11 @@ use App\Http\Requests\KillZone\APIDeleteAllFormRequest;
 use App\Http\Requests\KillZone\APIKillZoneFormRequest;
 use App\Http\Requests\KillZone\APIKillZoneMassFormRequest;
 use App\Jobs\RefreshEnemyForces;
+use App\Logic\Structs\LatLng;
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\DungeonRoute\DungeonRouteLimitType;
 use App\Models\Enemy;
+use App\Models\Floor\Floor;
 use App\Models\KillZone\KillZone;
 use App\Models\KillZone\KillZoneEnemy;
 use App\Models\KillZone\KillZoneSpell;
@@ -89,6 +91,66 @@ class AjaxKillZoneController extends Controller
     }
 
     /**
+     * Rewrites a submitted kill zone location that is expressed on a facade (combined multi-floor)
+     * map onto the real floor it belongs to, mutating $data so the conversion happens *before* the
+     * row is written rather than as a second update afterwards.
+     *
+     * Whether the submitted location is a facade location is derived from the submitted floor's own
+     * `facade` flag, deliberately not from the acting user's map facade style: that style is
+     * request-scoped state which the save request does not necessarily share with the request that
+     * rendered the map the location was placed on, and a mismatch used to persist the facade floor
+     * verbatim (#3917).
+     *
+     * @throws HttpException when the facade location cannot be expressed on any real floor
+     *
+     * @param  array<string, mixed> $data
+     * @return LatLng|null          the location exactly as submitted, so the response can echo it back in the
+     *                              plane the client is rendering, or null if no facade location was submitted
+     */
+    private function convertSubmittedFacadeLocation(
+        CoordinatesServiceInterface $coordinatesService,
+        DungeonRoute                $dungeonRoute,
+        array                      &                       $data,
+    ): ?LatLng {
+        if (!isset($data['floor_id'], $data['lat'], $data['lng'])) {
+            return null;
+        }
+
+        /** @var Floor|null $submittedFloor */
+        $submittedFloor = Floor::find($data['floor_id']);
+
+        if ($submittedFloor === null || !$submittedFloor->facade) {
+            return null;
+        }
+
+        $submittedLatLng = new LatLng((float)$data['lat'], (float)$data['lng'], $submittedFloor);
+
+        $convertedLatLng = $coordinatesService->convertFacadeMapLocationToMapLocation(
+            $dungeonRoute->mappingVersion,
+            $submittedLatLng,
+        );
+
+        $convertedFloor = $convertedLatLng->getFloor();
+
+        // convertFacadeMapLocationToMapLocation() is a no-op when the mapping version does not have
+        // facades enabled, and it hands back the facade floor unchanged when the location falls
+        // outside every floor union area. Refuse the save rather than persist a facade floor: every
+        // consumer downstream (ingame coordinate conversion, kill zone paths, MDT export) assumes a
+        // real floor, and silently dropping the location would throw away what the user just placed.
+        if ($convertedFloor === null || $convertedFloor->facade) {
+            // 422 as a literal, like abortIfDungeonRouteLimitReached() - Teapot's Http does not
+            // expose UNPROCESSABLE_ENTITY
+            abort(422, __('controller.killzone.error.facade_location_not_convertible'));
+        }
+
+        $data['floor_id'] = $convertedFloor->id;
+        $data['lat']      = $convertedLatLng->getLat();
+        $data['lng']      = $convertedLatLng->getLng();
+
+        return $submittedLatLng;
+    }
+
+    /**
      * @throws \Exception
      *
      * @param array<string, mixed> $data
@@ -113,6 +175,9 @@ class AjaxKillZoneController extends Controller
         $dungeonroute = $killZone->dungeonRoute ?? $dungeonroute;
 
         $this->abortIfDungeonRouteLimitReached($dungeonroute, DungeonRouteLimitType::KillZones);
+
+        // Must happen before the row is written - the database may never hold a facade floor
+        $submittedFacadeLatLng = $this->convertSubmittedFacadeLocation($coordinatesService, $dungeonroute, $data);
 
         $beforeModel = clone $killZone;
 
@@ -200,34 +265,13 @@ class AjaxKillZoneController extends Controller
                 $afterAttributes['enemies']  = $killZone->enemies->pluck('id');
             });
 
-            // If killzone has lat/lng set, convert it to facade location if it's not already
-            $useFacade = $dungeonroute->mappingVersion->facade_enabled &&
-                User::getCurrentUserMapFacadeStyle() === User::MAP_FACADE_STYLE_FACADE;
-
-            if ($killZone->hasKillArea()) {
-                // Track this latlng so we can re-echo it back to the user if we still want to use facades
-                $originalLatLng = $killZone->getLatLng();
-
-                // Only when we actually have a kill location set!
-                if ($useFacade && $originalLatLng->getFloor() !== null) {
-                    $latLng = $coordinatesService->convertFacadeMapLocationToMapLocation(
-                        $dungeonroute->mappingVersion,
-                        $originalLatLng,
-                    );
-
-                    // Save the killzone with converted lat/lngs in the database
-                    $killZone->update([
-                        'lat'      => $latLng->getLat(),
-                        'lng'      => $latLng->getLng(),
-                        'floor_id' => $latLng->getFloor()->id,
-                    ]);
-                }
-
-                // But echo it back as facade!
-                $killZone->setAttribute('lat', $originalLatLng->getLat());
-                $killZone->setAttribute('lng', $originalLatLng->getLng());
-                $killZone->setAttribute('floor_id', $originalLatLng->getFloor()->id);
-                $killZone->setRelation('floor', $originalLatLng->getFloor());
+            // The row now holds the real-floor location; echo the location back in the plane the
+            // client submitted it in, so the marker it just placed does not jump on its map
+            if ($submittedFacadeLatLng !== null) {
+                $killZone->setAttribute('lat', $submittedFacadeLatLng->getLat());
+                $killZone->setAttribute('lng', $submittedFacadeLatLng->getLng());
+                $killZone->setAttribute('floor_id', $submittedFacadeLatLng->getFloor()->id);
+                $killZone->setRelation('floor', $submittedFacadeLatLng->getFloor());
             }
 
             if (Auth::check()) {

--- a/app/Http/Controllers/Ajax/AjaxKillZoneController.php
+++ b/app/Http/Controllers/Ajax/AjaxKillZoneController.php
@@ -101,11 +101,12 @@ class AjaxKillZoneController extends Controller
      * rendered the map the location was placed on, and a mismatch used to persist the facade floor
      * verbatim (#3917).
      *
-     * @throws HttpException when the facade location cannot be expressed on any real floor
+     * @throws HttpException when a facade location on a facade-rendering route belongs to no real floor
      *
      * @param  array<string, mixed> $data
      * @return LatLng|null          the location exactly as submitted, so the response can echo it back in the
-     *                              plane the client is rendering, or null if no facade location was submitted
+     *                              plane the client is rendering, or null if no facade location was
+     *                              submitted or the submitted one was dropped
      */
     private function convertSubmittedFacadeLocation(
         CoordinatesServiceInterface $coordinatesService,
@@ -123,6 +124,18 @@ class AjaxKillZoneController extends Controller
             return null;
         }
 
+        // The route's map never renders a facade, so this cannot be a location the user just placed
+        // on one - it is a bad location echoed back by a client that loaded an already-corrupted row
+        // (convertFacadeMapLocationToMapLocation() would hand it straight back unconverted anyway).
+        // Drop it so the save still succeeds: failing here would make every such pull uneditable.
+        if (!$dungeonRoute->mappingVersion->facade_enabled) {
+            $data['floor_id'] = null;
+            $data['lat']      = null;
+            $data['lng']      = null;
+
+            return null;
+        }
+
         $submittedLatLng = new LatLng((float)$data['lat'], (float)$data['lng'], $submittedFloor);
 
         $convertedLatLng = $coordinatesService->convertFacadeMapLocationToMapLocation(
@@ -132,11 +145,11 @@ class AjaxKillZoneController extends Controller
 
         $convertedFloor = $convertedLatLng->getFloor();
 
-        // convertFacadeMapLocationToMapLocation() is a no-op when the mapping version does not have
-        // facades enabled, and it hands back the facade floor unchanged when the location falls
-        // outside every floor union area. Refuse the save rather than persist a facade floor: every
-        // consumer downstream (ingame coordinate conversion, kill zone paths, MDT export) assumes a
-        // real floor, and silently dropping the location would throw away what the user just placed.
+        // The location falls outside every floor union area, so it belongs to no real floor at all -
+        // the dead space of the combined image (0.003% of it, measured across every facade dungeon).
+        // Refuse the save rather than persist a facade floor: every consumer downstream (ingame
+        // coordinate conversion, kill zone paths, MDT export) assumes a real floor, and silently
+        // dropping the location would throw away what the user just placed with no feedback.
         if ($convertedFloor === null || $convertedFloor->facade) {
             // 422 as a literal, like abortIfDungeonRouteLimitReached() - Teapot's Http does not
             // expose UNPROCESSABLE_ENTITY

--- a/app/Http/Middleware/ResetsMapFacadeStyleOverride.php
+++ b/app/Http/Middleware/ResetsMapFacadeStyleOverride.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Clears the map facade style override at the start of every request.
+ *
+ * User::forceMapFacadeStyle() writes a *static* property, which under Octane/Swoole is worker state
+ * that lives until the worker is recycled - not request state. The three controllers that render an
+ * embedded route, dungeon explore or heatmap map set it from a query parameter and never clear it,
+ * so without this every later request handled by that same worker inherits the map facade style of
+ * whoever hit that page. That is what let a kill zone save decide it was not looking at a facade map
+ * while the client had placed its location on one, persisting a facade floor_id (#3917).
+ */
+class ResetsMapFacadeStyleOverride
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        User::forceMapFacadeStyle(null);
+
+        return $next($request);
+    }
+}

--- a/app/Service/KillZonePath/KillZonePathService.php
+++ b/app/Service/KillZonePath/KillZonePathService.php
@@ -126,7 +126,12 @@ class KillZonePathService implements KillZonePathServiceInterface
         $killZoneNodeIds = [];
         foreach ($killZones as $killZone) {
             $killLocation = $killZone->getKillLocation();
-            if ($killLocation === null || $killLocation->getFloor() === null) {
+            // A facade floor's coordinates aren't real ingame coordinates, so
+            // calculateIngameLocationForMapLocation() below rejects them - mirrors the floor-switch
+            // marker skip above (#3917). Excluding the kill zone from the graph entirely (rather than
+            // resolving its real floor) matches that same precedent: this is the collaborative-editing
+            // combined view, not stored data the path visualization needs to trust.
+            if ($killLocation === null || $killLocation->getFloor() === null || $killLocation->getFloor()->facade) {
                 continue;
             }
 

--- a/app/Service/KillZonePath/KillZonePathService.php
+++ b/app/Service/KillZonePath/KillZonePathService.php
@@ -96,12 +96,19 @@ class KillZonePathService implements KillZonePathServiceInterface
 
         // --- Dungeon start node ---
         if ($dungeonStart !== null) {
-            $startLatLng    = $dungeonStart->getLatLng();
-            $nodes['start'] = new PathNode(
-                'start',
-                $startLatLng,
-                $this->coordinatesService->calculateIngameLocationForMapLocation($startLatLng),
-            );
+            $startLatLng = $dungeonStart->getLatLng();
+
+            // Same facade-floor guard as the kill-zone nodes below (#3917) - a stale
+            // dungeon_start_map_icon_id can point at a map icon left on an old mapping version's
+            // facade floor. A missing start node is already an anticipated state everywhere this is
+            // consumed (both findPathsToKillZones() and computePathSegments() check isset()).
+            if ($startLatLng->getFloor()?->facade !== true) {
+                $nodes['start'] = new PathNode(
+                    'start',
+                    $startLatLng,
+                    $this->coordinatesService->calculateIngameLocationForMapLocation($startLatLng),
+                );
+            }
         }
 
         // --- Floor-switch marker nodes ---

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,6 +11,7 @@ use App\Http\Middleware\LegalAgreed;
 use App\Http\Middleware\OnlyAjax;
 use App\Http\Middleware\PoweredBySwoole;
 use App\Http\Middleware\ReadOnlyMode;
+use App\Http\Middleware\ResetsMapFacadeStyleOverride;
 use App\Http\Middleware\TracksUserIpAddress;
 use App\Http\Middleware\TrustProxies;
 use App\Http\Middleware\ViewCacheBuster;
@@ -64,6 +65,9 @@ return Application::configure(basePath: dirname(__DIR__))
             ServerTimingMiddleware::class,
             CheckForMaintenanceMode::class,
             PoweredBySwoole::class,
+            // Must run before any controller that calls User::forceMapFacadeStyle() - it writes a
+            // static that would otherwise leak into the next request on the same Octane worker
+            ResetsMapFacadeStyleOverride::class,
         ]);
 
         $middleware->api([

--- a/lang/en_US/controller.php
+++ b/lang/en_US/controller.php
@@ -123,6 +123,11 @@ return [
             'not_found'                  => 'Not found',
         ],
     ],
+    'killzone' => [
+        'error' => [
+            'facade_location_not_convertible' => 'Unable to place the pull here - this location does not belong to any floor of this dungeon',
+        ],
+    ],
     'oauthlogin' => [
         'flash' => [
             'registered_successfully' => 'Registered successfully. Enjoy the website!',

--- a/tests/Feature/App/Service/KillZonePath/KillZonePathServiceTest.php
+++ b/tests/Feature/App/Service/KillZonePath/KillZonePathServiceTest.php
@@ -230,7 +230,7 @@ final class KillZonePathServiceTest extends PublicTestCase
      * surface uncaught on save.
      */
     #[Test]
-    public function calculateForRoute_givenKillZoneOnFacadeFloor_skipsItInsteadOfThrowing(): void
+    public function findPathsToKillZones_givenKillZoneOnFacadeFloor_skipsKillZoneInsteadOfThrowing(): void
     {
         // Arrange
         [$dungeon, $mappingVersion] = $this->findDungeon(facadeEnabled: true);
@@ -266,8 +266,12 @@ final class KillZonePathServiceTest extends PublicTestCase
             $service = app(KillZonePathServiceInterface::class);
             $result  = $service->findPathsToKillZones($dungeonRoute);
 
-            // Assert - no InvalidArgumentException, and the real-floor kill zone is still resolvable
-            $this->assertArrayNotHasKey($facadeKillZone->id, $result);
+            // Assert - no InvalidArgumentException, the facade kill zone is excluded, and the
+            // real-floor one is the only remaining entry (findPathsToKillZones() creates a key for
+            // every non-skipped kill zone regardless of whether a path was found, so asserting the
+            // count pins down that exactly one kill zone survived rather than merely that the key
+            // exists)
+            $this->assertCount(1, $result);
             $this->assertArrayHasKey($realKillZone->id, $result);
         } finally {
             $realKillZone->delete();

--- a/tests/Feature/App/Service/KillZonePath/KillZonePathServiceTest.php
+++ b/tests/Feature/App/Service/KillZonePath/KillZonePathServiceTest.php
@@ -11,11 +11,14 @@ use App\Models\Mapping\MappingVersion;
 use App\Service\KillZonePath\KillZonePathServiceInterface;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Traits\ProvidesDungeon;
 use Tests\TestCases\PublicTestCase;
 
 #[Group('KillZonePath')]
 final class KillZonePathServiceTest extends PublicTestCase
 {
+    use ProvidesDungeon;
+
     #[\Override]
     protected function setUp(): void
     {
@@ -217,6 +220,59 @@ final class KillZonePathServiceTest extends PublicTestCase
             $markerA->delete();
             $dungeonRoute->delete();
             $mappingVersion->delete();
+        }
+    }
+
+    /**
+     * Guards #3917: a kill zone whose location was placed on a facade (combined multi-floor) view
+     * has a facade floor_id, which CoordinatesService::calculateIngameLocationForMapLocation()
+     * rejects - loadAndBuildGraph() must skip that kill zone instead of letting the exception
+     * surface uncaught on save.
+     */
+    #[Test]
+    public function calculateForRoute_givenKillZoneOnFacadeFloor_skipsItInsteadOfThrowing(): void
+    {
+        // Arrange
+        [$dungeon, $mappingVersion] = $this->findDungeon(facadeEnabled: true);
+        /** @var Floor $facadeFloor */
+        $facadeFloor = $dungeon->floors()->where('facade', true)->firstOrFail();
+        /** @var Floor $realFloor */
+        $realFloor = $dungeon->floors()->where('facade', false)->firstOrFail();
+
+        $dungeonRoute = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
+
+        // On the facade view, not a real floor - exactly how #3917's reported latlng was stored
+        $facadeKillZone = KillZone::factory()->create([
+            'dungeon_route_id' => $dungeonRoute->id,
+            'floor_id'         => $facadeFloor->id,
+            'lat'              => -100.0,
+            'lng'              => 100.0,
+            'index'            => 1,
+        ]);
+        $realKillZone = KillZone::factory()->create([
+            'dungeon_route_id' => $dungeonRoute->id,
+            'floor_id'         => $realFloor->id,
+            'lat'              => -50.0,
+            'lng'              => 50.0,
+            'index'            => 2,
+        ]);
+
+        try {
+            // Act
+            /** @var KillZonePathServiceInterface $service */
+            $service = app(KillZonePathServiceInterface::class);
+            $result  = $service->findPathsToKillZones($dungeonRoute);
+
+            // Assert - no InvalidArgumentException, and the real-floor kill zone is still resolvable
+            $this->assertArrayNotHasKey($facadeKillZone->id, $result);
+            $this->assertArrayHasKey($realKillZone->id, $result);
+        } finally {
+            $realKillZone->delete();
+            $facadeKillZone->delete();
+            $dungeonRoute->delete();
         }
     }
 }

--- a/tests/Feature/App/Service/MDT/MDTImportStringServicePullsTest.php
+++ b/tests/Feature/App/Service/MDT/MDTImportStringServicePullsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\App\Service\MDT;
 
+use App\Models\Enemy;
 use App\Models\KillZone\KillZone;
 use App\Models\Npc\NpcEnemyForces;
 use PHPUnit\Framework\Attributes\Group;
@@ -90,27 +91,29 @@ class MDTImportStringServicePullsTest extends MDTImportStringServiceTestBase
         $originalEnemyForcesTeeming = null;
 
         try {
-            // Arrange - getSafeMdtEnemies() shuffles its results, and not every safe enemy's npc has an
-            // NpcEnemyForces row (e.g. shrouded-only npcs), so pull a larger candidate pool and use the
-            // first one that actually has a row to flip null on.
-            $dungeonRoute = $this->getMDTCompatibleDungeonRouteWithSafeEnemies(enemyCount: 10, attributes: ['teeming' => true]);
-            $safeEnemies  = $this->getSafeMdtEnemies($dungeonRoute, limit: 10);
+            // Arrange - the enemy must have an NpcEnemyForces row to flip enemy_forces_teeming null on,
+            // and not every safe enemy's npc has one (e.g. shrouded-only npcs) - one MDT dungeon has
+            // none at all. Require it as part of the draw, not afterwards, or the draw succeeds and
+            // the test fails on something it never guaranteed.
+            $hasNpcEnemyForces = static fn(Enemy $enemy): bool => NpcEnemyForces::query()
+                ->where('mapping_version_id', $enemy->mapping_version_id)
+                ->where('npc_id', $enemy->npc_id)
+                ->exists();
 
-            $enemy = null;
-            foreach ($safeEnemies as $candidate) {
-                $npcEnemyForces = NpcEnemyForces::query()
-                    ->where('mapping_version_id', $dungeonRoute->mapping_version_id)
-                    ->where('npc_id', $candidate->npc_id)
-                    ->first();
+            $dungeonRoute = $this->getMDTCompatibleDungeonRouteWithSafeEnemies(
+                enemyCount:  1,
+                attributes:  ['teeming' => true],
+                enemyFilter: $hasNpcEnemyForces,
+            );
 
-                if ($npcEnemyForces !== null) {
-                    $enemy = $candidate;
+            /** @var Enemy $enemy */
+            $enemy = $this->getSafeMdtEnemies($dungeonRoute, limit: 1, enemyFilter: $hasNpcEnemyForces)->firstOrFail();
 
-                    break;
-                }
-            }
-
-            $this->assertNotNull($enemy, 'Expected at least one safe MDT enemy with an NpcEnemyForces row for this mapping version');
+            /** @var NpcEnemyForces $npcEnemyForces */
+            $npcEnemyForces = NpcEnemyForces::query()
+                ->where('mapping_version_id', $dungeonRoute->mapping_version_id)
+                ->where('npc_id', $enemy->npc_id)
+                ->firstOrFail();
 
             // enemy_forces_teeming can be null for an npc that has no teeming-specific override (#3912) -
             // PullImporter must fall back to enemy_forces instead of passing null into addEnemyForces(int).

--- a/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
@@ -4,21 +4,26 @@ namespace Tests\Feature\Controller\Ajax;
 
 use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Enemy;
+use App\Models\Floor\Floor;
 use App\Models\KillZone\KillZone;
 use App\Models\KillZone\KillZoneEnemy;
 use App\Models\PublishedState;
 use App\Models\User;
+use App\Service\Coordinates\CoordinatesServiceInterface;
 use App\Service\KillZonePath\KillZonePathServiceInterface;
 use Mockery;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Teapot\StatusCode;
 use Tests\Feature\Controller\DungeonRouteTestBase;
+use Tests\Feature\Traits\ProvidesDungeon;
 
 #[Group('Controller')]
 #[Group('KillZone')]
 final class AjaxKillZoneControllerTest extends DungeonRouteTestBase
 {
+    use ProvidesDungeon;
+
     #[\Override]
     protected function setUp(): void
     {
@@ -333,6 +338,73 @@ final class AjaxKillZoneControllerTest extends DungeonRouteTestBase
         } finally {
             KillZoneEnemy::query()->where('id', $killZoneEnemy->id)->delete();
             KillZone::query()->where('id', $killZone->id)->delete();
+        }
+    }
+
+    /**
+     * Guards #3917: the client places a pull's kill area in whatever plane the map it rendered was
+     * using, so on a facade (combined multi-floor) map it submits the facade floor and facade-plane
+     * coordinates. saveKillZone() used to convert those only when the *acting user's* map facade
+     * style said facade - state the save request need not share with the request that rendered the
+     * map (it leaks across requests on an Octane worker) - and stored the facade floor verbatim
+     * otherwise. The conversion must be driven by the submitted floor instead.
+     */
+    #[Test]
+    public function store_givenAFacadeLocationWhileTheMapFacadeStyleSaysSplitFloors_persistsTheLocationOnItsRealFloor(): void
+    {
+        // Arrange
+        [$dungeon, $mappingVersion] = $this->findDungeon(facadeEnabled: true, minEnemies: 1);
+        /** @var Floor $facadeFloor */
+        $facadeFloor = $dungeon->floors()->where('facade', true)->firstOrFail();
+        /** @var Enemy $enemy */
+        $enemy = $mappingVersion->enemies()->whereHas('floor', static fn($query) => $query->where('facade', false))
+            ->whereNotNull('lat')
+            ->firstOrFail();
+
+        /** @var CoordinatesServiceInterface $coordinatesService */
+        $coordinatesService = app(CoordinatesServiceInterface::class);
+        // Exactly the location the client would submit for a kill area placed on top of that enemy
+        // while the facade map is rendered
+        $facadeLatLng = $coordinatesService->convertMapLocationToFacadeMapLocation($mappingVersion, $enemy->getLatLng());
+        $this->assertTrue((bool)$facadeLatLng->getFloor()->facade, 'Expected the enemy to live inside a floor union area');
+
+        $dungeonRoute = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
+
+        // The state an /embed, /explore or /heatmap request handled by the same worker leaves behind
+        User::forceMapFacadeStyle(User::MAP_FACADE_STYLE_SPLIT_FLOORS);
+
+        try {
+            // Act
+            $response = $this->post(sprintf('/ajax/%s/killzone', $dungeonRoute->public_key), [
+                'color'    => '#ff0000',
+                'index'    => 1,
+                'floor_id' => $facadeFloor->id,
+                'lat'      => $facadeLatLng->getLat(),
+                'lng'      => $facadeLatLng->getLng(),
+                'enemies'  => [],
+                'spells'   => [],
+            ]);
+
+            // Assert
+            $response->assertSuccessful();
+
+            /** @var KillZone $killZone */
+            $killZone = $dungeonRoute->killZones()->firstOrFail();
+            $this->assertNotEquals($facadeFloor->id, $killZone->floor_id);
+            $this->assertFalse((bool)$killZone->floor->facade);
+            // Converting the enemy's own location and back must land on the enemy's floor again
+            $this->assertEquals($enemy->floor_id, $killZone->floor_id);
+
+            // ...but the response still echoes the location back in the plane the client renders,
+            // so the marker the user just placed does not jump
+            $response->assertJsonPath('floor_id', $facadeFloor->id);
+        } finally {
+            User::forceMapFacadeStyle(null);
+            $dungeonRoute->killZones()->delete();
+            $dungeonRoute->delete();
         }
     }
 

--- a/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
@@ -373,8 +373,15 @@ final class AjaxKillZoneControllerTest extends DungeonRouteTestBase
             'mapping_version_id' => $mappingVersion->id,
         ]);
 
-        // The state an /embed, /explore or /heatmap request handled by the same worker leaves behind
-        User::forceMapFacadeStyle(User::MAP_FACADE_STYLE_SPLIT_FLOORS);
+        // A persisted preference rather than User::forceMapFacadeStyle(), which the new
+        // ResetsMapFacadeStyleOverride middleware would clear before the controller ever read it -
+        // this is the surviving mismatch: the user flipped the setting in another tab while this map
+        // tab kept rendering the facade, so the client still submits facade coordinates
+        /** @var User $user */
+        $user                   = User::findOrFail(1);
+        $originalMapFacadeStyle = $user->map_facade_style;
+        $user->update(['map_facade_style' => User::MAP_FACADE_STYLE_SPLIT_FLOORS]);
+        $this->actingAs($user->fresh());
 
         try {
             // Act
@@ -402,7 +409,47 @@ final class AjaxKillZoneControllerTest extends DungeonRouteTestBase
             // so the marker the user just placed does not jump
             $response->assertJsonPath('floor_id', $facadeFloor->id);
         } finally {
-            User::forceMapFacadeStyle(null);
+            $user->update(['map_facade_style' => $originalMapFacadeStyle]);
+            $dungeonRoute->killZones()->delete();
+            $dungeonRoute->delete();
+        }
+    }
+
+    /**
+     * Guards #3917: a location the user just placed on a facade map that belongs to no real floor -
+     * the dead space of the combined image - must be refused with feedback rather than persisted as
+     * a facade floor or silently dropped. This is the only branch that can hard-fail a save, so it
+     * must stay reachable only for a genuinely new location (see the sibling test below).
+     */
+    #[Test]
+    public function store_givenANewFacadeLocationThatBelongsToNoRealFloor_refusesTheSave(): void
+    {
+        // Arrange
+        [$dungeon, $mappingVersion] = $this->findDungeon(facadeEnabled: true);
+        /** @var Floor $facadeFloor */
+        $facadeFloor = $dungeon->floors()->where('facade', true)->firstOrFail();
+
+        $dungeonRoute = DungeonRoute::factory()->create([
+            'dungeon_id'         => $dungeon->id,
+            'mapping_version_id' => $mappingVersion->id,
+        ]);
+
+        try {
+            // Act - far outside the map, so no floor union area can contain it
+            $response = $this->post(sprintf('/ajax/%s/killzone', $dungeonRoute->public_key), [
+                'color'    => '#ff0000',
+                'index'    => 1,
+                'floor_id' => $facadeFloor->id,
+                'lat'      => -100000.0,
+                'lng'      => 100000.0,
+                'enemies'  => [],
+                'spells'   => [],
+            ]);
+
+            // Assert - refused, and nothing was written
+            $response->assertStatus(422);
+            $this->assertSame(0, $dungeonRoute->killZones()->count());
+        } finally {
             $dungeonRoute->killZones()->delete();
             $dungeonRoute->delete();
         }

--- a/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxKillZoneControllerTest.php
@@ -409,6 +409,56 @@ final class AjaxKillZoneControllerTest extends DungeonRouteTestBase
     }
 
     /**
+     * Guards #3917: a kill zone that already carries a facade floor_id on a route whose mapping
+     * version does not render a facade cannot be converted - convertFacadeMapLocationToMapLocation()
+     * hands the facade floor straight back. Rejecting the save would make every such already-corrupted
+     * pull uneditable, which is worse than the bug; the location is dropped instead so the save lands.
+     */
+    #[Test]
+    public function store_givenAFacadeFloorOnARouteThatDoesNotRenderAFacade_dropsTheLocationInsteadOfFailingTheSave(): void
+    {
+        // Arrange - a facade floor that has nothing to do with this (non-facade) route's dungeon,
+        // exactly the shape of a row corrupted before this fix
+        /** @var Floor $foreignFacadeFloor */
+        $foreignFacadeFloor = Floor::where('facade', true)->firstOrFail();
+        $this->assertFalse((bool)$this->dungeonRoute->mappingVersion->facade_enabled);
+
+        $killZone = KillZone::factory()->create([
+            'dungeon_route_id' => $this->dungeonRoute->id,
+            'floor_id'         => $foreignFacadeFloor->id,
+            'lat'              => -100.0,
+            'lng'              => 100.0,
+            'color'            => '#000000',
+            'index'            => 1,
+        ]);
+
+        try {
+            // Act - the client echoes the stored location back while changing something else
+            $response = $this->put(sprintf('/ajax/%s/killzone/%s', $this->dungeonRoute->public_key, $killZone->id), [
+                'color'    => '#ff0000',
+                'index'    => 1,
+                'floor_id' => $foreignFacadeFloor->id,
+                'lat'      => -100.0,
+                'lng'      => 100.0,
+                'enemies'  => [],
+                'spells'   => [],
+            ]);
+
+            // Assert - the save succeeds, and the unusable location is gone rather than re-persisted
+            $response->assertSuccessful();
+            $this->assertDatabaseHas('kill_zones', [
+                'id'       => $killZone->id,
+                'color'    => '#ff0000',
+                'floor_id' => null,
+                'lat'      => null,
+                'lng'      => null,
+            ]);
+        } finally {
+            KillZone::query()->where('id', $killZone->id)->delete();
+        }
+    }
+
+    /**
      * A published, non-sandbox route authored by user 1. Sandbox routes (expires_at set, which the
      * factory does by default) are editable by anyone by design, so expires_at must be null for an
      * authorization assertion to mean anything.

--- a/tests/Feature/Http/ResetsMapFacadeStyleOverrideTest.php
+++ b/tests/Feature/Http/ResetsMapFacadeStyleOverrideTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Middleware')]
+#[Group('ResetsMapFacadeStyleOverride')]
+final class ResetsMapFacadeStyleOverrideTest extends PublicTestCase
+{
+    /**
+     * Guards #3917: User::forceMapFacadeStyle() writes a static, so on Octane/Swoole the value the
+     * embed, dungeon explore and heatmap controllers set survives until the worker is recycled and
+     * silently decides the map facade style of every later request that worker handles.
+     */
+    #[Test]
+    public function handle_givenAMapFacadeStyleOverrideLeftBehindByAnEarlierRequest_clearsItBeforeHandlingTheNextRequest(): void
+    {
+        // Arrange - the worker state a /embed?mapFacadeStyle=split_floors request leaves behind
+        User::forceMapFacadeStyle(User::MAP_FACADE_STYLE_SPLIT_FLOORS);
+
+        try {
+            // Act - any subsequent request, by any visitor, on that same worker
+            $this->get(route('home'))->assertSuccessful();
+
+            // Assert - the next request resolves the style from the visitor again, not from the override
+            self::assertSame(User::DEFAULT_MAP_FACADE_STYLE, User::getCurrentUserMapFacadeStyle());
+        } finally {
+            User::forceMapFacadeStyle(null);
+        }
+    }
+}

--- a/tests/Feature/Traits/GeneratesDungeonRoutes.php
+++ b/tests/Feature/Traits/GeneratesDungeonRoutes.php
@@ -9,6 +9,7 @@ use App\Models\DungeonRoute\DungeonRoute;
 use App\Models\Enemy;
 use App\Service\Cache\CacheServiceInterface;
 use App\Service\Coordinates\CoordinatesServiceInterface;
+use Closure;
 use Illuminate\Support\Collection;
 
 trait GeneratesDungeonRoutes
@@ -63,10 +64,19 @@ trait GeneratesDungeonRoutes
      * survive an import round-trip. Filters out teeming-only enemies, MDT placeholders,
      * and seasonally restricted enemies that the import service would skip.
      *
-     * @param array<string, mixed> $attributes
+     * Pass $enemyFilter for any *extra* requirement the test has of those enemies, so the draw
+     * only ever returns a dungeon that satisfies it. Asserting the requirement afterwards instead
+     * is what makes these tests flaky: not every MDT dungeon has e.g. NpcEnemyForces rows, so the
+     * draw succeeds and the test then fails on something it never guaranteed.
+     *
+     * @param array<string, mixed>        $attributes
+     * @param (Closure(Enemy): bool)|null $enemyFilter
      */
-    protected function getMDTCompatibleDungeonRouteWithSafeEnemies(int $enemyCount = 1, array $attributes = []): DungeonRoute
-    {
+    protected function getMDTCompatibleDungeonRouteWithSafeEnemies(
+        int      $enemyCount = 1,
+        array    $attributes = [],
+        ?Closure $enemyFilter = null,
+    ): DungeonRoute {
         do {
             /** @var DungeonRoute $dungeonRoute */
             $dungeonRoute = DungeonRoute::factory()->make($attributes);
@@ -76,7 +86,7 @@ trait GeneratesDungeonRoutes
             if (
                 !Conversion::hasMDTDungeonName($dungeonRoute->dungeon->key) ||
                 $dungeonRoute->mappingVersion->facade_enabled ||
-                $this->getSafeMdtEnemies($dungeonRoute, $enemyCount)->count() < $enemyCount
+                $this->getSafeMdtEnemies($dungeonRoute, $enemyCount, $enemyFilter)->count() < $enemyCount
             ) {
                 $dungeonRoute = null;
             }
@@ -96,9 +106,10 @@ trait GeneratesDungeonRoutes
      * Additionally, applies the same clone-index offset hacks as parseMdtNpcClonesInPull()
      * to exclude enemies that would fail to match during import due to duplicate-NPC merging.
      *
+     * @param  (Closure(Enemy): bool)|null $enemyFilter an extra per-enemy requirement of the caller's
      * @return Collection<int, Enemy>
      */
-    protected function getSafeMdtEnemies(DungeonRoute $dungeonRoute, int $limit = 1): Collection
+    protected function getSafeMdtEnemies(DungeonRoute $dungeonRoute, int $limit = 1, ?Closure $enemyFilter = null): Collection
     {
         $mdtClones = app(MDTDungeon::class, [
             'cacheService'       => app(CacheServiceInterface::class),
@@ -152,6 +163,7 @@ trait GeneratesDungeonRoutes
                 return $mdtClonesByNpcIndex->has($npcIndex) &&
                     $mdtClonesByNpcIndex->get($npcIndex)->contains('mdt_id', $importMdtId);
             })
+            ->filter(static fn(Enemy $enemy): bool => $enemyFilter === null || $enemyFilter($enemy))
             ->shuffle()
             ->take($limit)
             ->values();


### PR DESCRIPTION
:robot: Closes #3917

`CoordinatesService::calculateIngameLocationForMapLocation()` rejects a `latlng` on a facade floor, and `KillZonePathService::loadAndBuildGraph()` called it unconditionally for every kill zone's location — crashing with an uncaught `InvalidArgumentException` whenever a kill zone's location was placed on the facade (combined multi-floor) view rather than a real floor. This is the same call that #3916 (merged separately, PR #3927) improved the fallback handling for — this PR fixes the actual root cause.

Fix: skip facade-floor kill zones the same way `loadAndBuildGraph()` already skips facade-floor `DungeonFloorSwitchMarker`s a few lines above, rather than resolving them to a real floor — the facade view is a collaborative-editing convenience, not stored data the path visualization needs to trust.

Following a cold review, also guarded the dungeon-start node a few lines above the kill-zone loop, which had the exact same unguarded call — a stale `dungeon_start_map_icon_id` pointing at an old mapping version's facade floor would throw before the kill-zone loop is even reached, affecting map loads too, not just kill-zone save.

Added a regression test (`findPathsToKillZones_givenKillZoneOnFacadeFloor_skipsKillZoneInsteadOfThrowing`) that creates a kill zone on a facade floor alongside one on a real floor, and asserts the facade one is excluded from the graph while the real one is the only remaining entry. Confirmed it reproduces the exact reported `InvalidArgumentException: Unable to convert latlng ... that is on facade floor!` against the pre-fix code.
