### PR TITLE
#3903 Fix Handler::isApiRequest() missing bare /api/, /ajax/ and /benchmark paths

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,7 +4,7 @@ namespace App\Exceptions;
 
 use App\Exceptions\Logging\HandlerLoggingInterface;
 use App\Models\User;
-use App\Service\View\ViewServiceInterface;
+use App\Service\Request\ApiRequestServiceInterface;
 use Auth;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
@@ -178,15 +178,21 @@ class Handler extends ExceptionHandler
     }
 
     /**
-     * No view composer runs for a request whose path ViewService::shouldLoadViewVariables()
-     * blacklists (KeystoneGuruServiceProvider::boot() skips registering them there entirely). An
-     * HTML error view rendered for one of those paths is guaranteed to crash on a missing view
-     * variable (#3806, #3903), so isApiRequest() forces JSON for their errors - except
-     * ValidationException, which render() above already carves out since it never renders an
-     * HTML error view in the first place. The blacklist has a handful of /ajax/ routes
-     * (search/view) explicitly whitelisted back out of it to deliberately render an HTML
-     * fragment on success - composers DO run there, so their errors are left alone too and may
-     * render their own HTML instead of JSON.
+     * An API request must never be answered with an HTML error view: no view composer runs for it
+     * (KeystoneGuruServiceProvider::boot() skips registering them for any path
+     * ViewService::shouldLoadViewVariables() rejects, which is every API path bar a few that render
+     * a view on purpose), so such a view is guaranteed to crash on a missing view variable
+     * (#3806, #3903). Force JSON for those - except ValidationException, which render() above
+     * already carves out since it never renders an HTML error view in the first place.
+     *
+     * Whether the request is an API request is ApiRequestService's call, not something derived from
+     * the view layer: it is resolved here rather than constructor-injected to match how this class
+     * already resolves HandlerLoggingInterface, keeping the exception handler constructible even
+     * when the container is in a degraded state. The previous hand-rolled check
+     * (str_starts_with($path, 'api/') || str_starts_with($path, 'ajax/')) that the service replaces
+     * had drifted in two ways: it never covered '/benchmark' at all, and Request::decodedPath()
+     * trims the trailing slash, so a bare "/api/" request decoded to "api" and silently failed
+     * "starts with 'api/'" (#3903).
      */
     #[Override]
     protected function shouldReturnJson($request, Throwable $e): bool
@@ -199,20 +205,8 @@ class Handler extends ExceptionHandler
             return parent::shouldReturnJson($request, $e);
         }
 
-        return $this->isApiRequest($request) || parent::shouldReturnJson($request, $e);
-    }
-
-    /**
-     * Delegates to the same blacklist check ViewService's composer registration already applies,
-     * rather than duplicating its path list by hand - the previous hand-rolled version
-     * (str_starts_with($path, 'api/') || str_starts_with($path, 'ajax/')) drifted from it in two
-     * ways: it never covered '/benchmark' at all, and Request::decodedPath() trims the trailing
-     * slash Request::path() strips, so a bare "/api/" or "/api" request decoded to "api" and
-     * silently failed "starts with 'api/'" (#3903).
-     */
-    private function isApiRequest(Request $request): bool
-    {
-        return !app(ViewServiceInterface::class)->shouldLoadViewVariables($request->getPathInfo());
+        return app(ApiRequestServiceInterface::class)->isApiRequest($request)
+            || parent::shouldReturnJson($request, $e);
     }
 
     /**

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace App\Exceptions;
 
 use App\Exceptions\Logging\HandlerLoggingInterface;
 use App\Models\User;
+use App\Service\View\ViewServiceInterface;
 use Auth;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
@@ -201,9 +202,15 @@ class Handler extends ExceptionHandler
 
     private function isApiRequest(Request $request): bool
     {
-        $path = $request->decodedPath();
-
-        return str_starts_with($path, 'api/') || str_starts_with($path, 'ajax/');
+        // Any exception rendered as an HTML error view on a path ViewService blacklists is
+        // guaranteed to crash - no view composer ran there, so the view can't read the variables
+        // it unconditionally depends on (#3806, #3903). This used to duplicate that blacklist as
+        // a hand-rolled prefix check here (str_starts_with($path, 'api/')), which drifted from it
+        // in two ways: it never covered '/benchmark' at all, and decodedPath() trims the trailing
+        // slash Request::path() strips, so a bare "/api/" or "/api" request decodes to "api" and
+        // silently fails "starts with 'api/'". Delegating to the same check both sides already
+        // share removes the duplication instead of patching one more case of it.
+        return !app(ViewServiceInterface::class)->shouldLoadViewVariables($request->getPathInfo());
     }
 
     /**

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -178,13 +178,15 @@ class Handler extends ExceptionHandler
     }
 
     /**
-     * No view composers run on /ajax/ (KeystoneGuruServiceProvider::boot(), gated by
-     * ViewService::shouldLoadViewVariables()) - not even for the handful of /ajax/ routes
-     * whitelisted there to deliberately render an HTML fragment on success (search/view). So an
-     * HTML error view rendered for ANY /ajax/ request is guaranteed to crash on a missing view
-     * variable (#3806). Force JSON for every /ajax/ error (matching how /api/ is already treated
-     * here) except ValidationException, which render() above already carves out since it never
-     * renders an HTML error view in the first place.
+     * No view composer runs for a request whose path ViewService::shouldLoadViewVariables()
+     * blacklists (KeystoneGuruServiceProvider::boot() skips registering them there entirely). An
+     * HTML error view rendered for one of those paths is guaranteed to crash on a missing view
+     * variable (#3806, #3903), so isApiRequest() forces JSON for their errors - except
+     * ValidationException, which render() above already carves out since it never renders an
+     * HTML error view in the first place. The blacklist has a handful of /ajax/ routes
+     * (search/view) explicitly whitelisted back out of it to deliberately render an HTML
+     * fragment on success - composers DO run there, so their errors are left alone too and may
+     * render their own HTML instead of JSON.
      */
     #[Override]
     protected function shouldReturnJson($request, Throwable $e): bool
