### PR TITLE
#3904 Don't let a floor without ingame coordinates fail combat log route submission

### DIFF
--- a/app/Service/CombatLog/CombatLogRouteDungeonRouteService.php
+++ b/app/Service/CombatLog/CombatLogRouteDungeonRouteService.php
@@ -508,6 +508,10 @@ class CombatLogRouteDungeonRouteService implements CombatLogRouteDungeonRouteSer
                 continue;
             }
 
+            // Track the floor regardless of whether a failure gets recorded below - later npcs that
+            // fall back to $previousFloor must still see this npc's floor even if this one is skipped.
+            $previousFloor = $currentFloor;
+
             if ($combatLogRouteNpc->getResolvedEnemy() === null) {
                 // This table is diagnostic bookkeeping only (unresolved-npc triage) - a floor with
                 // unset ingame coordinates (a mapping data gap, #3904) must not fail the whole combat
@@ -521,7 +525,7 @@ class CombatLogRouteDungeonRouteService implements CombatLogRouteDungeonRouteSer
                         ),
                     );
                 } catch (InvalidArgumentException) {
-                    $this->log->saveCombatLogRouteEnemyFailuresUnableToCalculateMapLocation($currentFloor->id);
+                    $this->log->saveCombatLogRouteEnemyFailuresUnableToCalculateMapLocation($dungeonRoute->id, $combatLogRouteNpc->npcId, $currentFloor->id);
 
                     continue;
                 }
@@ -536,8 +540,6 @@ class CombatLogRouteDungeonRouteService implements CombatLogRouteDungeonRouteSer
                     'updated_at'         => $now,
                 ], $latLng->toArray());
             }
-
-            $previousFloor = $currentFloor;
         }
 
         CombatLogRouteEnemyFailure::insert($failureAttributes);
@@ -569,13 +571,21 @@ class CombatLogRouteDungeonRouteService implements CombatLogRouteDungeonRouteSer
                 continue;
             }
 
-            $latLng = $this->coordinatesService->calculateMapLocationForIngameLocation(
-                new IngameXY(
-                    $combatLogRouteNpc->coord->x,
-                    $combatLogRouteNpc->coord->y,
-                    $currentFloor,
-                ),
-            );
+            // A floor with unset ingame coordinates (a mapping data gap, #3904) must not fail the
+            // whole request just because this one npc's icon can't be placed.
+            try {
+                $latLng = $this->coordinatesService->calculateMapLocationForIngameLocation(
+                    new IngameXY(
+                        $combatLogRouteNpc->coord->x,
+                        $combatLogRouteNpc->coord->y,
+                        $currentFloor,
+                    ),
+                );
+            } catch (InvalidArgumentException) {
+                $this->log->generateMapIconsUnableToCalculateMapLocation($combatLogRouteNpc->getUniqueId(), $currentFloor->id);
+
+                continue;
+            }
             $latLngs[] = $latLng;
 
             /** @var Npc|null $npc */

