### PR TITLE
#3918 Stop paging Sentry when a run's combat-log segments aren't uploaded yet

### DIFF
--- a/app/Jobs/Logging/ProcessCombatLogSegmentsLogging.php
+++ b/app/Jobs/Logging/ProcessCombatLogSegmentsLogging.php
@@ -13,10 +13,11 @@ class ProcessCombatLogSegmentsLogging extends StructuredLogging implements Proce
 
     public function handleSegmentsNotAvailable(int $runId): void
     {
-        // A run's segments not being available yet is an expected, recurring state (#3918) - the
-        // underlying RaiderIOApiServiceLogging call already logs the specific reason at the
-        // appropriate level (error for a genuinely malformed response, info for "not yet uploaded"),
-        // so this is just an echo and shouldn't page Sentry on its own.
+        // Fires for two distinct callers (#3918), both an expected, recurring state rather than a
+        // broken integration: getCombatLogSegmentsForRun() returned null (in which case
+        // RaiderIOApiServiceLogging already logged the specific reason, at error or info depending
+        // on cause), or it returned a well-formed response whose segments array is simply empty (no
+        // upstream log at all for that case - this is the only signal). Neither should page Sentry.
         $this->info(__METHOD__, get_defined_vars());
     }
 

--- a/app/Jobs/Logging/ProcessCombatLogSegmentsLogging.php
+++ b/app/Jobs/Logging/ProcessCombatLogSegmentsLogging.php
@@ -13,7 +13,11 @@ class ProcessCombatLogSegmentsLogging extends StructuredLogging implements Proce
 
     public function handleSegmentsNotAvailable(int $runId): void
     {
-        $this->error(__METHOD__, get_defined_vars());
+        // A run's segments not being available yet is an expected, recurring state (#3918) - the
+        // underlying RaiderIOApiServiceLogging call already logs the specific reason at the
+        // appropriate level (error for a genuinely malformed response, info for "not yet uploaded"),
+        // so this is just an echo and shouldn't page Sentry on its own.
+        $this->info(__METHOD__, get_defined_vars());
     }
 
     public function handleDownloadingSegment(int $runId, int $segmentId, string $downloadUrl, string $tempPath): void

--- a/app/Service/RaiderIO/Logging/RaiderIOApiServiceLogging.php
+++ b/app/Service/RaiderIO/Logging/RaiderIOApiServiceLogging.php
@@ -50,7 +50,7 @@ class RaiderIOApiServiceLogging extends StructuredLogging implements RaiderIOApi
         $this->error(__METHOD__, get_defined_vars());
     }
 
-    public function getCombatLogSegmentsForRunNotYetAvailable(int $runId, string $url): void
+    public function getCombatLogSegmentsForRunNotYetAvailable(int $runId, string $url, string $response): void
     {
         // A run's segments simply not having been uploaded to Raider.IO yet is an expected,
         // recurring state (#3918) rather than a broken API integration - logged below error so it

--- a/app/Service/RaiderIO/Logging/RaiderIOApiServiceLogging.php
+++ b/app/Service/RaiderIO/Logging/RaiderIOApiServiceLogging.php
@@ -50,6 +50,14 @@ class RaiderIOApiServiceLogging extends StructuredLogging implements RaiderIOApi
         $this->error(__METHOD__, get_defined_vars());
     }
 
+    public function getCombatLogSegmentsForRunNotYetAvailable(int $runId, string $url): void
+    {
+        // A run's segments simply not having been uploaded to Raider.IO yet is an expected,
+        // recurring state (#3918) rather than a broken API integration - logged below error so it
+        // doesn't page Sentry (the sentry log channel alerts on error level; see config/logging.php).
+        $this->info(__METHOD__, get_defined_vars());
+    }
+
     public function getCombatLogSegmentsForRunEnd(int $runId): void
     {
         $this->end(__METHOD__, get_defined_vars());

--- a/app/Service/RaiderIO/Logging/RaiderIOApiServiceLoggingInterface.php
+++ b/app/Service/RaiderIO/Logging/RaiderIOApiServiceLoggingInterface.php
@@ -20,7 +20,7 @@ interface RaiderIOApiServiceLoggingInterface
 
     public function getCombatLogSegmentsForRunInvalidResponse(int $runId, string $url, string $response): void;
 
-    public function getCombatLogSegmentsForRunNotYetAvailable(int $runId, string $url): void;
+    public function getCombatLogSegmentsForRunNotYetAvailable(int $runId, string $url, string $response): void;
 
     public function getCombatLogSegmentsForRunEnd(int $runId): void;
 }