@@ -200,16 +202,16 @@ class Handler extends ExceptionHandler
         return $this->isApiRequest($request) || parent::shouldReturnJson($request, $e);
     }
 
+    /**
+     * Delegates to the same blacklist check ViewService's composer registration already applies,
+     * rather than duplicating its path list by hand - the previous hand-rolled version
+     * (str_starts_with($path, 'api/') || str_starts_with($path, 'ajax/')) drifted from it in two
+     * ways: it never covered '/benchmark' at all, and Request::decodedPath() trims the trailing
+     * slash Request::path() strips, so a bare "/api/" or "/api" request decoded to "api" and
+     * silently failed "starts with 'api/'" (#3903).
+     */
     private function isApiRequest(Request $request): bool
     {
-        // Any exception rendered as an HTML error view on a path ViewService blacklists is
-        // guaranteed to crash - no view composer ran there, so the view can't read the variables
-        // it unconditionally depends on (#3806, #3903). This used to duplicate that blacklist as
-        // a hand-rolled prefix check here (str_starts_with($path, 'api/')), which drifted from it
-        // in two ways: it never covered '/benchmark' at all, and decodedPath() trims the trailing
-        // slash Request::path() strips, so a bare "/api/" or "/api" request decodes to "api" and
-        // silently fails "starts with 'api/'". Delegating to the same check both sides already
-        // share removes the duplication instead of patching one more case of it.
         return !app(ViewServiceInterface::class)->shouldLoadViewVariables($request->getPathInfo());
     }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -186,9 +186,8 @@ class Handler extends ExceptionHandler
      * already carves out since it never renders an HTML error view in the first place.
      *
      * Whether the request is an API request is ApiRequestService's call, not something derived from
-     * the view layer: it is resolved here rather than constructor-injected to match how this class
-     * already resolves HandlerLoggingInterface, keeping the exception handler constructible even
-     * when the container is in a degraded state. The previous hand-rolled check
+     * the view layer: it is resolved here rather than constructor-injected, matching how this class
+     * already resolves HandlerLoggingInterface. The previous hand-rolled check
      * (str_starts_with($path, 'api/') || str_starts_with($path, 'ajax/')) that the service replaces
      * had drifted in two ways: it never covered '/benchmark' at all, and Request::decodedPath()
      * trims the trailing slash, so a bare "/api/" request decoded to "api" and silently failed

--- a/app/Providers/KeystoneGuruServiceProvider.php
+++ b/app/Providers/KeystoneGuruServiceProvider.php
@@ -144,6 +144,8 @@ use App\Service\RaiderIO\RaiderIOApiServiceInterface;
 use App\Service\RaiderIO\RaiderIOKeystoneGuruApiService;
 use App\Service\ReadOnlyMode\ReadOnlyModeService;
 use App\Service\ReadOnlyMode\ReadOnlyModeServiceInterface;
+use App\Service\Request\ApiRequestService;
+use App\Service\Request\ApiRequestServiceInterface;
 use App\Service\Reverb\ReverbHttpApiService;
 use App\Service\Reverb\ReverbHttpApiServiceInterface;
 use App\Service\Season\SeasonAffixGroupService;
@@ -206,6 +208,8 @@ class KeystoneGuruServiceProvider extends ServiceProvider
         $this->app->bind(ReverbHttpApiServiceInterface::class, ReverbHttpApiService::class);
 
         // Internals
+        // No dependencies - resolved very early (ViewService, and Handler on any request that errors)
+        $this->app->bind(ApiRequestServiceInterface::class, ApiRequestService::class);
         $this->app->bind(CoordinatesServiceInterface::class, CoordinatesService::class);
         $this->app->bind(ThumbnailServiceInterface::class, ThumbnailService::class);
         $this->app->bind(PatreonServiceInterface::class, PatreonService::class);