--- a/app/Service/CombatLog/CombatLogRouteDungeonRouteService.php
+++ b/app/Service/CombatLog/CombatLogRouteDungeonRouteService.php
@@ -73,6 +73,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Ramsey\Uuid\Uuid;
 
 /**
@@ -508,13 +509,22 @@ class CombatLogRouteDungeonRouteService implements CombatLogRouteDungeonRouteSer
             }
 
             if ($combatLogRouteNpc->getResolvedEnemy() === null) {
-                $latLng = $this->coordinatesService->calculateMapLocationForIngameLocation(
-                    new IngameXY(
-                        $combatLogRouteNpc->coord->x,
-                        $combatLogRouteNpc->coord->y,
-                        $currentFloor,
-                    ),
-                );
+                // This table is diagnostic bookkeeping only (unresolved-npc triage) - a floor with
+                // unset ingame coordinates (a mapping data gap, #3904) must not fail the whole combat
+                // log route submission just because it can't be recorded here.
+                try {
+                    $latLng = $this->coordinatesService->calculateMapLocationForIngameLocation(
+                        new IngameXY(
+                            $combatLogRouteNpc->coord->x,
+                            $combatLogRouteNpc->coord->y,
+                            $currentFloor,
+                        ),
+                    );
+                } catch (InvalidArgumentException) {
+                    $this->log->saveCombatLogRouteEnemyFailuresUnableToCalculateMapLocation($currentFloor->id);
+
+                    continue;
+                }
 
                 $failureAttributes[] = array_merge([
                     'dungeon_route_id'   => $dungeonRoute->id,

--- a/app/Service/CombatLog/Logging/CombatLogRouteDungeonRouteServiceLogging.php
+++ b/app/Service/CombatLog/Logging/CombatLogRouteDungeonRouteServiceLogging.php
@@ -54,7 +54,12 @@ class CombatLogRouteDungeonRouteServiceLogging extends StructuredLogging impleme
         $this->warning(__METHOD__, get_defined_vars());
     }
 
-    public function saveCombatLogRouteEnemyFailuresUnableToCalculateMapLocation(int $floorId): void
+    public function generateMapIconsUnableToCalculateMapLocation(string $uniqueId, int $floorId): void
+    {
+        $this->warning(__METHOD__, get_defined_vars());
+    }
+
+    public function saveCombatLogRouteEnemyFailuresUnableToCalculateMapLocation(int $dungeonRouteId, ?int $npcId, int $floorId): void
     {
         $this->warning(__METHOD__, get_defined_vars());
     }

--- a/app/Service/CombatLog/Logging/CombatLogRouteDungeonRouteServiceLogging.php
+++ b/app/Service/CombatLog/Logging/CombatLogRouteDungeonRouteServiceLogging.php
@@ -53,4 +53,9 @@ class CombatLogRouteDungeonRouteServiceLogging extends StructuredLogging impleme
     {
         $this->warning(__METHOD__, get_defined_vars());
     }
+
+    public function saveCombatLogRouteEnemyFailuresUnableToCalculateMapLocation(int $floorId): void
+    {
+        $this->warning(__METHOD__, get_defined_vars());
+    }
 }

--- a/app/Service/CombatLog/Logging/CombatLogRouteDungeonRouteServiceLoggingInterface.php
+++ b/app/Service/CombatLog/Logging/CombatLogRouteDungeonRouteServiceLoggingInterface.php
@@ -21,4 +21,6 @@ interface CombatLogRouteDungeonRouteServiceLoggingInterface
     public function saveChallengeModeRunUnableToFindFloor(int $uiMapId): void;
 
     public function generateMapIconsUnableToFindFloor(string $uniqueId): void;
+
+    public function saveCombatLogRouteEnemyFailuresUnableToCalculateMapLocation(int $floorId): void;
 }

--- a/app/Service/CombatLog/Logging/CombatLogRouteDungeonRouteServiceLoggingInterface.php
+++ b/app/Service/CombatLog/Logging/CombatLogRouteDungeonRouteServiceLoggingInterface.php
@@ -22,5 +22,7 @@ interface CombatLogRouteDungeonRouteServiceLoggingInterface
 
     public function generateMapIconsUnableToFindFloor(string $uniqueId): void;
 
-    public function saveCombatLogRouteEnemyFailuresUnableToCalculateMapLocation(int $floorId): void;
+    public function generateMapIconsUnableToCalculateMapLocation(string $uniqueId, int $floorId): void;
+
+    public function saveCombatLogRouteEnemyFailuresUnableToCalculateMapLocation(int $dungeonRouteId, ?int $npcId, int $floorId): void;
 }

--- a/tests/Feature/App/Service/CombatLog/CombatLogRouteDungeonRouteServiceEnemyFailuresTest.php
+++ b/tests/Feature/App/Service/CombatLog/CombatLogRouteDungeonRouteServiceEnemyFailuresTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\App\Service\CombatLog;
+
+use App\Dto\Request\CombatLog\Route\CombatLogRouteCoordRequestDto;
+use App\Dto\Request\CombatLog\Route\CombatLogRouteNpcRequestDto;
+use App\Dto\Request\CombatLog\Route\CombatLogRouteRequestDto;
+use App\Models\CombatLog\CombatLogRouteEnemyFailure;
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\Enemy;
+use App\Models\Floor\Floor;
+use App\Service\CombatLog\CombatLogRouteDungeonRouteServiceInterface;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Exercises CombatLogRouteDungeonRouteService::saveCombatLogRouteEnemyFailures() directly via
+ * reflection rather than through the full API/builder pipeline: that pipeline resolves floors
+ * through FloorRepositorySwoole/EnemyRepositorySwoole, which cache Floor/Enemy instances for the
+ * lifetime of the process, so mutating a floor's ingame coordinates mid-test would not reliably be
+ * observed there. The method under test only ever reads floors via plain Eloquent relations, so a
+ * direct call is both faster and immune to that caching layer.
+ */
+#[Group('CombatLog')]
+#[Group('CombatLogRouteDungeonRouteService')]
+final class CombatLogRouteDungeonRouteServiceEnemyFailuresTest extends PublicTestCase
+{
+    /**
+     * Guards #3904: a floor with unset (zero-size) ingame coordinates must not fail the whole
+     * combat log route submission - CombatLogRouteEnemyFailure is diagnostic bookkeeping only, so a
+     * failure that can't be located should be skipped instead of throwing.
+     */
+    #[Test]
+    public function saveCombatLogRouteEnemyFailures_givenUnresolvableNpcOnFloorWithoutIngameCoordinates_skipsItWithoutThrowing(): void
+    {
+        $enemy = Enemy::query()->whereNotNull('floor_id')->with('floor')->first();
+        $this->assertNotNull($enemy, 'Expected at least one seeded Enemy with a floor.');
+
+        $floor          = $enemy->floor;
+        $originalCoords = [
+            'ingame_min_x' => $floor->ingame_min_x,
+            'ingame_min_y' => $floor->ingame_min_y,
+            'ingame_max_x' => $floor->ingame_max_x,
+            'ingame_max_y' => $floor->ingame_max_y,
+        ];
+
+        $dungeonRoute = null;
+
+        try {
+            // Arrange - zero out the enemy's floor so calculateMapLocationForIngameLocation() throws
+            $floor->update([
+                'ingame_min_x' => 0,
+                'ingame_min_y' => 0,
+                'ingame_max_x' => 0,
+                'ingame_max_y' => 0,
+            ]);
+            $floor->refresh();
+
+            $dungeonRoute = DungeonRoute::factory()->create([
+                'dungeon_id'         => $floor->dungeon_id,
+                'mapping_version_id' => $enemy->mapping_version_id,
+            ]);
+
+            // npc1 resolves to a real enemy on the zeroed floor, becoming the "previous floor" for npc2
+            $resolvedNpc = new CombatLogRouteNpcRequestDto(npcId: $enemy->npc_id, coord: new CombatLogRouteCoordRequestDto(1.0, 1.0));
+            $resolvedNpc->setResolvedEnemy($enemy);
+
+            // npc2 does not resolve to an enemy, so it falls back to npc1's floor (the zeroed one)
+            $unresolvedNpc = new CombatLogRouteNpcRequestDto(npcId: -1, coord: new CombatLogRouteCoordRequestDto(2.0, 2.0));
+
+            $combatLogRoute = new CombatLogRouteRequestDto(npcs: new Collection([$resolvedNpc, $unresolvedNpc]));
+
+            $countBefore = CombatLogRouteEnemyFailure::where('dungeon_route_id', $dungeonRoute->id)->count();
+
+            /** @var CombatLogRouteDungeonRouteServiceInterface $service */
+            $service = app(CombatLogRouteDungeonRouteServiceInterface::class);
+            $method  = new ReflectionClass($service)->getMethod('saveCombatLogRouteEnemyFailures');
+
+            // Act
+            $method->invokeArgs($service, [$dungeonRoute->mappingVersion, $combatLogRoute, $dungeonRoute]);
+
+            // Assert - no exception, and no failure recorded for the floor that couldn't be located
+            $this->assertSame($countBefore, CombatLogRouteEnemyFailure::where('dungeon_route_id', $dungeonRoute->id)->count());
+        } finally {
+            $floor->update($originalCoords);
+            CombatLogRouteEnemyFailure::where('dungeon_route_id', $dungeonRoute?->id)->delete();
+            $dungeonRoute?->delete();
+        }
+    }
+}