--- a/app/Service/RaiderIO/Logging/RaiderIOApiServiceLoggingInterface.php
+++ b/app/Service/RaiderIO/Logging/RaiderIOApiServiceLoggingInterface.php
@@ -20,5 +20,7 @@ interface RaiderIOApiServiceLoggingInterface
 
     public function getCombatLogSegmentsForRunInvalidResponse(int $runId, string $url, string $response): void;
 
+    public function getCombatLogSegmentsForRunNotYetAvailable(int $runId, string $url): void;
+
     public function getCombatLogSegmentsForRunEnd(int $runId): void;
 }

--- a/app/Service/RaiderIO/RaiderIOApiService.php
+++ b/app/Service/RaiderIO/RaiderIOApiService.php
@@ -178,7 +178,14 @@ class RaiderIOApiService implements RaiderIOApiServiceInterface
             $json     = json_decode($response, true);
 
             if (!is_array($json) || !isset($json['sourceUserId'], $json['segments']) || !is_array($json['segments'])) {
-                $this->log->getCombatLogSegmentsForRunInvalidResponse($runId, $url, $response);
+                // A 404 with this shape means the run's segments simply haven't been uploaded to
+                // Raider.IO yet (#3918) - an expected, recurring state to log distinctly from a
+                // genuinely malformed/unexpected response, which stays error-level below.
+                if (($json['statusCode'] ?? null) === 404) {
+                    $this->log->getCombatLogSegmentsForRunNotYetAvailable($runId, $url);
+                } else {
+                    $this->log->getCombatLogSegmentsForRunInvalidResponse($runId, $url, $response);
+                }
 
                 return null;
             }

