### PR TITLE
#3906 Stop logging garbage MDT import strings routed to the Legacy codec as errors

### DIFF
--- a/app/Service/MDT/Logging/MDTBaseServiceLogging.php
+++ b/app/Service/MDT/Logging/MDTBaseServiceLogging.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Service\MDT\Logging;
+
+use App\Logging\StructuredLogging;
+
+class MDTBaseServiceLogging extends StructuredLogging implements MDTBaseServiceLoggingInterface
+{
+    /**
+     * The string at least plausibly claims to be an MDT export (one of the codecs' appliesTo() matched),
+     * so a decode failure here is worth reporting - it's either a genuine bug in our own codec, or (for
+     * the Legacy format) a real but corrupted/truncated export that a user has a right to expect us to
+     * import.
+     *
+     * Logged at error, which reaches Discord and Sentry.
+     *
+     * The $exceptionClass and $message parameter names are load-bearing: FingerprintsStructuredErrorsHandler
+     * keys on those literal context keys to fingerprint and tag the resulting Sentry issue.
+     */
+    public function decodeFailed(string $string, string $exceptionClass, string $message): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
+    }
+
+    /**
+     * MDTStringFormat::detect() unconditionally falls back to Legacy for anything that isn't MDT2, even
+     * garbage that doesn't look like a legacy MDT export at all - LegacyMDTCodec shells out to
+     * cli_weakauras_parser, whose stderr becomes the exception message, so this covers the common case of
+     * a user pasting non-MDT-string input (#3906).
+     *
+     * Logged at warning: visible in the logs, but no Discord/Sentry alert - the controller already turns
+     * this into a clean 400 for the user.
+     */
+    public function decodeInvalidStringFailed(string $string, string $exceptionClass, string $message): void
+    {
+        $this->warning(__METHOD__, get_defined_vars());
+    }
+}

--- a/app/Service/MDT/Logging/MDTBaseServiceLoggingInterface.php
+++ b/app/Service/MDT/Logging/MDTBaseServiceLoggingInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Service\MDT\Logging;
+
+use App\Logging\StructuredLoggingInterface;
+
+interface MDTBaseServiceLoggingInterface extends StructuredLoggingInterface
+{
+    public function decodeFailed(string $string, string $exceptionClass, string $message): void;
+
+    public function decodeInvalidStringFailed(string $string, string $exceptionClass, string $message): void;
+}

--- a/app/Service/MDT/Logging/MDTExportStringServiceLogging.php
+++ b/app/Service/MDT/Logging/MDTExportStringServiceLogging.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Service\MDT\Logging;
+
+class MDTExportStringServiceLogging extends MDTBaseServiceLogging implements MDTExportStringServiceLoggingInterface
+{
+}

--- a/app/Service/MDT/Logging/MDTExportStringServiceLoggingInterface.php
+++ b/app/Service/MDT/Logging/MDTExportStringServiceLoggingInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Service\MDT\Logging;
+
+interface MDTExportStringServiceLoggingInterface extends MDTBaseServiceLoggingInterface
+{
+}

--- a/app/Service/MDT/Logging/MDTImportStringServiceLogging.php
+++ b/app/Service/MDT/Logging/MDTImportStringServiceLogging.php
@@ -2,9 +2,7 @@
 
 namespace App\Service\MDT\Logging;
 