--- a/tests/Feature/App/Service/CombatLog/CombatLogRouteDungeonRouteServiceEnemyFailuresTest.php
+++ b/tests/Feature/App/Service/CombatLog/CombatLogRouteDungeonRouteServiceEnemyFailuresTest.php
@@ -18,11 +18,13 @@ use Tests\TestCases\PublicTestCase;
 
 /**
  * Exercises CombatLogRouteDungeonRouteService::saveCombatLogRouteEnemyFailures() directly via
- * reflection rather than through the full API/builder pipeline: that pipeline resolves floors
- * through FloorRepositorySwoole/EnemyRepositorySwoole, which cache Floor/Enemy instances for the
- * lifetime of the process, so mutating a floor's ingame coordinates mid-test would not reliably be
- * observed there. The method under test only ever reads floors via plain Eloquent relations, so a
- * direct call is both faster and immune to that caching layer.
+ * reflection rather than through the full API/builder pipeline: within a single test, that pipeline
+ * resolves floors through FloorRepositorySwoole/EnemyRepositorySwoole, which cache Floor/Enemy
+ * instances for the lifetime of the test (Laravel's TestCase rebuilds the container per test via
+ * refreshApplication(), but not between requests within one test), so mutating a floor's ingame
+ * coordinates and re-submitting within the same test would not reliably be observed there. The
+ * method under test only ever reads floors via plain Eloquent relations, so a direct call is both
+ * faster and immune to that caching layer.
  */
 #[Group('CombatLog')]
 #[Group('CombatLogRouteDungeonRouteService')]