--- a/app/Service/Request/ApiRequestService.php
+++ b/app/Service/Request/ApiRequestService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Service\Request;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class ApiRequestService implements ApiRequestServiceInterface
+{
+    /**
+     * Path prefixes that make up the API surface. The exact spelling is load bearing: '/api/' and
+     * '/ajax/' carry a trailing slash so that a page like '/api_keys.json' or '/apis/config.js' is
+     * NOT considered an API request, while '/benchmark' deliberately has none since it is a single
+     * route rather than a prefixed group.
+     *
+     * @var array<int, string>
+     */
+    private const array API_PATH_PREFIXES = [
+        '/ajax/',
+        '/api/',
+        '/benchmark',
+    ];
+
+    public function isApiRequest(Request $request): bool
+    {
+        return $this->isApiRequestPath($request->getPathInfo());
+    }
+
+    public function isApiRequestPath(string $pathInfo): bool
+    {
+        return Str::startsWith($pathInfo, self::API_PATH_PREFIXES);
+    }
+}

--- a/app/Service/Request/ApiRequestServiceInterface.php
+++ b/app/Service/Request/ApiRequestServiceInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Service\Request;
+
+use Illuminate\Http\Request;
+
+interface ApiRequestServiceInterface
+{
+    /**
+     * Whether $request targets the API surface - the set of paths that only ever produce a
+     * machine-readable (JSON) response and never render a Blade view.
+     */
+    public function isApiRequest(Request $request): bool;
+
+    /**
+     * Path variant of {@see ApiRequestServiceInterface::isApiRequest()}.
+     *
+     * @param string $pathInfo The raw, slash-preserving request path as returned by
+     *                         {@see Request::getPathInfo()}. Do NOT pass Request::path() or
+     *                         Request::decodedPath() - both trim the trailing slash, which makes a
+     *                         bare "/api/" request read as "api" and escape detection (#3903).
+     */
+    public function isApiRequestPath(string $pathInfo): bool;
+}

--- a/app/Service/View/ViewService.php
+++ b/app/Service/View/ViewService.php
@@ -25,6 +25,7 @@ use App\Service\Cache\CacheServiceInterface;
 use App\Service\Cache\Traits\RemembersToFile;
 use App\Service\Expansion\ExpansionData;
 use App\Service\Expansion\ExpansionServiceInterface;
+use App\Service\Request\ApiRequestServiceInterface;
 use App\Service\Season\SeasonAffixGroupServiceInterface;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
@@ -35,18 +36,18 @@ class ViewService implements ViewServiceInterface
 {
     use RemembersToFile;
 
+    /**
+     * The handful of API-surface paths that DO render a view back to the user, and therefore need
+     * their view variables loaded even though ApiRequestService classifies them as API requests.
+     *
+     * @var array<int, string>
+     */
     private const array VIEW_VARIABLES_URL_WHITELIST = [
         // search actually renders views back to the user which we need
         '/ajax/dungeonroute/search',
         '/ajax/search',
         // Renders views through Ajax
         '/ajax/view',
-    ];
-
-    private const array VIEW_VARIABLES_URL_BLACKLIST = [
-        '/ajax/',
-        '/api/',
-        '/benchmark',
     ];
 
     private string $release;
@@ -59,6 +60,7 @@ class ViewService implements ViewServiceInterface
         private readonly ExpansionServiceInterface          $expansionService,
         private readonly SeasonAffixGroupServiceInterface   $seasonAffixGroupService,
         private readonly AffixGroupEaseTierServiceInterface $easeTierService,
+        private readonly ApiRequestServiceInterface         $apiRequestService,
     ) {
         // Load the release version from the file, this is used to cache view variables
         // We want to cache view variables per release so we don't mix up view variables between releases
@@ -596,19 +598,18 @@ class ViewService implements ViewServiceInterface
         }
     }
 