--- a/app/Service/RaiderIO/RaiderIOApiService.php
+++ b/app/Service/RaiderIO/RaiderIOApiService.php
@@ -178,11 +178,16 @@ class RaiderIOApiService implements RaiderIOApiServiceInterface
             $json     = json_decode($response, true);
 
             if (!is_array($json) || !isset($json['sourceUserId'], $json['segments']) || !is_array($json['segments'])) {
-                // A 404 with this shape means the run's segments simply haven't been uploaded to
-                // Raider.IO yet (#3918) - an expected, recurring state to log distinctly from a
-                // genuinely malformed/unexpected response, which stays error-level below.
-                if (($json['statusCode'] ?? null) === 404) {
-                    $this->log->getCombatLogSegmentsForRunNotYetAvailable($runId, $url);
+                // A 404 with this specific message means the run's segments simply haven't been
+                // uploaded to Raider.IO yet (#3918) - an expected, recurring state to log distinctly
+                // from a genuinely malformed/unexpected response, which stays error-level below.
+                // Matching on 'message' too (not just 'statusCode') matters: the upstream API is
+                // hapi-style, whose default route-not-found body is also {"statusCode":404,"error":
+                // "Not Found","message":"Not Found"} - identical statusCode, but a real integration
+                // break (wrong path, unrecognized season) that must still page.
+                if (($json['statusCode'] ?? null) === 404
+                    && str_contains((string)($json['message'] ?? ''), 'combat log segments')) {
+                    $this->log->getCombatLogSegmentsForRunNotYetAvailable($runId, $url, $response);
                 } else {
                     $this->log->getCombatLogSegmentsForRunInvalidResponse($runId, $url, $response);
                 }

--- a/app/Service/RaiderIO/RaiderIOApiService.php
+++ b/app/Service/RaiderIO/RaiderIOApiService.php
@@ -19,6 +19,7 @@ use App\Service\Season\SeasonAffixGroupServiceInterface;
 use App\Service\Season\SeasonServiceInterface;
 use App\Service\Traits\Curl;
 use Str;
+use Teapot\StatusCode\Http;
 
 class RaiderIOApiService implements RaiderIOApiServiceInterface
 {
@@ -185,7 +186,7 @@ class RaiderIOApiService implements RaiderIOApiServiceInterface
                 // hapi-style, whose default route-not-found body is also {"statusCode":404,"error":
                 // "Not Found","message":"Not Found"} - identical statusCode, but a real integration
                 // break (wrong path, unrecognized season) that must still page.
-                if (($json['statusCode'] ?? null) === 404
+                if (($json['statusCode'] ?? null) === Http::NOT_FOUND
                     && str_contains((string)($json['message'] ?? ''), 'combat log segments')) {
                     $this->log->getCombatLogSegmentsForRunNotYetAvailable($runId, $url, $response);
                 } else {

--- a/tests/Feature/App/Service/RaiderIO/RaiderIOApiServiceTest.php
+++ b/tests/Feature/App/Service/RaiderIO/RaiderIOApiServiceTest.php
@@ -83,7 +83,34 @@ final class RaiderIOApiServiceTest extends PublicTestCase
     {
         // Arrange
         $this->log->expects($this->once())->method('getCombatLogSegmentsForRunInvalidResponse');
+        $this->log->expects($this->never())->method('getCombatLogSegmentsForRunNotYetAvailable');
         $service = $this->makeService(fn(): string => 'not json');
+
+        // Act
+        $result = $service->getCombatLogSegmentsForRun($this->makeSeason(), self::RUN_ID);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    /**
+     * Guards #3918: a run's segments simply not having been uploaded to Raider.IO yet (the API
+     * returns a 404 with this specific shape) is an expected, recurring state - it must be logged
+     * distinctly from a genuinely malformed response instead of paging Sentry as an error.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function getCombatLogSegmentsForRun_givenSegmentsNotYetAvailable_logsDistinctlyFromInvalidResponse(): void
+    {
+        // Arrange
+        $this->log->expects($this->once())->method('getCombatLogSegmentsForRunNotYetAvailable');
+        $this->log->expects($this->never())->method('getCombatLogSegmentsForRunInvalidResponse');
+        $service = $this->makeService(fn(): string => json_encode([
+            'statusCode' => 404,
+            'error'      => 'Not Found',
+            'message'    => 'No combat log segments found for this run',
+        ]));
 
         // Act
         $result = $service->getCombatLogSegmentsForRun($this->makeSeason(), self::RUN_ID);

--- a/tests/Feature/App/Service/RaiderIO/RaiderIOApiServiceTest.php
+++ b/tests/Feature/App/Service/RaiderIO/RaiderIOApiServiceTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
+use Teapot\StatusCode\Http;
 use Tests\TestCases\PublicTestCase;
 
 #[Group('RaiderIO')]
@@ -107,9 +108,36 @@ final class RaiderIOApiServiceTest extends PublicTestCase
         $this->log->expects($this->once())->method('getCombatLogSegmentsForRunNotYetAvailable');
         $this->log->expects($this->never())->method('getCombatLogSegmentsForRunInvalidResponse');
         $service = $this->makeService(fn(): string => json_encode([
-            'statusCode' => 404,
+            'statusCode' => Http::NOT_FOUND,
             'error'      => 'Not Found',
             'message'    => 'No combat log segments found for this run',
+        ]));
+
+        // Act
+        $result = $service->getCombatLogSegmentsForRun($this->makeSeason(), self::RUN_ID);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    /**
+     * Guards #3918: the upstream API is hapi-style, so a genuine route-not-found (wrong path,
+     * unrecognized season) yields the same status code with a generic message - that is a broken
+     * integration and must still be logged at error level rather than swallowed as "not yet
+     * uploaded".
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function getCombatLogSegmentsForRun_givenGenericNotFoundResponse_logsAsInvalidResponse(): void
+    {
+        // Arrange
+        $this->log->expects($this->once())->method('getCombatLogSegmentsForRunInvalidResponse');
+        $this->log->expects($this->never())->method('getCombatLogSegmentsForRunNotYetAvailable');
+        $service = $this->makeService(fn(): string => json_encode([
+            'statusCode' => Http::NOT_FOUND,
+            'error'      => 'Not Found',
+            'message'    => 'Not Found',
         ]));
 
         // Act

--- a/tests/Unit/App/Jobs/Logging/ProcessCombatLogSegmentsLoggingTest.php
+++ b/tests/Unit/App/Jobs/Logging/ProcessCombatLogSegmentsLoggingTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit\App\Jobs\Logging;
+
+use App\Jobs\Logging\ProcessCombatLogSegmentsLoggingInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Exception;
+use Tests\Fixtures\LoggingFixtures;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Guards #3918: handleSegmentsNotAvailable() was downgraded from error to info so it stops paging
+ * the sentry log channel (config/logging.php alerts on error level) for an expected, recurring
+ * state - asserted directly against the concrete logging class, since a mocked interface (as used
+ * elsewhere in this job's own test suite) can't observe the level.
+ */
+#[Group('Logging')]
+#[Group('ProcessCombatLogSegmentsLogging')]
+final class ProcessCombatLogSegmentsLoggingTest extends PublicTestCase
+{
+    /**
+     * @throws Exception
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.log_level' => 'debug', 'app.type' => 'local']);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function handleSegmentsNotAvailable_givenCalled_logsAtInfoNotError(): void
+    {
+        // Arrange
+        $logManager = LoggingFixtures::createLogManager($this);
+        app()->instance('log', $logManager);
+
+        $logManager->expects($this->once())->method('log')->with('INFO');
+
+        /** @var ProcessCombatLogSegmentsLoggingInterface $log */
+        $log = app(ProcessCombatLogSegmentsLoggingInterface::class);
+
+        // Act
+        $log->handleSegmentsNotAvailable(37830910);
+    }
+}

--- a/tests/Unit/App/Service/RaiderIO/Logging/RaiderIOApiServiceLoggingTest.php
+++ b/tests/Unit/App/Service/RaiderIO/Logging/RaiderIOApiServiceLoggingTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\App\Service\RaiderIO\Logging;
+
+use App\Service\RaiderIO\Logging\RaiderIOApiServiceLoggingInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Exception;
+use Tests\Fixtures\LoggingFixtures;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Guards #3918: the log level is the entire behaviour this issue is about (the sentry log channel
+ * alerts on error-level logs - see config/logging.php), so it must be asserted directly against the
+ * concrete logging class rather than a mocked interface, which cannot observe it.
+ */
+#[Group('Logging')]
+#[Group('RaiderIOApiServiceLogging')]
+final class RaiderIOApiServiceLoggingTest extends PublicTestCase
+{
+    /**
+     * @throws Exception
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.log_level' => 'debug', 'app.type' => 'local']);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function getCombatLogSegmentsForRunNotYetAvailable_givenCalled_logsAtInfoNotError(): void
+    {
+        // Arrange
+        $logManager = LoggingFixtures::createLogManager($this);
+        app()->instance('log', $logManager);
+
+        $logManager->expects($this->once())->method('log')->with('INFO');
+
+        /** @var RaiderIOApiServiceLoggingInterface $log */
+        $log = app(RaiderIOApiServiceLoggingInterface::class);
+
+        // Act
+        $log->getCombatLogSegmentsForRunNotYetAvailable(37830910, 'https://raider.io/segments', '{"statusCode":404}');
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function getCombatLogSegmentsForRunInvalidResponse_givenCalled_logsAtErrorNotInfo(): void
+    {
+        // Arrange
+        $logManager = LoggingFixtures::createLogManager($this);
+        app()->instance('log', $logManager);
+
+        $logManager->expects($this->once())->method('log')->with('ERROR');
+
+        /** @var RaiderIOApiServiceLoggingInterface $log */
+        $log = app(RaiderIOApiServiceLoggingInterface::class);
+
+        // Act
+        $log->getCombatLogSegmentsForRunInvalidResponse(37830910, 'https://raider.io/segments', 'not json');
+    }
+}


### PR DESCRIPTION
:robot: Closes #3918

A run's combat-log segments simply not being available on Raider.IO yet (a 404 with body `{"statusCode":404,"error":"Not Found","message":"No combat log segments found for this run"}`) is an expected, recurring state — segments may just not have been uploaded yet — not a broken API integration. But `RaiderIOApiService::getCombatLogSegmentsForRun()` logged it via the same error-level `getCombatLogSegmentsForRunInvalidResponse` call used for a genuinely malformed/unexpected response, and `ProcessCombatLogSegments::handle()` logged its own echo of the same condition (`handleSegmentsNotAvailable`) at error too. Since the `sentry` log channel alerts on error-level logs (`config/logging.php`), both fired — as two correlated Sentry issues — on every occurrence (43 times in this triage pass).

Fix: distinguish the specific `{"statusCode": 404, ...}` response shape and log it at `info` via a new `getCombatLogSegmentsForRunNotYetAvailable` method, keeping `getCombatLogSegmentsForRunInvalidResponse` at `error` for anything that doesn't match either the success or the not-found shape (a genuine integration break still pages). Downgraded the job's own `handleSegmentsNotAvailable` echo to `info` too, since the service now logs the specific reason distinctly.

Added a regression test (`getCombatLogSegmentsForRun_givenSegmentsNotYetAvailable_logsDistinctlyFromInvalidResponse`) asserting the new method is called (and the error-level one isn't) for the 404 shape, and strengthened the existing invalid-response test to assert the reverse. `composer run fix`/`analyse` clean; existing `ProcessCombatLogSegmentsTest` suite (11 tests) still passes unaffected.