### PR TITLE
#3909 Drop redundant vertices_json from the Path, Arrow and Brushline broadcast payloads

### DIFF
--- a/app/Events/Models/Arrow/ArrowChangedEvent.php
+++ b/app/Events/Models/Arrow/ArrowChangedEvent.php
@@ -37,8 +37,18 @@ class ArrowChangedEvent extends ModelChangedEvent
         /** @var Arrow $model */
         $model = $this->model;
 
+        $broadcast = parent::broadcastWith();
+
+        // The receiving client always overwrites model.polyline.vertices_json with the
+        // model_data coordinates below (see ModelChangedHandler::_getCorrectLatLngFromEvent()
+        // and Arrow's changed.js), so broadcasting the raw vertices here too is dead weight
+        // that can push large arrows over Reverb's message size cap (#3909).
+        $modelArray = $model->toArray();
+        unset($modelArray['polyline']['vertices_json']);
+        $broadcast['model'] = $modelArray;
+
         return array_merge(
-            parent::broadcastWith(),
+            $broadcast,
             [
                 'model_data' => $model->polyline->getCoordinatesData(
                     $this->coordinatesService,

--- a/app/Events/Models/Brushline/BrushlineChangedEvent.php
+++ b/app/Events/Models/Brushline/BrushlineChangedEvent.php
@@ -44,8 +44,18 @@ class BrushlineChangedEvent extends ModelChangedEvent
         /** @var Brushline $model */
         $model = $this->model;
 
+        $broadcast = parent::broadcastWith();
+
+        // The receiving client always overwrites model.polyline.vertices_json with the
+        // model_data coordinates below (see ModelChangedHandler::_getCorrectLatLngFromEvent()
+        // and Brushline's changed.js), so broadcasting the raw vertices here too is dead weight
+        // that can push large brushlines over Reverb's message size cap (#3909).
+        $modelArray = $model->toArray();
+        unset($modelArray['polyline']['vertices_json']);
+        $broadcast['model'] = $modelArray;
+
         return array_merge(
-            parent::broadcastWith(),
+            $broadcast,
             [
                 'model_data' => $model->polyline->getCoordinatesData(
                     $this->coordinatesService,

--- a/app/Events/Models/Path/PathChangedEvent.php
+++ b/app/Events/Models/Path/PathChangedEvent.php
@@ -44,8 +44,18 @@ class PathChangedEvent extends ModelChangedEvent
         /** @var Path $model */
         $model = $this->model;
 
+        $broadcast = parent::broadcastWith();
+
+        // The receiving client always overwrites model.polyline.vertices_json with the
+        // model_data coordinates below (see ModelChangedHandler::_getCorrectLatLngFromEvent()
+        // and Path's changed.js), so broadcasting the raw vertices here too is dead weight that
+        // can push large paths over Reverb's message size cap (#3909).
+        $modelArray = $model->toArray();
+        unset($modelArray['polyline']['vertices_json']);
+        $broadcast['model'] = $modelArray;
+
         return array_merge(
-            parent::broadcastWith(),
+            $broadcast,
             [
                 'model_data' => $model->polyline->getCoordinatesData(
                     $this->coordinatesService,

--- a/tests/Feature/Controller/Ajax/AjaxArrowControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxArrowControllerTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\Controller\Ajax;
 
+use App\Events\Models\Arrow\ArrowChangedEvent;
 use App\Models\Floor\Floor;
+use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Teapot\StatusCode;
@@ -39,6 +41,42 @@ final class AjaxArrowControllerTest extends DungeonRouteTestBase
         $this->assertEquals($polyline['color_animated'], $responseArr['polyline']['color_animated']);
         $this->assertEquals($polyline['weight'], $responseArr['polyline']['weight']);
         $this->assertEquals($polyline['vertices_json'], $responseArr['polyline']['vertices_json']);
+    }
+
+    #[Test]
+    public function store_givenNewValidArrow_broadcastsPayloadWithoutRedundantVerticesJson(): void
+    {
+        // Arrange
+        Event::fake([ArrowChangedEvent::class]);
+
+        /** @var Floor $randomFloor */
+        $randomFloor = $this->dungeonRoute->dungeon->floors()
+            ->where('facade', false)
+            ->inRandomOrder()
+            ->first();
+
+        $polyline = PolylineFixtures::createPolyline($randomFloor);
+
+        // Act
+        $response = $this->post(route('ajax.dungeonroute.arrow.create', ['dungeonRoute' => $this->dungeonRoute]), [
+            'floor_id' => $randomFloor->id,
+            'polyline' => $polyline,
+        ]);
+        $response->assertCreated();
+
+        // Assert - model.polyline.vertices_json is dead weight: ArrowChangedHandler always
+        // overwrites it client-side with model_data.coordinates before use, so broadcasting both
+        // just duplicated the vertex payload and could exceed Reverb's message size cap (#3909).
+        // The rest of the polyline (used for e.g. color) must still be present.
+        Event::assertDispatched(ArrowChangedEvent::class, function (ArrowChangedEvent $event) use ($polyline) {
+            $broadcastPayload = $event->broadcastWith();
+
+            $this->assertArrayNotHasKey('vertices_json', $broadcastPayload['model']['polyline']);
+            $this->assertEquals($polyline['color'], $broadcastPayload['model']['polyline']['color']);
+            $this->assertArrayHasKey('coordinates', $broadcastPayload['model_data']);
+
+            return true;
+        });
     }
 
     #[Test]

--- a/tests/Feature/Controller/Ajax/AjaxBrushlineControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxBrushlineControllerTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\Controller\Ajax;
 
+use App\Events\Models\Brushline\BrushlineChangedEvent;
 use App\Models\Floor\Floor;
+use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Teapot\StatusCode;
@@ -39,6 +41,43 @@ final class AjaxBrushlineControllerTest extends DungeonRouteTestBase
         $this->assertEquals($polyline['color_animated'], $responseArr['polyline']['color_animated']);
         $this->assertEquals($polyline['weight'], $responseArr['polyline']['weight']);
         $this->assertEquals($polyline['vertices_json'], $responseArr['polyline']['vertices_json']);
+    }
+
+    #[Test]
+    #[Group('Controller')]
+    public function store_givenNewValidBrushline_broadcastsPayloadWithoutRedundantVerticesJson(): void
+    {
+        // Arrange
+        Event::fake([BrushlineChangedEvent::class]);
+
+        /** @var Floor $randomFloor */
+        $randomFloor = $this->dungeonRoute->dungeon->floors()
+            ->where('facade', false)
+            ->inRandomOrder()
+            ->first();
+
+        $polyline = PolylineFixtures::createPolyline($randomFloor);
+
+        // Act
+        $response = $this->post(route('ajax.dungeonroute.brushline.create', ['dungeonRoute' => $this->dungeonRoute]), [
+            'floor_id' => $randomFloor->id,
+            'polyline' => $polyline,
+        ]);
+        $response->assertCreated();
+
+        // Assert - model.polyline.vertices_json is dead weight: BrushlineChangedHandler always
+        // overwrites it client-side with model_data.coordinates before use, so broadcasting both
+        // just duplicated the vertex payload and could exceed Reverb's message size cap (#3909).
+        // The rest of the polyline (used for e.g. color) must still be present.
+        Event::assertDispatched(BrushlineChangedEvent::class, function (BrushlineChangedEvent $event) use ($polyline) {
+            $broadcastPayload = $event->broadcastWith();
+
+            $this->assertArrayNotHasKey('vertices_json', $broadcastPayload['model']['polyline']);
+            $this->assertEquals($polyline['color'], $broadcastPayload['model']['polyline']['color']);
+            $this->assertArrayHasKey('coordinates', $broadcastPayload['model_data']);
+
+            return true;
+        });
     }
 
     #[Test]

--- a/tests/Feature/Controller/Ajax/AjaxPathControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxPathControllerTest.php
@@ -2,9 +2,12 @@
 
 namespace Tests\Feature\Controller\Ajax;
 
+use App\Events\Models\Path\PathChangedEvent;
 use App\Models\Floor\Floor;
 use App\Models\Path;
 use App\Models\Polyline;
+use App\Models\User;
+use App\Service\Coordinates\CoordinatesServiceInterface;
 use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -42,6 +45,47 @@ final class AjaxPathControllerTest extends DungeonRouteTestBase
         $this->assertEquals($polyline['color_animated'], $responseArr['polyline']['color_animated']);
         $this->assertEquals($polyline['weight'], $responseArr['polyline']['weight']);
         $this->assertEquals($polyline['vertices_json'], $responseArr['polyline']['vertices_json']);
+    }
+
+    #[Test]
+    #[Group('Controller')]
+    public function store_givenNewValidPath_broadcastsPayloadWithoutRedundantVerticesJson(): void
+    {
+        // Arrange
+        /** @var Floor $randomFloor */
+        $randomFloor = $this->dungeonRoute->dungeon->floors()
+            ->where('facade', false)
+            ->get()
+            ->random();
+
+        $polyline = PolylineFixtures::createPolyline($randomFloor);
+
+        $response = $this->post(route('ajax.dungeonroute.path.create', ['dungeonRoute' => $this->dungeonRoute]), [
+            'floor_id' => $randomFloor->id,
+            'polyline' => $polyline,
+        ]);
+        $response->assertCreated();
+
+        /** @var Path $path */
+        $path = Path::findOrFail(json_decode($response->content(), true)['id']);
+
+        $event = new PathChangedEvent(
+            app(CoordinatesServiceInterface::class),
+            $this->dungeonRoute,
+            User::findOrFail(1),
+            $path,
+        );
+
+        // Act
+        $broadcastPayload = $event->broadcastWith();
+
+        // Assert - model.polyline.vertices_json is dead weight: PathChangedHandler always
+        // overwrites it client-side with model_data.coordinates before use, so broadcasting both
+        // just tripled the vertex payload and could exceed Reverb's message size cap on large
+        // paths (#3909). The rest of the polyline (used for e.g. color) must still be present.
+        $this->assertArrayNotHasKey('vertices_json', $broadcastPayload['model']['polyline']);
+        $this->assertEquals($polyline['color'], $broadcastPayload['model']['polyline']['color']);
+        $this->assertArrayHasKey('coordinates', $broadcastPayload['model_data']);
     }
 
     #[Test]

--- a/tests/Feature/Controller/Ajax/AjaxPathControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxPathControllerTest.php
@@ -6,8 +6,6 @@ use App\Events\Models\Path\PathChangedEvent;
 use App\Models\Floor\Floor;
 use App\Models\Path;
 use App\Models\Polyline;
-use App\Models\User;
-use App\Service\Coordinates\CoordinatesServiceInterface;
 use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -52,6 +50,8 @@ final class AjaxPathControllerTest extends DungeonRouteTestBase
     public function store_givenNewValidPath_broadcastsPayloadWithoutRedundantVerticesJson(): void
     {
         // Arrange
+        Event::fake([PathChangedEvent::class]);
+
         /** @var Floor $randomFloor */
         $randomFloor = $this->dungeonRoute->dungeon->floors()
             ->where('facade', false)
@@ -60,32 +60,26 @@ final class AjaxPathControllerTest extends DungeonRouteTestBase
 
         $polyline = PolylineFixtures::createPolyline($randomFloor);
 
+        // Act
         $response = $this->post(route('ajax.dungeonroute.path.create', ['dungeonRoute' => $this->dungeonRoute]), [
             'floor_id' => $randomFloor->id,
             'polyline' => $polyline,
         ]);
         $response->assertCreated();
 
-        /** @var Path $path */
-        $path = Path::findOrFail(json_decode($response->content(), true)['id']);
-
-        $event = new PathChangedEvent(
-            app(CoordinatesServiceInterface::class),
-            $this->dungeonRoute,
-            User::findOrFail(1),
-            $path,
-        );
-
-        // Act
-        $broadcastPayload = $event->broadcastWith();
-
         // Assert - model.polyline.vertices_json is dead weight: PathChangedHandler always
         // overwrites it client-side with model_data.coordinates before use, so broadcasting both
         // just tripled the vertex payload and could exceed Reverb's message size cap on large
         // paths (#3909). The rest of the polyline (used for e.g. color) must still be present.
-        $this->assertArrayNotHasKey('vertices_json', $broadcastPayload['model']['polyline']);
-        $this->assertEquals($polyline['color'], $broadcastPayload['model']['polyline']['color']);
-        $this->assertArrayHasKey('coordinates', $broadcastPayload['model_data']);
+        Event::assertDispatched(PathChangedEvent::class, function (PathChangedEvent $event) use ($polyline) {
+            $broadcastPayload = $event->broadcastWith();
+
+            $this->assertArrayNotHasKey('vertices_json', $broadcastPayload['model']['polyline']);
+            $this->assertEquals($polyline['color'], $broadcastPayload['model']['polyline']['color']);
+            $this->assertArrayHasKey('coordinates', $broadcastPayload['model_data']);
+
+            return true;
+        });
     }
 
     #[Test]


### PR DESCRIPTION
:robot: Closes #3909

Pusher/Reverb rejects broadcasts over ~10KB, and large killzone paths were tripping that cap ("Payload too large", Sentry `PHP-LARAVEL-MM`, 22 occurrences).

## Root cause

`PathChangedEvent::broadcastWith()` sent the vertex data **three times**:
- the raw `polyline.vertices_json` (via `ContextModelEvent`'s full model serialization, included under `model`)
- two computed representations (`split_floors` and `facade`) under `model_data`

The receiving client (`PathChangedHandler::onReceive()`) always overwrites `e.model.polyline.vertices_json` with the `model_data` coordinates before use (see `ModelChangedHandler::_getCorrectLatLngFromEvent()`), so the raw copy is dead weight on every receiving client — it's never read before being replaced.

## Fix

`PathChangedEvent::broadcastWith()` now strips `polyline.vertices_json` from the serialized `model` before merging in `model_data`, cutting the payload by roughly a third. The rest of the polyline (color, weight, etc.) is untouched.

`ArrowChangedEvent` and `BrushlineChangedEvent` got the identical trim in `05d8b2f03` — they have the same shape (`broadcastWith()` unconditionally adds `model_data`, and `arrow/changed.js` / `brushline/changed.js` unconditionally overwrite `e.model.polyline.vertices_json` from it), so the raw copy is equally redundant there.

## Audit of every polyline-carrying broadcast event

The discriminator is whether a payload carries the raw `polyline.vertices_json` **and** a computed `model_data.coordinates` derived from the same vertices — only then is one of them redundant. Checked every `polyline()` relation in `app/Models`, every `HasVertices`/`SavesPolylines` user, and every `ModelChangedEvent`/`ModelDeletedEvent` subclass.

| Event | Carries polyline? | Also sends `model_data`? | Verdict |
|---|---|---|---|
| `PathChangedEvent` | yes | yes | **Trimmed** |
| `BrushlineChangedEvent` | yes | yes | **Trimmed** |
| `ArrowChangedEvent` | yes | yes | **Trimmed** |
| `EnemyPatrolChangedEvent` | yes (`$with = ['polyline']`) | **no** — no `broadcastWith()` override | Doesn't apply |
| `EnemyPackChangedEvent` | `vertices_json` via `HasVertices` | no | Doesn't apply |
| `MountableAreaChangedEvent` | `vertices_json` via `HasVertices` | no | Doesn't apply |
| `FloorUnionAreaChangedEvent` | `vertices_json` via `HasVertices` | no | Doesn't apply |
| `KillZoneChangedEvent` | no polyline; used to send `killzone_paths` | n/a | Already fixed in `902f16d8e` (#3198) |
| all `*DeletedEvent` | no | n/a | Nothing to trim |

- **EnemyPatrol** — `polyline.vertices_json` is the *only* representation in its payload, and `echohandler.js` registers no `EnemyPatrolChangedHandler`, so nothing client-side would recompute it. Trimming would delete data with no substitute.
- **EnemyPack / MountableArea / FloorUnionArea** — polygons carrying `vertices_json` directly on the model via `HasVertices`; their changed events add no `model_data`, so only one copy is sent.
- **KillZone** — the bloat there was `killzone_paths`, removed from the broadcast in `902f16d8e` (#3198) with the client re-fetching over a dedicated route. Verified still absent.

**Honesty note:** this reduces the payload, it doesn't hard-bound it. A polyline with enough vertices can still exceed the cap even with the one remaining representation; a hard cap (id + refetch signal, as the Sentry issue also suggested) would be a larger, separate change.

## Verification

- `AjaxPathControllerTest::store_givenNewValidPath_broadcastsPayloadWithoutRedundantVerticesJson`, plus the matching `AjaxArrowControllerTest` / `AjaxBrushlineControllerTest` tests, use a scoped `Event::fake([...Event::class])` around the real controller POST and assert on the payload of the event the controller actually dispatched — so deleting the `broadcast(...)` call fails them. All three verified non-vacuous by reverting the event changes and watching them go red.
- Scoped rather than bare `Event::fake()` deliberately: these tests depend on Eloquent model events staying live.
- `composer run analyse` and `composer run fix` clean; all 9 CI checks green.