+    /**
+     * An API request produces JSON and never renders a view, so it needs no view variables - unless
+     * it's one of the few whitelisted paths that deliberately render a view anyway. Whether a
+     * request is an API request is not this service's call to make; ApiRequestService owns it.
+     */
     public function shouldLoadViewVariables(string $pathInfo): bool
     {
-        $isWhitelisted = collect(self::VIEW_VARIABLES_URL_WHITELIST)->contains(static fn($url) => Str::startsWith($pathInfo, $url));
-
-        if (!$isWhitelisted) {
-            // If it's blacklisted..
-            if (collect(self::VIEW_VARIABLES_URL_BLACKLIST)->contains(static fn($url) => Str::startsWith($pathInfo, $url))) {
-                // Don't set the view variables at all
-                return false;
-            }
+        if (Str::startsWith($pathInfo, self::VIEW_VARIABLES_URL_WHITELIST)) {
+            return true;
         }
 
-        return true;
+        return !$this->apiRequestService->isApiRequestPath($pathInfo);
     }
 
     /**

--- a/tests/Feature/App/Service/Request/ApiRequestServiceTest.php
+++ b/tests/Feature/App/Service/Request/ApiRequestServiceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\App\Service\Request;
+
+use App\Service\Request\ApiRequestService;
+use App\Service\Request\ApiRequestServiceInterface;
+use Generator;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('ApiRequestService')]
+final class ApiRequestServiceTest extends PublicTestCase
+{
+    #[Test]
+    public function apiRequestServiceInterface_givenTheContainer_resolvesToApiRequestService(): void
+    {
+        // Act - both call sites (ViewService by constructor injection, Handler by resolving it in
+        // shouldReturnJson()) go through the container, so a missing binding breaks both
+        $apiRequestService = app(ApiRequestServiceInterface::class);
+
+        // Assert
+        $this->assertInstanceOf(ApiRequestService::class, $apiRequestService);
+    }
+
+    #[Test]
+    #[DataProvider('isApiRequestPath_givenApiSurfacePath_returnsTrue_dataProvider')]
+    public function isApiRequestPath_givenApiSurfacePath_returnsTrue(string $pathInfo): void
+    {
+        // Arrange
+        $apiRequestService = new ApiRequestService();
+
+        // Act
+        $result = $apiRequestService->isApiRequestPath($pathInfo);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public static function isApiRequestPath_givenApiSurfacePath_returnsTrue_dataProvider(): Generator
+    {
+        yield ['/ajax/brushline'];
+        yield ['/ajax/profile/adfree/1'];
+
+        yield ['/api/v1/dungeon'];
+        yield ['/api/v1/route'];
+
+        // A bare '/api/' with nothing behind it - the exact shape the hand-rolled check this
+        // service replaces missed, because Request::decodedPath() trimmed it to "api" (#3903)
+        yield ['/api/'];
+        yield ['/ajax/'];
+
+        // '/benchmark' is a single route rather than a prefixed group, so it carries no trailing
+        // slash - the hand-rolled check never covered it at all
+        yield ['/benchmark'];
+
+        // The whitelisted /ajax/ paths ARE API requests; that they additionally render a view is a
+        // view-layer concern owned by ViewService::shouldLoadViewVariables(), not by this service
+        yield ['/ajax/search'];
+        yield ['/ajax/dungeonroute/search'];
+        yield ['/ajax/view'];
+    }
+
+    #[Test]
+    #[DataProvider('isApiRequestPath_givenNonApiPath_returnsFalse_dataProvider')]
+    public function isApiRequestPath_givenNonApiPath_returnsFalse(string $pathInfo): void
+    {
+        // Arrange
+        $apiRequestService = new ApiRequestService();
+
+        // Act
+        $result = $apiRequestService->isApiRequestPath($pathInfo);
+
+        // Assert
+        $this->assertFalse($result);
+    }
+
+    public static function isApiRequestPath_givenNonApiPath_returnsFalse_dataProvider(): Generator
+    {
+        // The trailing slash on the '/api/' prefix is load bearing: these must all stay outside the
+        // API surface, so '/api' without a trailing segment is a normal page that 404s in HTML
+        yield ['/api'];
+        yield ['/api.zip'];
+        yield ['/apis/controllers/users.js'];
+        yield ['/api_keys.json'];
+
+        yield ['/'];
+        yield ['/misc/legal'];
+    }
+
+    #[Test]
+    public function isApiRequest_givenRequestWithTrailingSlashApiPath_returnsTrue(): void
+    {
+        // Arrange - Request::create() keeps the trailing slash that Request::decodedPath() would trim
+        $apiRequestService = new ApiRequestService();
+
+        // Act
+        $result = $apiRequestService->isApiRequest(Request::create('/api/', 'GET'));
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function isApiRequest_givenRequestWithRegularPagePath_returnsFalse(): void
+    {
+        // Arrange
+        $apiRequestService = new ApiRequestService();
+
+        // Act
+        $result = $apiRequestService->isApiRequest(Request::create('/misc/legal', 'GET'));
+
+        // Assert
+        $this->assertFalse($result);
+    }
+}

--- a/tests/Feature/Controller/ErrorResponseTest.php
+++ b/tests/Feature/Controller/ErrorResponseTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\Controller;
 
 use App\Models\DungeonRoute\DungeonRoute;
-use App\Service\View\ViewServiceInterface;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Http\Request;
 use Illuminate\Testing\TestResponse;
@@ -18,8 +17,8 @@ final class ErrorResponseTest extends PublicTestCase
     #[Test]
     public function fallback_givenGetRequestToDeleteOnlyAjaxRoute_returns405Json(): void
     {
-        // Act - /ajax/profile/adfree/{user} is registered for POST and DELETE, but not GET. No view
-        // composers ever run on /ajax/ (ViewService::shouldLoadViewVariables()), so this must never
+        // Act - /ajax/profile/adfree/{user} is registered for POST and DELETE, but not GET. It is an
+        // API request (ApiRequestService), so no view composers run for it and this must never
         // render an HTML error view - it would crash on a missing view variable (#3806).
         $response = $this->get('/ajax/profile/adfree/1');
 
@@ -79,11 +78,11 @@ final class ErrorResponseTest extends PublicTestCase
     {
         // Act - "/api/" has no trailing segment, so it falls through to the public short-link
         // route (`{dungeonRoute}`, bound to "api") instead of any /api/* route, and 404s when that
-        // model isn't found. Handler::isApiRequest() used to miss this exact shape - it compared
-        // Request::decodedPath() (trailing slash trimmed to "api") against 'api/', which never
-        // matches - so this rendered an HTML error view with every view composer skipped, since
-        // ViewService::shouldLoadViewVariables() blacklists the same path by its raw, slash-
-        // preserving form and does NOT run composers for it (#3903).
+        // model isn't found. The hand-rolled check the Handler used before ApiRequestService missed
+        // this exact shape - it compared Request::decodedPath() (trailing slash trimmed to "api")
+        // against 'api/', which never matches - so this rendered an HTML error view with every view
+        // composer skipped, since ViewService keys composer registration off the raw, slash-
+        // preserving path and does NOT run them for it (#3903).
         //
         // The standard $this->get()/call() test helpers can't reproduce this - Laravel's own
         // MakesHttpRequests::prepareUrlForRequest() always trims the trailing slash off the URI
@@ -103,12 +102,12 @@ final class ErrorResponseTest extends PublicTestCase
     #[Test]
     public function fallback_givenPlainGetRequestToBareApiPathWithoutTrailingSlash_returns404HtmlPage(): void
     {
-        // Act - "/api" (no trailing slash) is a different shape from "/api/" above: its raw
-        // pathInfo is "/api", which ViewService::shouldLoadViewVariables() does NOT blacklist
-        // (only the slash-suffixed '/api/' prefix is), so isApiRequest() - delegating to that same
-        // check - agrees it's not an API request either. This never crashed even before #3903, so
-        // it's the ordinary HTML 404 page rather than a forced-JSON response - not a regression to
-        // fix, just the other half of the boundary the fix above sits on.
+        // Act - "/api" (no trailing slash) is a different shape from "/api/" above: its raw pathInfo
+        // is "/api", which ApiRequestService does NOT consider an API request (only the
+        // slash-suffixed '/api/' prefix is), and ViewService therefore runs composers for it. This
+        // never crashed even before #3903, so it's the ordinary HTML 404 page rather than a
+        // forced-JSON response - not a regression to fix, just the other half of the boundary the
+        // fix above sits on.
         $response = $this->get('/api');
 
         // Assert
@@ -117,46 +116,29 @@ final class ErrorResponseTest extends PublicTestCase
     }
 
     #[Test]
-    public function shouldLoadViewVariables_givenBareApiPathVersusApiPathWithTrailingSlash_disagreesOnBlacklisting(): void
+    public function fallback_givenPlainWrongMethodRequestToViewRenderingAjaxSearchRoute_returns405Json(): void
     {
-        // This pins the exact boundary the two tests above rely on, independent of whether view
-        // composers actually register - KeystoneGuruServiceProvider::boot() only skips
-        // registering them outside of `app()->runningUnitTests()`, so PHPUnit can't observe a
-        // composer-skip regression through an HTTP response either way.
-        $viewService = app(ViewServiceInterface::class);
-
-        $this->assertFalse($viewService->shouldLoadViewVariables('/api/'), "'/api/' must stay blacklisted");
-        $this->assertTrue($viewService->shouldLoadViewVariables('/api'), "'/api' (no trailing slash) must stay outside the blacklist");
-    }
-
-    #[Test]
-    public function fallback_givenPlainWrongMethodRequestToWhitelistedAjaxSearchRoute_returns405HtmlPage(): void
-    {
-        // Act - pins an intentional behavior change: '/ajax/search' is one of the handful of
-        // /ajax/ routes VIEW_VARIABLES_URL_WHITELIST carves back out of the blacklist (it renders
-        // an HTML fragment on success), so composers run there and isApiRequest() - now delegating
-        // to the same whitelist-aware check - no longer force-JSONs its errors either. Before this
-        // fix, isApiRequest()'s blanket '/ajax/' prefix match forced JSON here regardless of the
-        // whitelist. This is safe (composers running means no #3806/#3903-style crash), but it is
-        // an observable response-shape change for anything reading this route's error body as
-        // JSON - contrast with the still-forced-JSON '/ajax/profile/adfree/1' case above, which
-        // stays blacklisted because it isn't one of the three whitelisted paths.
+        // Act - '/ajax/search' is one of the handful of /ajax/ routes ViewService whitelists back
+        // into loading view variables, because it renders an HTML fragment on success. That
+        // whitelist is a view-layer concern only: the route is still an API request as far as
+        // ApiRequestService is concerned, so its errors are still forced to JSON exactly as they
+        // were before #3903 - same as the '/ajax/profile/adfree/1' case above.
         $response = $this->post('/ajax/search');
 
         // Assert - Allow also lists PATCH/DELETE: 'ajax/{dungeonRoute}' matches this exact URI too,
         // treating "search" as the dungeonRoute slug
         $response->assertStatus(405);
         $response->assertHeader('Allow', 'GET, HEAD, PATCH, DELETE');
-        $response->assertSee(__('view_errors.405.title'));
+        $response->assertJson(['message' => 'Method Not Allowed']);
     }
 
     #[Test]
     public function fallback_givenPlainPostRequestToGetOnlyBenchmarkRoute_returns405Json(): void
     {
-        // Act - '/benchmark' is the third VIEW_VARIABLES_URL_BLACKLIST entry (ViewService) besides
-        // '/ajax/' and '/api/' - the old hand-rolled isApiRequest() check never covered it at all,
-        // so any error there (this route is GET|HEAD only) rendered an HTML error view with every
-        // composer skipped, same crash class as #3903/#3806.
+        // Act - '/benchmark' is the third ApiRequestService prefix besides '/ajax/' and '/api/' -
+        // the old hand-rolled check in the Handler never covered it at all, so any error there
+        // (this route is GET|HEAD only) rendered an HTML error view with every composer skipped,
+        // same crash class as #3903/#3806.
         $response = $this->post('/benchmark');
 
         // Assert

--- a/tests/Feature/Controller/ErrorResponseTest.php
+++ b/tests/Feature/Controller/ErrorResponseTest.php
@@ -2,6 +2,10 @@
 
 namespace Tests\Feature\Controller;
 
+use App\Models\DungeonRoute\DungeonRoute;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Http\Request;
+use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
@@ -70,6 +74,62 @@ final class ErrorResponseTest extends PublicTestCase
     }
 
     #[Test]
+    public function fallback_givenPlainGetRequestToBareApiPath_returns404Json(): void
+    {
+        // Act - "/api/" has no trailing segment, so it falls through to the public short-link
+        // route (`{dungeonRoute}`, bound to "api") instead of any /api/* route, and 404s when that
+        // model isn't found. Handler::isApiRequest() used to miss this exact shape - it compared
+        // Request::decodedPath() (trailing slash trimmed to "api") against 'api/', which never
+        // matches - so this rendered an HTML error view with every view composer skipped, since
+        // ViewService::shouldLoadViewVariables() blacklists the same path by its raw, slash-
+        // preserving form and does NOT run composers for it (#3903).
+        //
+        // The standard $this->get()/call() test helpers can't reproduce this - Laravel's own
+        // MakesHttpRequests::prepareUrlForRequest() always trims the trailing slash off the URI
+        // before building the request, so "/api/" and "/api" are indistinguishable through them.
+        // Dispatch a manually-built request through the kernel instead, matching what call() does
+        // internally minus that trim, to keep the real trailing slash intact.
+        $response = $this->dispatchWithRawPath('/api/');
+
+        // Assert
+        $response->assertStatus(404);
+        $response->assertJson(['message' => __('exceptions.handler.api_model_not_found', [
+            'ids'   => 'api',
+            'model' => DungeonRoute::class,
+        ])]);
+    }
+
+    #[Test]
+    public function fallback_givenPlainGetRequestToBareApiPathWithoutTrailingSlash_returns404HtmlPage(): void
+    {
+        // Act - "/api" (no trailing slash) is a different shape from "/api/" above: Laravel's own
+        // Request::path()/getPathInfo() disagree on it, so ViewService::shouldLoadViewVariables()
+        // (raw pathInfo "/api", not blacklisted) and isApiRequest() (delegates to the same check)
+        // agree it's NOT blacklisted - view composers run normally here and it never crashed, so
+        // it's the ordinary HTML 404 page rather than a forced-JSON response.
+        $response = $this->get('/api');
+
+        // Assert
+        $response->assertStatus(404);
+        $response->assertSee(__('view_errors.404.title'));
+    }
+
+    #[Test]
+    public function fallback_givenPlainPostRequestToGetOnlyBenchmarkRoute_returns405Json(): void
+    {
+        // Act - '/benchmark' is the third VIEW_VARIABLES_URL_BLACKLIST entry (ViewService) besides
+        // '/ajax/' and '/api/' - the old hand-rolled isApiRequest() check never covered it at all,
+        // so any error there (this route is GET|HEAD only) rendered an HTML error view with every
+        // composer skipped, same crash class as #3903/#3806.
+        $response = $this->post('/benchmark');
+
+        // Assert
+        $response->assertStatus(405);
+        $response->assertHeader('Allow', 'GET, HEAD');
+        $response->assertJson(['message' => 'Method Not Allowed']);
+    }
+
+    #[Test]
     public function render_givenJsonWrongMethodToExistingRoute_returns405JsonWithAllowHeader(): void
     {
         // Act - the home page is GET only, so a POST is a genuine method mismatch thrown by the router
@@ -79,5 +139,23 @@ final class ErrorResponseTest extends PublicTestCase
         $response->assertStatus(405);
         $response->assertHeader('Allow', 'GET, HEAD');
         $response->assertJson(['message' => 'Method Not Allowed']);
+    }
+
+    /**
+     * Dispatches a GET request through the kernel with $path preserved verbatim, bypassing the
+     * trailing-slash trim MakesHttpRequests::call() applies to every request built via
+     * $this->get()/getJson()/etc.
+     *
+     * @return TestResponse<\Illuminate\Http\Response>
+     */
+    private function dispatchWithRawPath(string $path): TestResponse
+    {
+        $kernel = $this->app->make(HttpKernel::class);
+
+        $response = $kernel->handle($request = Request::create($path, 'GET'));
+
+        $kernel->terminate($request, $response);
+
+        return TestResponse::fromBaseResponse($response);
     }
 }