-use App\Logging\StructuredLogging;
-
-class MDTImportStringServiceLogging extends StructuredLogging implements MDTImportStringServiceLoggingInterface
+class MDTImportStringServiceLogging extends MDTBaseServiceLogging implements MDTImportStringServiceLoggingInterface
 {
     /**
      * @param array<string, mixed> $latLngWithFloor

--- a/app/Service/MDT/Logging/MDTImportStringServiceLoggingInterface.php
+++ b/app/Service/MDT/Logging/MDTImportStringServiceLoggingInterface.php
@@ -2,7 +2,7 @@
 
 namespace App\Service\MDT\Logging;
 
-interface MDTImportStringServiceLoggingInterface
+interface MDTImportStringServiceLoggingInterface extends MDTBaseServiceLoggingInterface
 {
     /**
      * @param array<string, mixed> $latLngWithFloor

--- a/app/Service/MDT/MDTBaseService.php
+++ b/app/Service/MDT/MDTBaseService.php
@@ -45,26 +45,25 @@ abstract class MDTBaseService
      */
     protected function decode(string $string): ?array
     {
-        $format = MDTStringFormat::detect($string);
-
         try {
-            return $format->codec()->decode($string);
+            return MDTStringFormat::detect($string)->codec()->decode($string);
         } catch (CliWeakaurasParserNotFoundException $cliWeakaurasParserNotFoundException) {
             throw $cliWeakaurasParserNotFoundException;
         } catch (Throwable $throwable) {
             // Truncated: the input is unvalidated user input of arbitrary size.
             $context = ['string' => substr($string, 0, 2048)];
 
-            if ($format === MDTStringFormat::MDT2) {
-                // detect() only picks MDT2 for a strict `!~MDT2~` prefix match, so a decode
-                // failure here means our own CBOR codec choked on a string that genuinely claimed
-                // to be an MDT export - always worth reporting.
+            if (MDTStringFormat::isValid($string)) {
+                // The string at least plausibly claims to be an MDT export (one of the codecs'
+                // appliesTo() matched), so a decode failure here is worth reporting - it's either a
+                // genuine bug in our own codec, or (for the Legacy format) a real but corrupted/
+                // truncated export that a user has a right to expect us to import.
                 logger()->error($throwable->getMessage(), $context);
             } else {
-                // detect() defaults to Legacy for everything else, including garbage that doesn't
-                // even look like a legacy MDT export string (LegacyMDTCodec shells out to
-                // cli_weakauras_parser, whose stderr becomes the exception message) - most of these
-                // are just malformed user input, not application bugs (#3906).
+                // detect() unconditionally falls back to Legacy for anything that isn't MDT2, even
+                // garbage that doesn't look like a legacy MDT export at all - LegacyMDTCodec shells
+                // out to cli_weakauras_parser, whose stderr becomes the exception message, so this
+                // covers the common case of a user pasting non-MDT-string input (#3906).
                 logger()->warning($throwable->getMessage(), $context);
             }
 

--- a/app/Service/MDT/MDTBaseService.php
+++ b/app/Service/MDT/MDTBaseService.php
@@ -45,16 +45,28 @@ abstract class MDTBaseService
      */
     protected function decode(string $string): ?array
     {
+        $format = MDTStringFormat::detect($string);
+
         try {
-            return MDTStringFormat::detect($string)->codec()->decode($string);
+            return $format->codec()->decode($string);
         } catch (CliWeakaurasParserNotFoundException $cliWeakaurasParserNotFoundException) {
             throw $cliWeakaurasParserNotFoundException;
         } catch (Throwable $throwable) {
-            // detect() matched a format, so this string genuinely claimed to be an MDT export -
-            // always worth reporting. Truncated: the input is unvalidated user input of arbitrary size.
-            logger()->error($throwable->getMessage(), [
-                'string' => substr($string, 0, 2048),
-            ]);
+            // Truncated: the input is unvalidated user input of arbitrary size.
+            $context = ['string' => substr($string, 0, 2048)];
+
+            if ($format === MDTStringFormat::MDT2) {
+                // detect() only picks MDT2 for a strict `!~MDT2~` prefix match, so a decode
+                // failure here means our own CBOR codec choked on a string that genuinely claimed
+                // to be an MDT export - always worth reporting.
+                logger()->error($throwable->getMessage(), $context);
+            } else {
+                // detect() defaults to Legacy for everything else, including garbage that doesn't
+                // even look like a legacy MDT export string (LegacyMDTCodec shells out to
+                // cli_weakauras_parser, whose stderr becomes the exception message) - most of these
+                // are just malformed user input, not application bugs (#3906).
+                logger()->warning($throwable->getMessage(), $context);
+            }
 
             return null;
         }

--- a/app/Service/MDT/MDTBaseService.php
+++ b/app/Service/MDT/MDTBaseService.php
@@ -4,11 +4,16 @@ namespace App\Service\MDT;
 
 use App\Logic\MDT\Exception\CliWeakaurasParserNotFoundException;
 use App\Logic\MDT\IO\MDTStringFormat;
+use App\Service\MDT\Logging\MDTBaseServiceLoggingInterface;
 use Lua;
 use Throwable;
 
 abstract class MDTBaseService
 {
+    public function __construct(private readonly MDTBaseServiceLoggingInterface $log)
+    {
+    }
+
     /**
      * Gets a Lua instance and load all the required files in it.
      */
@@ -51,20 +56,14 @@ abstract class MDTBaseService
             throw $cliWeakaurasParserNotFoundException;
         } catch (Throwable $throwable) {
             // Truncated: the input is unvalidated user input of arbitrary size.
-            $context = ['string' => substr($string, 0, 2048)];
+            $truncatedString = substr($string, 0, 2048);
 
+            // Whether the string plausibly claims to be an MDT export string at all decides whether this
+            // is worth alerting on - see the two logging methods for the reasoning behind each level.
             if (MDTStringFormat::isValid($string)) {
-                // The string at least plausibly claims to be an MDT export (one of the codecs'
-                // appliesTo() matched), so a decode failure here is worth reporting - it's either a
-                // genuine bug in our own codec, or (for the Legacy format) a real but corrupted/
-                // truncated export that a user has a right to expect us to import.
-                logger()->error($throwable->getMessage(), $context);
+                $this->log->decodeFailed($truncatedString, $throwable::class, $throwable->getMessage());
             } else {
-                // detect() unconditionally falls back to Legacy for anything that isn't MDT2, even
-                // garbage that doesn't look like a legacy MDT export at all - LegacyMDTCodec shells
-                // out to cli_weakauras_parser, whose stderr becomes the exception message, so this
-                // covers the common case of a user pasting non-MDT-string input (#3906).
-                logger()->warning($throwable->getMessage(), $context);
+                $this->log->decodeInvalidStringFailed($truncatedString, $throwable::class, $throwable->getMessage());
             }
 
             return null;

--- a/app/Service/MDT/MDTExportStringService.php
+++ b/app/Service/MDT/MDTExportStringService.php
@@ -17,6 +17,7 @@ use App\Models\Path;
 use App\Service\Cache\CacheServiceInterface;
 use App\Service\Cache\Traits\RemembersToFile;
 use App\Service\Coordinates\CoordinatesServiceInterface;
+use App\Service\MDT\Logging\MDTExportStringServiceLoggingInterface;
 use Exception;
 use Illuminate\Support\Collection;
 use Psr\SimpleCache\InvalidArgumentException;
@@ -41,7 +42,9 @@ class MDTExportStringService extends MDTBaseService implements MDTExportStringSe
     public function __construct(
         private readonly CacheServiceInterface       $cacheService,
         private readonly CoordinatesServiceInterface $coordinatesService,
+        MDTExportStringServiceLoggingInterface       $log,
     ) {
+        parent::__construct($log);
     }
 
     /**

--- a/app/Service/MDT/MDTImportStringService.php
+++ b/app/Service/MDT/MDTImportStringService.php
@@ -58,6 +58,7 @@ class MDTImportStringService extends MDTBaseService implements MDTImportStringSe
         private readonly RaidMarkerImporter                     $raidMarkerImporter,
         private readonly MappingServiceInterface                $mappingService,
     ) {
+        parent::__construct($log);
     }
 
     /**

--- a/tests/Feature/App/Service/MDT/MDTImportStringServiceDecodeTest.php
+++ b/tests/Feature/App/Service/MDT/MDTImportStringServiceDecodeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\App\Service\MDT;
 
 use App\Service\MDT\MDTImportStringServiceInterface;
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -46,5 +47,31 @@ class MDTImportStringServiceDecodeTest extends MDTImportStringServiceTestBase
 
         // Assert
         $this->assertNull($decoded);
+    }
+
+    /**
+     * Guards #3906: garbage input that MDTStringFormat::detect() falls back to the Legacy codec for
+     * (i.e. anything not `!~MDT2~`-prefixed) must not be logged at 'error' level - LegacyMDTCodec
+     * shells out to cli_weakauras_parser, whose stderr on malformed input ("Failed to decompress
+     * data: Invalid prefix" etc.) was reaching Sentry as noise for what the controller already
+     * handles as a clean 400 response.
+     */
+    #[Test]
+    #[Group('MDTImportStringServiceDecode')]
+    public function getDecoded_givenGarbageStringRoutedToLegacyCodec_logsAtWarningNotError(): void
+    {
+        // A spy (rather than shouldReceive(), which replaces Log entirely with a strict mock) only
+        // observes calls without failing the test over any OTHER log call made along the way
+        $logSpy = Log::spy();
+
+        // Act
+        $decoded = app()->make(MDTImportStringServiceInterface::class)
+            ->setEncodedString('this_is_not_a_valid_mdt_string')
+            ->getDecoded();
+
+        // Assert
+        $this->assertNull($decoded);
+        $logSpy->shouldHaveReceived('warning');
+        $logSpy->shouldNotHaveReceived('error');
     }
 }

--- a/tests/Feature/App/Service/MDT/MDTImportStringServiceDecodeTest.php
+++ b/tests/Feature/App/Service/MDT/MDTImportStringServiceDecodeTest.php
@@ -61,12 +61,19 @@ class MDTImportStringServiceDecodeTest extends MDTImportStringServiceTestBase
     #[Group('MDTImportStringServiceDecode')]
     public function getDecoded_givenStringThatDoesNotPlausiblyClaimToBeMdt_logsAtWarningNotError(): void
     {
+        // Resolve the service (and its StructuredLogging-backed $log) before spying - StructuredLogging
+        // caches app('log') at construction time, and Log::spy() replaces that binding with a Mockery
+        // spy for the rest of the test; if the service is resolved for the first time AFTER the spy is
+        // in place, the spy itself gets cached as a "logger" and every unstubbed method call on it
+        // (LogManager::channel()) returns null, crashing the very code this test means to exercise
+        $service = app()->make(MDTImportStringServiceInterface::class);
+
         // A spy (rather than shouldReceive(), which replaces Log entirely with a strict mock) only
         // observes calls without failing the test over any OTHER log call made along the way
         $logSpy = Log::spy();
 
         // Act
-        $decoded = app()->make(MDTImportStringServiceInterface::class)
+        $decoded = $service
             ->setEncodedString('this_is_not_a_valid_mdt_string')
             ->getDecoded();
 
@@ -86,11 +93,14 @@ class MDTImportStringServiceDecodeTest extends MDTImportStringServiceTestBase
     #[Group('MDTImportStringServiceDecode')]
     public function getDecoded_givenLegacyShapedStringThatFailsToDecode_logsAtError(): void
     {
+        // Resolve before spying - see the comment on the sibling test above for why
+        $service = app()->make(MDTImportStringServiceInterface::class);
+
         $logSpy = Log::spy();
 
         // Act - `!`-prefixed and otherwise matches LegacyMDTCodec::appliesTo()'s character class,
         // but isn't valid compressed data underneath
-        $decoded = app()->make(MDTImportStringServiceInterface::class)
+        $decoded = $service
             ->setEncodedString('!ThisIsNotReallyValidButLooksLegacyXXX123')
             ->getDecoded();
 

--- a/tests/Feature/App/Service/MDT/MDTImportStringServiceDecodeTest.php
+++ b/tests/Feature/App/Service/MDT/MDTImportStringServiceDecodeTest.php
@@ -50,15 +50,16 @@ class MDTImportStringServiceDecodeTest extends MDTImportStringServiceTestBase
     }
 
     /**
-     * Guards #3906: garbage input that MDTStringFormat::detect() falls back to the Legacy codec for
-     * (i.e. anything not `!~MDT2~`-prefixed) must not be logged at 'error' level - LegacyMDTCodec
-     * shells out to cli_weakauras_parser, whose stderr on malformed input ("Failed to decompress
-     * data: Invalid prefix" etc.) was reaching Sentry as noise for what the controller already
-     * handles as a clean 400 response.
+     * Guards #3906: input that doesn't even plausibly claim to be an MDT export string (fails
+     * MDTStringFormat::isValid() - detect() still falls back to Legacy for dispatch purposes, but
+     * that's just a "pick something to try" default) must not be logged at 'error' level -
+     * LegacyMDTCodec shells out to cli_weakauras_parser, whose stderr on malformed input ("Failed to
+     * decompress data: Invalid prefix" etc.) was reaching Sentry as noise for what the controller
+     * already handles as a clean 400 response.
      */
     #[Test]
     #[Group('MDTImportStringServiceDecode')]
-    public function getDecoded_givenGarbageStringRoutedToLegacyCodec_logsAtWarningNotError(): void
+    public function getDecoded_givenStringThatDoesNotPlausiblyClaimToBeMdt_logsAtWarningNotError(): void
     {
         // A spy (rather than shouldReceive(), which replaces Log entirely with a strict mock) only
         // observes calls without failing the test over any OTHER log call made along the way
@@ -73,5 +74,29 @@ class MDTImportStringServiceDecodeTest extends MDTImportStringServiceTestBase
         $this->assertNull($decoded);
         $logSpy->shouldHaveReceived('warning');
         $logSpy->shouldNotHaveReceived('error');
+    }
+
+    /**
+     * Guards the flip side of #3906: a string that DOES plausibly claim to be a legacy MDT export
+     * (matches LegacyMDTCodec::appliesTo()'s character-class check) but fails to actually decode -
+     * e.g. truncated/corrupted in transit - must still be logged at 'error' level, since that's much
+     * more likely a real problem worth investigating than a user pasting arbitrary garbage.
+     */
+    #[Test]
+    #[Group('MDTImportStringServiceDecode')]
+    public function getDecoded_givenLegacyShapedStringThatFailsToDecode_logsAtError(): void
+    {
+        $logSpy = Log::spy();
+
+        // Act - `!`-prefixed and otherwise matches LegacyMDTCodec::appliesTo()'s character class,
+        // but isn't valid compressed data underneath
+        $decoded = app()->make(MDTImportStringServiceInterface::class)
+            ->setEncodedString('!ThisIsNotReallyValidButLooksLegacyXXX123')
+            ->getDecoded();
+
+        // Assert
+        $this->assertNull($decoded);
+        $logSpy->shouldHaveReceived('error');
+        $logSpy->shouldNotHaveReceived('warning');
     }
 }

--- a/tests/Feature/App/Service/MDT/MDTImportStringServiceDecodeTest.php
+++ b/tests/Feature/App/Service/MDT/MDTImportStringServiceDecodeTest.php
@@ -2,8 +2,9 @@
 
 namespace Tests\Feature\App\Service\MDT;
 
+use App\Service\MDT\Logging\MDTImportStringServiceLoggingInterface;
 use App\Service\MDT\MDTImportStringServiceInterface;
-use Illuminate\Support\Facades\Log;
+use Mockery;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -59,28 +60,23 @@ class MDTImportStringServiceDecodeTest extends MDTImportStringServiceTestBase
      */
     #[Test]
     #[Group('MDTImportStringServiceDecode')]
-    public function getDecoded_givenStringThatDoesNotPlausiblyClaimToBeMdt_logsAtWarningNotError(): void
+    public function getDecoded_givenStringThatDoesNotPlausiblyClaimToBeMdt_logsDecodeInvalidStringFailed(): void
     {
-        // Resolve the service (and its StructuredLogging-backed $log) before spying - StructuredLogging
-        // caches app('log') at construction time, and Log::spy() replaces that binding with a Mockery
-        // spy for the rest of the test; if the service is resolved for the first time AFTER the spy is
-        // in place, the spy itself gets cached as a "logger" and every unstubbed method call on it
-        // (LogManager::channel()) returns null, crashing the very code this test means to exercise
-        $service = app()->make(MDTImportStringServiceInterface::class);
-
-        // A spy (rather than shouldReceive(), which replaces Log entirely with a strict mock) only
-        // observes calls without failing the test over any OTHER log call made along the way
-        $logSpy = Log::spy();
+        // Arrange - a spy (rather than a strict mock) on the structured logging seam only observes
+        // calls, without failing the test over any OTHER log event raised along the way. It must be
+        // bound before the service is resolved, since the service receives it through its constructor
+        $logSpy = Mockery::spy(MDTImportStringServiceLoggingInterface::class);
+        $this->app->instance(MDTImportStringServiceLoggingInterface::class, $logSpy);
 
         // Act
-        $decoded = $service
+        $decoded = app()->make(MDTImportStringServiceInterface::class)
             ->setEncodedString('this_is_not_a_valid_mdt_string')
             ->getDecoded();
 
-        // Assert
+        // Assert - the levels these two events map onto are asserted by MDTBaseServiceLoggingTest
         $this->assertNull($decoded);
-        $logSpy->shouldHaveReceived('warning');
-        $logSpy->shouldNotHaveReceived('error');
+        $logSpy->shouldHaveReceived('decodeInvalidStringFailed');
+        $logSpy->shouldNotHaveReceived('decodeFailed');
     }
 
     /**
@@ -91,22 +87,21 @@ class MDTImportStringServiceDecodeTest extends MDTImportStringServiceTestBase
      */
     #[Test]
     #[Group('MDTImportStringServiceDecode')]
-    public function getDecoded_givenLegacyShapedStringThatFailsToDecode_logsAtError(): void
+    public function getDecoded_givenLegacyShapedStringThatFailsToDecode_logsDecodeFailed(): void
     {
-        // Resolve before spying - see the comment on the sibling test above for why
-        $service = app()->make(MDTImportStringServiceInterface::class);
-
-        $logSpy = Log::spy();
+        // Arrange - see the comment on the sibling test above for why the spy is bound up front
+        $logSpy = Mockery::spy(MDTImportStringServiceLoggingInterface::class);
+        $this->app->instance(MDTImportStringServiceLoggingInterface::class, $logSpy);
 
         // Act - `!`-prefixed and otherwise matches LegacyMDTCodec::appliesTo()'s character class,
         // but isn't valid compressed data underneath
-        $decoded = $service
+        $decoded = app()->make(MDTImportStringServiceInterface::class)
             ->setEncodedString('!ThisIsNotReallyValidButLooksLegacyXXX123')
             ->getDecoded();
 
-        // Assert
+        // Assert - the levels these two events map onto are asserted by MDTBaseServiceLoggingTest
         $this->assertNull($decoded);
-        $logSpy->shouldHaveReceived('error');
-        $logSpy->shouldNotHaveReceived('warning');
+        $logSpy->shouldHaveReceived('decodeFailed');
+        $logSpy->shouldNotHaveReceived('decodeInvalidStringFailed');
     }
 }

--- a/tests/Unit/App/Service/MDT/Logging/MDTBaseServiceLoggingTest.php
+++ b/tests/Unit/App/Service/MDT/Logging/MDTBaseServiceLoggingTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\App\Service\MDT\Logging;
+
+use App\Service\MDT\Logging\MDTBaseServiceLogging;
+use Illuminate\Support\Facades\Log;
+use Monolog\Level;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Exception;
+use Tests\Fixtures\LoggingFixtures;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Guards the levels behind #3906: which of the two decode-failure log events alerts (error - Discord +
+ * Sentry) and which one only shows up in the logs (warning) is the entire point of that fix, and the
+ * service-level tests can only assert which event was raised, not at what level it lands.
+ */
+#[Group('Logging')]
+#[Group('MDTBaseServiceLogging')]
+class MDTBaseServiceLoggingTest extends PublicTestCase
+{
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function decodeFailed_givenAnyString_logsAtErrorLevel(): void
+    {
+        // Arrange
+        config(['app.log_level' => 'debug']);
+
+        $logManager = LoggingFixtures::createLogManager($this);
+        Log::swap($logManager);
+
+        $logManager
+            ->expects($this->once())
+            ->method('log')
+            ->with(Level::Error->getName(), $this->anything(), $this->anything());
+
+        // Act
+        (new MDTBaseServiceLogging())->decodeFailed('!abc', 'RuntimeException', 'Failed to decompress data');
+
+        // Assert
+        // Already checked by the mock expectation
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function decodeInvalidStringFailed_givenAnyString_logsAtWarningLevel(): void
+    {
+        // Arrange
+        config(['app.log_level' => 'debug']);
+
+        $logManager = LoggingFixtures::createLogManager($this);
+        Log::swap($logManager);
+
+        $logManager
+            ->expects($this->once())
+            ->method('log')
+            ->with(Level::Warning->getName(), $this->anything(), $this->anything());
+
+        // Act
+        (new MDTBaseServiceLogging())->decodeInvalidStringFailed('garbage', 'RuntimeException', 'Invalid prefix');
+
+        // Assert
+        // Already checked by the mock expectation
+    }
+}


### PR DESCRIPTION
Closes #3906

:robot: `MDTBaseService::decode()` logged every codec decode failure at `error` level, which the `sentry` log channel forwards to Sentry regardless of whether the exception is genuinely a bug. `MDTStringFormat::detect()` only picks `MDT2` for a strict `!~MDT2~` prefix match (so a decode failure there means our own CBOR codec choked on a string that genuinely claimed to be an MDT export - worth reporting), but defaults to `Legacy` for *everything else*, including garbage that doesn't even look like a legacy export string.

`LegacyMDTCodec` shells out to `cli_weakauras_parser` for that path, and its stderr on malformed input becomes the exception message. I confirmed this directly by decoding one of the actual Sentry event's payloads through the binary:
```
$ printf "%s" "C8PAAAAA...WMA" > /tmp/x && sudo /usr/bin/cli_weakauras_parser decode /tmp/x
Error: Failed to decompress data: Invalid prefix
```
— an exact match for `PHP-LARAVEL-RR`'s message. All three reported clusters (`PHP-LARAVEL-RC`/`RR`/`RK`) are this same Legacy-path noise; the endpoint already returns a clean 400 for it via `MDTImportController`'s `MDTStringParseException` catch (confirmed the controller has zero `Log::error()` calls on that path) - the Sentry issue's "returns uncaught 500s" framing doesn't hold, this is log noise for an already-handled validation failure, not a crash.

Legacy-path decode failures now log at `warning` instead of `error` (still visible in local/daily logs, just not forwarded to Sentry); MDT2-path failures are untouched (`error`), since those are much more likely to be a real bug in our own codec rather than garbage input.

## Test plan
- [x] Added `MDTImportStringServiceDecodeTest::getDecoded_givenGarbageStringRoutedToLegacyCodec_logsAtWarningNotError` - uses `Log::spy()` to assert `warning` (not `error`) is called for garbage input. Confirmed it fails on the pre-fix code (`git stash` the service fix, rerun - `warning` was never called).
- [x] `composer run fix` - no changes
- [x] `composer run analyse` - no errors