@@ -31,15 +33,19 @@ final class CombatLogRouteDungeonRouteServiceEnemyFailuresTest extends PublicTes
     /**
      * Guards #3904: a floor with unset (zero-size) ingame coordinates must not fail the whole
      * combat log route submission - CombatLogRouteEnemyFailure is diagnostic bookkeeping only, so a
-     * failure that can't be located should be skipped instead of throwing.
+     * failure that can't be located should be skipped instead of throwing. A second unresolvable
+     * npc on a floor WITH coordinates proves this is a selective skip, not "nothing got recorded".
      */
     #[Test]
-    public function saveCombatLogRouteEnemyFailures_givenUnresolvableNpcOnFloorWithoutIngameCoordinates_skipsItWithoutThrowing(): void
+    public function saveCombatLogRouteEnemyFailures_givenUnresolvableNpcOnFloorWithoutIngameCoordinates_skipsOnlyThatOne(): void
     {
-        $enemy = Enemy::query()->whereNotNull('floor_id')->with('floor')->first();
-        $this->assertNotNull($enemy, 'Expected at least one seeded Enemy with a floor.');
+        $zeroedEnemy = Enemy::query()->whereNotNull('floor_id')->with('floor')->first();
+        $this->assertNotNull($zeroedEnemy, 'Expected at least one seeded Enemy with a floor.');
 
-        $floor          = $enemy->floor;
+        $goodEnemy = Enemy::query()->whereNotNull('floor_id')->where('floor_id', '!=', $zeroedEnemy->floor_id)->with('floor')->first();
+        $this->assertNotNull($goodEnemy, 'Expected at least one seeded Enemy on a different floor.');
+
+        $floor          = $zeroedEnemy->floor;
         $originalCoords = [
             'ingame_min_x' => $floor->ingame_min_x,
             'ingame_min_y' => $floor->ingame_min_y,
@@ -50,7 +56,8 @@ final class CombatLogRouteDungeonRouteServiceEnemyFailuresTest extends PublicTes
         $dungeonRoute = null;
 
         try {
-            // Arrange - zero out the enemy's floor so calculateMapLocationForIngameLocation() throws
+            // Arrange - zero out one enemy's floor so calculateMapLocationForIngameLocation() throws
+            // for it, while the other enemy's floor keeps its real (non-zero) coordinates.
             $floor->update([
                 'ingame_min_x' => 0,
                 'ingame_min_y' => 0,
@@ -61,19 +68,29 @@ final class CombatLogRouteDungeonRouteServiceEnemyFailuresTest extends PublicTes
 
             $dungeonRoute = DungeonRoute::factory()->create([
                 'dungeon_id'         => $floor->dungeon_id,
-                'mapping_version_id' => $enemy->mapping_version_id,
+                'mapping_version_id' => $zeroedEnemy->mapping_version_id,
             ]);
 
             // npc1 resolves to a real enemy on the zeroed floor, becoming the "previous floor" for npc2
-            $resolvedNpc = new CombatLogRouteNpcRequestDto(npcId: $enemy->npc_id, coord: new CombatLogRouteCoordRequestDto(1.0, 1.0));
-            $resolvedNpc->setResolvedEnemy($enemy);
+            $resolvedOnZeroedFloor = new CombatLogRouteNpcRequestDto(npcId: $zeroedEnemy->npc_id, coord: new CombatLogRouteCoordRequestDto(1.0, 1.0));
+            $resolvedOnZeroedFloor->setResolvedEnemy($zeroedEnemy);
 
-            // npc2 does not resolve to an enemy, so it falls back to npc1's floor (the zeroed one)
-            $unresolvedNpc = new CombatLogRouteNpcRequestDto(npcId: -1, coord: new CombatLogRouteCoordRequestDto(2.0, 2.0));
+            // npc2 does not resolve to an enemy, so it falls back to npc1's floor (the zeroed one) - skipped
+            $unresolvedOnZeroedFloor = new CombatLogRouteNpcRequestDto(npcId: -1, coord: new CombatLogRouteCoordRequestDto(2.0, 2.0));
 
-            $combatLogRoute = new CombatLogRouteRequestDto(npcs: new Collection([$resolvedNpc, $unresolvedNpc]));
+            // npc3 resolves to a real enemy on a floor with real coordinates, becoming the "previous floor" for npc4
+            $resolvedOnGoodFloor = new CombatLogRouteNpcRequestDto(npcId: $goodEnemy->npc_id, coord: new CombatLogRouteCoordRequestDto(3.0, 3.0));
+            $resolvedOnGoodFloor->setResolvedEnemy($goodEnemy);
 
-            $countBefore = CombatLogRouteEnemyFailure::where('dungeon_route_id', $dungeonRoute->id)->count();
+            // npc4 does not resolve to an enemy, so it falls back to npc3's floor (real coordinates) - recorded
+            $unresolvedOnGoodFloor = new CombatLogRouteNpcRequestDto(npcId: -2, coord: new CombatLogRouteCoordRequestDto(4.0, 4.0));
+
+            $combatLogRoute = new CombatLogRouteRequestDto(npcs: new Collection([
+                $resolvedOnZeroedFloor,
+                $unresolvedOnZeroedFloor,
+                $resolvedOnGoodFloor,
+                $unresolvedOnGoodFloor,
+            ]));
 
             /** @var CombatLogRouteDungeonRouteServiceInterface $service */
             $service = app(CombatLogRouteDungeonRouteServiceInterface::class);
@@ -82,12 +99,18 @@ final class CombatLogRouteDungeonRouteServiceEnemyFailuresTest extends PublicTes
             // Act
             $method->invokeArgs($service, [$dungeonRoute->mappingVersion, $combatLogRoute, $dungeonRoute]);
 
-            // Assert - no exception, and no failure recorded for the floor that couldn't be located
-            $this->assertSame($countBefore, CombatLogRouteEnemyFailure::where('dungeon_route_id', $dungeonRoute->id)->count());
+            // Assert - no exception, exactly one failure recorded (npc4, on the floor with real coordinates)
+            $failures = CombatLogRouteEnemyFailure::where('dungeon_route_id', $dungeonRoute->id)->get();
+            $this->assertCount(1, $failures);
+            $this->assertSame(-2, $failures->first()->npc_id);
+            $this->assertSame($goodEnemy->floor_id, $failures->first()->floor_id);
         } finally {
             $floor->update($originalCoords);
-            CombatLogRouteEnemyFailure::where('dungeon_route_id', $dungeonRoute?->id)->delete();
-            $dungeonRoute?->delete();
+
+            if ($dungeonRoute !== null) {
+                CombatLogRouteEnemyFailure::where('dungeon_route_id', $dungeonRoute->id)->delete();
+                $dungeonRoute->delete();
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #3904

:robot: `CombatLogRouteDungeonRouteService::saveCombatLogRouteEnemyFailures()` records diagnostic bookkeeping (`CombatLogRouteEnemyFailure`) for npcs the combat log route couldn't resolve to a mapped enemy. It called `CoordinatesService::calculateMapLocationForIngameLocation()` unguarded, which throws an `InvalidArgumentException` when the npc's floor has unset (zero-size) ingame coordinates - confirmed via Sentry (`PHP-LARAVEL-RD`, 16 occurrences, Halls of Spite floor 454) that this is a real mapping data gap that reaches production and 500s `POST /api/v1/combatlog/route`.

The dungeon route itself is already built successfully by this point (`saveCombatLogRouteEnemyFailures()` runs after `->build()`) - this table is purely diagnostic triage data, so one unlocatable failure shouldn't fail the whole submission. Now it's caught, logged via a new `saveCombatLogRouteEnemyFailuresUnableToCalculateMapLocation` structured-logging method, and skipped.

## Test plan
- [x] Added `CombatLogRouteDungeonRouteServiceEnemyFailuresTest::saveCombatLogRouteEnemyFailures_givenUnresolvableNpcOnFloorWithoutIngameCoordinates_skipsItWithoutThrowing` - calls the private method directly via reflection (see the class docblock for why: the full API/builder pipeline resolves floors through `FloorRepositorySwoole`/`EnemyRepositorySwoole`, which cache `Floor`/`Enemy` instances for the process lifetime, so mutating a floor's coordinates mid-test wouldn't reliably be observed there). Reproduced the exact reported exception on the pre-fix code (`git stash` the service fix, rerun - `InvalidArgumentException: Floor The High Gate (16) does not have ingame coordinates set!`) and confirmed it passes after.
- [x] `composer run fix` - no changes
- [x] `composer run analyse` - no errors