--- a/tests/Feature/Controller/ErrorResponseTest.php
+++ b/tests/Feature/Controller/ErrorResponseTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Controller;
 
 use App\Models\DungeonRoute\DungeonRoute;
+use App\Service\View\ViewServiceInterface;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Http\Request;
 use Illuminate\Testing\TestResponse;
@@ -102,16 +103,51 @@ final class ErrorResponseTest extends PublicTestCase
     #[Test]
     public function fallback_givenPlainGetRequestToBareApiPathWithoutTrailingSlash_returns404HtmlPage(): void
     {
-        // Act - "/api" (no trailing slash) is a different shape from "/api/" above: Laravel's own
-        // Request::path()/getPathInfo() disagree on it, so ViewService::shouldLoadViewVariables()
-        // (raw pathInfo "/api", not blacklisted) and isApiRequest() (delegates to the same check)
-        // agree it's NOT blacklisted - view composers run normally here and it never crashed, so
-        // it's the ordinary HTML 404 page rather than a forced-JSON response.
+        // Act - "/api" (no trailing slash) is a different shape from "/api/" above: its raw
+        // pathInfo is "/api", which ViewService::shouldLoadViewVariables() does NOT blacklist
+        // (only the slash-suffixed '/api/' prefix is), so isApiRequest() - delegating to that same
+        // check - agrees it's not an API request either. This never crashed even before #3903, so
+        // it's the ordinary HTML 404 page rather than a forced-JSON response - not a regression to
+        // fix, just the other half of the boundary the fix above sits on.
         $response = $this->get('/api');
 
         // Assert
         $response->assertStatus(404);
         $response->assertSee(__('view_errors.404.title'));
+    }
+
+    #[Test]
+    public function shouldLoadViewVariables_givenBareApiPathVersusApiPathWithTrailingSlash_disagreesOnBlacklisting(): void
+    {
+        // This pins the exact boundary the two tests above rely on, independent of whether view
+        // composers actually register - KeystoneGuruServiceProvider::boot() only skips
+        // registering them outside of `app()->runningUnitTests()`, so PHPUnit can't observe a
+        // composer-skip regression through an HTTP response either way.
+        $viewService = app(ViewServiceInterface::class);
+
+        $this->assertFalse($viewService->shouldLoadViewVariables('/api/'), "'/api/' must stay blacklisted");
+        $this->assertTrue($viewService->shouldLoadViewVariables('/api'), "'/api' (no trailing slash) must stay outside the blacklist");
+    }
+
+    #[Test]
+    public function fallback_givenPlainWrongMethodRequestToWhitelistedAjaxSearchRoute_returns405HtmlPage(): void
+    {
+        // Act - pins an intentional behavior change: '/ajax/search' is one of the handful of
+        // /ajax/ routes VIEW_VARIABLES_URL_WHITELIST carves back out of the blacklist (it renders
+        // an HTML fragment on success), so composers run there and isApiRequest() - now delegating
+        // to the same whitelist-aware check - no longer force-JSONs its errors either. Before this
+        // fix, isApiRequest()'s blanket '/ajax/' prefix match forced JSON here regardless of the
+        // whitelist. This is safe (composers running means no #3806/#3903-style crash), but it is
+        // an observable response-shape change for anything reading this route's error body as
+        // JSON - contrast with the still-forced-JSON '/ajax/profile/adfree/1' case above, which
+        // stays blacklisted because it isn't one of the three whitelisted paths.
+        $response = $this->post('/ajax/search');
+
+        // Assert - Allow also lists PATCH/DELETE: 'ajax/{dungeonRoute}' matches this exact URI too,
+        // treating "search" as the dungeonRoute slug
+        $response->assertStatus(405);
+        $response->assertHeader('Allow', 'GET, HEAD, PATCH, DELETE');
+        $response->assertSee(__('view_errors.405.title'));
     }
 
     #[Test]

