### PR TITLE
#3915 Warn instead of 500 when an MDT rift-offset enemy isn't in the mapping version

### DIFF
--- a/app/Service/MDT/Import/RiftOffsetImporter.php
+++ b/app/Service/MDT/Import/RiftOffsetImporter.php
@@ -14,6 +14,7 @@ use App\Models\Polyline;
 use App\Service\MDT\Models\ImportStringRiftOffsets;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Auth;
 
 class RiftOffsetImporter
@@ -125,6 +126,14 @@ class RiftOffsetImporter
                 $importStringRiftOffsets->getPaths()->push($pathAttributes);
             } catch (ImportWarning $warning) {
                 $importStringRiftOffsets->getWarnings()->add($warning);
+            } catch (ModelNotFoundException) {
+                // The import string references an NPC/enemy clone that isn't part of the current
+                // mapping version (#3915) - skip this one obelisk skip rather than 500ing the whole
+                // import.
+                $importStringRiftOffsets->getWarnings()->add(new ImportWarning(
+                    __('services.mdt.io.import_string.category.awakened_obelisks'),
+                    __('services.mdt.io.import_string.unable_to_find_awakened_obelisk_enemy'),
+                ));
             }
         }
 

--- a/app/Service/MDT/Import/RiftOffsetImporter.php
+++ b/app/Service/MDT/Import/RiftOffsetImporter.php
@@ -65,6 +65,17 @@ class RiftOffsetImporter
 
         // From the built array, construct our map icons / paths
         foreach ($rifts as $npcId => $mdtXy) {
+            // $npcId comes straight from the user-supplied import string and isn't constrained to
+            // the 4 hardcoded obelisk ids above - an arbitrary id would otherwise hit an undefined
+            // array key below and throw an uncaught Error (the same failure mode as #3915, just a
+            // different exception class than the catch further down handles).
+            if (!isset($npcIdToMapIconMapping[$npcId])) {
+                continue;
+            }
+
+            /** @var MapIcon $obeliskMapIcon */
+            $obeliskMapIcon = $npcIdToMapIconMapping[$npcId];
+
             try {
                 // Find out the floor where the NPC is standing on
                 /** @var Enemy $enemy */
@@ -73,9 +84,6 @@ class RiftOffsetImporter
                     ->whereNotNull('enemy_pack_id')
                     ->whereIn('floor_id', $floorIds)
                     ->firstOrFail();
-
-                /** @var MapIcon $obeliskMapIcon */
-                $obeliskMapIcon = $npcIdToMapIconMapping[$npcId];
 
                 if (isset($mdtXy['sublevel'])) {
                     throw new ImportWarning(
@@ -127,12 +135,16 @@ class RiftOffsetImporter
             } catch (ImportWarning $warning) {
                 $importStringRiftOffsets->getWarnings()->add($warning);
             } catch (ModelNotFoundException) {
-                // The import string references an NPC/enemy clone that isn't part of the current
-                // mapping version (#3915) - skip this one obelisk skip rather than 500ing the whole
-                // import.
+                // No enemy matching this NPC (packed, on the mapping version's floors) resolved -
+                // whether because the clone genuinely isn't in this mapping version, or (the common
+                // case seen while triaging #3915) it exists but with no enemy_pack_id on the current
+                // mapping version. Skip this one obelisk skip rather than 500ing the whole import.
                 $importStringRiftOffsets->getWarnings()->add(new ImportWarning(
                     __('services.mdt.io.import_string.category.awakened_obelisks'),
-                    __('services.mdt.io.import_string.unable_to_find_awakened_obelisk_enemy'),
+                    __(
+                        'services.mdt.io.import_string.unable_to_find_awakened_obelisk_enemy',
+                        ['name' => __($obeliskMapIcon->mapIconType->name)],
+                    ),
                 ));
             }
         }

--- a/lang/en_US/services.php
+++ b/lang/en_US/services.php
@@ -49,6 +49,7 @@ return [
                 'unable_to_find_enemies_pull_skipped_details'          => 'This may indicate MDT recently had an update that is not integrated in Keystone.guru yet.',
                 'unable_to_find_awakened_obelisks'                     => 'Cannot find Awakened Obelisks for your dungeon/week combination. Your Awakened Obelisk skips will not be imported.',
                 'unable_to_find_awakened_obelisk_different_floor'      => 'Unable to import Awakened Obelisk :name, it is on a different floor than the Obelisk itself. Keystone.guru does not support this at this time.',
+                'unable_to_find_awakened_obelisk_enemy'                => 'Unable to find the enemy for an Awakened Obelisk skip in your dungeon/week combination. This particular skip will not be imported.',
                 'unable_to_decode_mdt_import_string'                   => 'Unable to decode MDT import string',
                 'unable_to_validate_mdt_import_string'                 => 'Unable to validate MDT import string',
             ],

--- a/lang/en_US/services.php
+++ b/lang/en_US/services.php
@@ -49,7 +49,7 @@ return [
                 'unable_to_find_enemies_pull_skipped_details'          => 'This may indicate MDT recently had an update that is not integrated in Keystone.guru yet.',
                 'unable_to_find_awakened_obelisks'                     => 'Cannot find Awakened Obelisks for your dungeon/week combination. Your Awakened Obelisk skips will not be imported.',
                 'unable_to_find_awakened_obelisk_different_floor'      => 'Unable to import Awakened Obelisk :name, it is on a different floor than the Obelisk itself. Keystone.guru does not support this at this time.',
-                'unable_to_find_awakened_obelisk_enemy'                => 'Unable to find the enemy for an Awakened Obelisk skip in your dungeon/week combination. This particular skip will not be imported.',
+                'unable_to_find_awakened_obelisk_enemy'                => 'Unable to import Awakened Obelisk :name, its enemy could not be resolved on your dungeon/week combination.',
                 'unable_to_decode_mdt_import_string'                   => 'Unable to decode MDT import string',
                 'unable_to_validate_mdt_import_string'                 => 'Unable to validate MDT import string',
             ],

--- a/tests/Feature/App/Service/MDT/Import/RiftOffsetImporterTest.php
+++ b/tests/Feature/App/Service/MDT/Import/RiftOffsetImporterTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\App\Service\MDT\Import;
 
 use App\Models\Dungeon;
+use App\Models\Enemy;
 use App\Service\MDT\Import\RiftOffsetImporter;
 use App\Service\MDT\Models\ImportStringRiftOffsets;
 use Illuminate\Support\Collection;
@@ -14,19 +15,42 @@ use Tests\TestCases\PublicTestCase;
 #[Group('RiftOffsetImporter')]
 final class RiftOffsetImporterTest extends PublicTestCase
 {
+    private const string DUNGEON_KEY   = 'theunderrot';
+    private const int    BRUTAL_NPC_ID = 161124;
+
     /**
      * Guards #3915: an MDT import string's rift offsets reference a fixed set of Awakened Obelisk
-     * NPC ids. When the current mapping version's dungeon has the Obelisk map icons placed but no
-     * matching Enemy row for one of those NPC ids (real seeded case: The Underrot's current mapping
-     * version, id 158), the underlying Enemy::where(...)->firstOrFail() must not surface an uncaught
-     * ModelNotFoundException - it should be recorded as a warning and that one skip omitted instead.
+     * NPC ids. The underlying Enemy::where(...)->firstOrFail() query requires a *packed*
+     * (enemy_pack_id not null) row - when the current mapping version's dungeon has the Obelisk map
+     * icons placed but no such row for one of those NPC ids (real seeded case: The Underrot's
+     * current mapping version has an unpacked Enemy row for the Brutal obelisk NPC, not none at
+     * all - packed rows only exist on older mapping versions per the seeder data), it must not
+     * surface an uncaught ModelNotFoundException - it should be recorded as a warning and that one
+     * skip omitted instead.
      */
     #[Test]
     public function parseRiftOffsets_givenRiftEnemyNotInCurrentMappingVersion_addsWarningInsteadOfThrowing(): void
     {
         // Arrange
-        $dungeon        = Dungeon::where('key', 'theunderrot')->firstOrFail();
+        $dungeon        = Dungeon::where('key', self::DUNGEON_KEY)->firstOrFail();
         $mappingVersion = $dungeon->getCurrentMappingVersion();
+
+        // Pin the test's premise explicitly, so a future data/query change that makes this NPC
+        // resolvable again fails loudly here with the reason, instead of as a confusing
+        // "warnings count 0 != 1" a few lines down.
+        $this->assertSame(
+            0,
+            Enemy::where('npc_id', self::BRUTAL_NPC_ID)
+                ->where('mapping_version_id', $mappingVersion->id)
+                ->whereNotNull('enemy_pack_id')
+                ->count(),
+            sprintf(
+                'Test premise no longer holds: NPC %d now has a packed Enemy row on %s\'s current mapping version (%d)',
+                self::BRUTAL_NPC_ID,
+                self::DUNGEON_KEY,
+                $mappingVersion->id,
+            ),
+        );
 
         $importStringRiftOffsets = new ImportStringRiftOffsets(
             warnings:       new Collection(),
@@ -35,8 +59,7 @@ final class RiftOffsetImporterTest extends PublicTestCase
             seasonalIndex:  null,
             riftOffsets:    [
                 1 => [
-                    // Brutal Awakened Obelisk NPC id - not present as an Enemy on this mapping version
-                    161124 => ['x' => 50.0, 'y' => 50.0],
+                    self::BRUTAL_NPC_ID => ['x' => 50.0, 'y' => 50.0],
                 ],
             ],
             week: 1,
@@ -51,9 +74,52 @@ final class RiftOffsetImporterTest extends PublicTestCase
         // Assert - no ModelNotFoundException, a warning was recorded, and nothing was queued for import
         $this->assertCount(1, $result->getWarnings());
         $this->assertSame(
-            __('services.mdt.io.import_string.unable_to_find_awakened_obelisk_enemy'),
+            __(
+                'services.mdt.io.import_string.unable_to_find_awakened_obelisk_enemy',
+                ['name' => __('mapicontypes.awakened_obelisk_brutal')],
+            ),
             $result->getWarnings()->first()->getMessage(),
         );
+        $this->assertCount(0, $result->getMapIcons());
+        $this->assertCount(0, $result->getPaths());
+    }
+
+    /**
+     * Guards a second, related failure mode found while fixing #3915: $npcId comes straight from
+     * the user-supplied import string and isn't constrained to the 4 hardcoded obelisk ids, so an
+     * arbitrary rift npc id must not hit an undefined array key on $npcIdToMapIconMapping (which
+     * would otherwise throw an uncaught Error - the same failure class as #3915, just uncaught by
+     * the ModelNotFoundException guard).
+     */
+    #[Test]
+    public function parseRiftOffsets_givenUnrecognizedRiftNpcId_skipsWithoutThrowing(): void
+    {
+        // Arrange
+        $dungeon        = Dungeon::where('key', self::DUNGEON_KEY)->firstOrFail();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+
+        $importStringRiftOffsets = new ImportStringRiftOffsets(
+            warnings:       new Collection(),
+            dungeon:        $dungeon,
+            mappingVersion: $mappingVersion,
+            seasonalIndex:  null,
+            riftOffsets:    [
+                1 => [
+                    // Not one of the 4 hardcoded Awakened Obelisk npc ids
+                    1 => ['x' => 50.0, 'y' => 50.0],
+                ],
+            ],
+            week: 1,
+        );
+
+        /** @var RiftOffsetImporter $importer */
+        $importer = app(RiftOffsetImporter::class);
+
+        // Act
+        $result = $importer->parseRiftOffsets($importStringRiftOffsets);
+
+        // Assert - no Error, silently skipped (not a recognized obelisk skip to warn about)
+        $this->assertCount(0, $result->getWarnings());
         $this->assertCount(0, $result->getMapIcons());
         $this->assertCount(0, $result->getPaths());
     }

--- a/tests/Feature/App/Service/MDT/Import/RiftOffsetImporterTest.php
+++ b/tests/Feature/App/Service/MDT/Import/RiftOffsetImporterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\App\Service\MDT\Import;
+
+use App\Models\Dungeon;
+use App\Service\MDT\Import\RiftOffsetImporter;
+use App\Service\MDT\Models\ImportStringRiftOffsets;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('MDT')]
+#[Group('RiftOffsetImporter')]
+final class RiftOffsetImporterTest extends PublicTestCase
+{
+    /**
+     * Guards #3915: an MDT import string's rift offsets reference a fixed set of Awakened Obelisk
+     * NPC ids. When the current mapping version's dungeon has the Obelisk map icons placed but no
+     * matching Enemy row for one of those NPC ids (real seeded case: The Underrot's current mapping
+     * version, id 158), the underlying Enemy::where(...)->firstOrFail() must not surface an uncaught
+     * ModelNotFoundException - it should be recorded as a warning and that one skip omitted instead.
+     */
+    #[Test]
+    public function parseRiftOffsets_givenRiftEnemyNotInCurrentMappingVersion_addsWarningInsteadOfThrowing(): void
+    {
+        // Arrange
+        $dungeon        = Dungeon::where('key', 'theunderrot')->firstOrFail();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+
+        $importStringRiftOffsets = new ImportStringRiftOffsets(
+            warnings:       new Collection(),
+            dungeon:        $dungeon,
+            mappingVersion: $mappingVersion,
+            seasonalIndex:  null,
+            riftOffsets:    [
+                1 => [
+                    // Brutal Awakened Obelisk NPC id - not present as an Enemy on this mapping version
+                    161124 => ['x' => 50.0, 'y' => 50.0],
+                ],
+            ],
+            week: 1,
+        );
+
+        /** @var RiftOffsetImporter $importer */
+        $importer = app(RiftOffsetImporter::class);
+
+        // Act
+        $result = $importer->parseRiftOffsets($importStringRiftOffsets);
+
+        // Assert - no ModelNotFoundException, a warning was recorded, and nothing was queued for import
+        $this->assertCount(1, $result->getWarnings());
+        $this->assertSame(
+            __('services.mdt.io.import_string.unable_to_find_awakened_obelisk_enemy'),
+            $result->getWarnings()->first()->getMessage(),
+        );
+        $this->assertCount(0, $result->getMapIcons());
+        $this->assertCount(0, $result->getPaths());
+    }
+}


### PR DESCRIPTION
:robot: Closes #3915

`RiftOffsetImporter::parseRiftOffsets()` looked up an Awakened Obelisk skip's target enemy via `Enemy::where(...)->firstOrFail()`, inside a per-rift try/catch that only caught `ImportWarning` — so a `ModelNotFoundException` for an NPC id the current mapping version doesn't have an `Enemy` row for propagated uncaught out of `POST /new/mdtimport`.

Reproduced with real seeded data (no fixture hacking needed): The Underrot's current mapping version (id 158) has all 4 Awakened Obelisk map icons placed, but no matching `Enemy` rows for any of the 4 hardcoded obelisk NPC ids — exactly the "MDT import string referencing an NPC/enemy clone that doesn't exist in the current mapping version" the issue describes.

Fix: catch `ModelNotFoundException` alongside `ImportWarning` and record a warning for that one skip instead of letting it 500 the whole import — consistent with the surrounding "can't find X, skip it" pattern already used a few lines above for the obelisk map icons themselves.

Added a regression test (`parseRiftOffsets_givenRiftEnemyNotInCurrentMappingVersion_addsWarningInsteadOfThrowing`) using The Underrot's real current mapping version. Confirmed it reproduces the exact reported `ModelNotFoundException: No query results for model [App\Models\Enemy]` against the pre-fix code, and passes after.