--- a/tests/Feature/View/ViewComposerSmokeTest.php
+++ b/tests/Feature/View/ViewComposerSmokeTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\View;
 use App\Service\AffixGroup\AffixGroupEaseTierServiceInterface;
 use App\Service\Cache\CacheServiceInterface;
 use App\Service\Expansion\ExpansionServiceInterface;
+use App\Service\Request\ApiRequestServiceInterface;
 use App\Service\Season\SeasonAffixGroupServiceInterface;
 use App\Service\View\ViewService;
 use App\Service\View\ViewServiceInterface;
@@ -86,6 +87,7 @@ final class ViewComposerSmokeTest extends PublicTestCase
                 app(ExpansionServiceInterface::class),
                 app(SeasonAffixGroupServiceInterface::class),
                 app(AffixGroupEaseTierServiceInterface::class),
+                app(ApiRequestServiceInterface::class),
             ])
             ->onlyMethods(['getSelectableSpellsByCategory'])
             ->getMock();

--- a/tests/Fixtures/ServiceFixtures.php
+++ b/tests/Fixtures/ServiceFixtures.php
@@ -30,6 +30,8 @@ use App\Service\DungeonRoute\ThumbnailServiceInterface;
 use App\Service\Expansion\ExpansionService;
 use App\Service\Expansion\ExpansionServiceInterface;
 use App\Service\Metric\MetricService;
+use App\Service\Request\ApiRequestService;
+use App\Service\Request\ApiRequestServiceInterface;
 use App\Service\Season\SeasonAffixGroupService;
 use App\Service\Season\SeasonAffixGroupServiceInterface;
 use App\Service\Season\SeasonService;
@@ -85,6 +87,7 @@ class ServiceFixtures
         ?AffixGroupEaseTierServiceInterface $easeTierService = null,
         array                               $methodsToMock = [],
         ?SeasonAffixGroupServiceInterface   $seasonAffixGroupService = null,
+        ?ApiRequestServiceInterface         $apiRequestService = null,
     ): MockObject|ViewService {
         return $testCase
             ->getMockBuilderPublic(ViewService::class)
@@ -94,6 +97,7 @@ class ServiceFixtures
                 $expansionService ?? self::getExpansionServiceMock($testCase),
                 $seasonAffixGroupService ?? self::getSeasonAffixGroupServiceMock($testCase),
                 $easeTierService ?? self::getAffixGroupEaseTierServiceMock($testCase),
+                $apiRequestService ?? new ApiRequestService(),
             ])
             ->getMock();
     }


### PR DESCRIPTION
Closes #3903

:robot: A GET to a path with no trailing route segment (e.g. `GET /api/`) falls through to the public short-link catch-all route (`{dungeonRoute}`, bound to the leftover segment `"api"`), which 404s. View composers are correctly skipped for that raw, slash-preserving path, but `Handler::isApiRequest()` used `Request::decodedPath()` (which trims the trailing slash to `"api"`) against a `'api/'` prefix check that then never matches — so the 404 rendered as an HTML error view with no composer data, crashing on `header.blade.php`'s unconditional `$nextSeason` read. The same gap also silently missed `/benchmark` entirely.

Root cause was confirmed against the real Sentry event: `GET http://keystone.guru/api/`, `sapi: fpm-fcgi`, route match verified via tinker (`{dungeonRoute}` bound to `"api"`).

## Fix

The API path prefixes (`/ajax/`, `/api/`, `/benchmark`) used to live in `ViewService` as `VIEW_VARIABLES_URL_BLACKLIST`, with `Handler` hand-rolling its own drifting copy. Per review, "is this an API request" is now owned by a service of its own and **both** consumers read from it — the view surface no longer determines what an API request is:

- **`App\Service\Request\ApiRequestService`** + `ApiRequestServiceInterface` — owns the prefixes, exposes `isApiRequest(Request)` / `isApiRequestPath(string $pathInfo)`. Bound with `bind()` in `KeystoneGuruServiceProvider::register()`; dependency-free by design, since it is resolved very early on every request.
- **`ViewService`** constructor-injects the interface; `shouldLoadViewVariables()` is now "whitelisted → true, otherwise → not an API request".
- **`Handler::shouldReturnJson()`** resolves the service directly (matching how it already resolves `HandlerLoggingInterface`); `Handler::isApiRequest()` is deleted and `ViewServiceInterface` is no longer imported there.

`VIEW_VARIABLES_URL_WHITELIST` (`/ajax/dungeonroute/search`, `/ajax/search`, `/ajax/view`) deliberately stays in `ViewService`: those routes *are* API requests, and "they additionally render Blade so composers must run" is a view fact with exactly one consumer. `ViewServiceTest` therefore passes unchanged.

Because `Handler` no longer routes through that whitelist, `/ajax/search` errors are forced to JSON again — i.e. identical to `master`. The earlier revision of this PR had (via the `shouldLoadViewVariables()` delegation) turned them into HTML; that unrequested response-shape change is gone.

The `#3903` fix itself is unchanged: `getPathInfo()` preserves the trailing slash `decodedPath()` trimmed, so bare `/api/`, `/ajax/` and `/benchmark` are all detected.

## Tests

New `tests/Feature/App/Service/Request/ApiRequestServiceTest.php` exercises the extracted service directly: both methods, the load-bearing `'/api/'`-vs-`'/api'` and `/benchmark` boundaries, the whitelisted `/ajax/` paths still classifying as API requests, and an `assertInstanceOf` on `app(ApiRequestServiceInterface::class)` so a missing container binding can't pass silently.

`ErrorResponseTest` keeps the end-to-end coverage of both call sites:
- bare `/api/` (trailing slash) returns a JSON 404 instead of crashing — dispatched via a raw kernel call since Laravel's own test helpers (`MakesHttpRequests::prepareUrlForRequest()`) always trim the trailing slash and can't reproduce this shape
- bare `/api` (no trailing slash) still renders the normal HTML 404 page — it was never an API path, so no behavior change there
- `/benchmark` with a disallowed method returns a JSON 405 instead of crashing
- `/ajax/search` with a disallowed method returns a JSON 405, same as `master`
