### PR TITLE
#3902 Fingerprint scheduled-command failures by command name

### DIFF
--- a/app/Logging/Sentry/ScheduledCommandFingerprint.php
+++ b/app/Logging/Sentry/ScheduledCommandFingerprint.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Logging\Sentry;
+
+use Sentry\Event;
+use Sentry\EventHint;
+
+/**
+ * Sentry `before_send` callback that gives each failing scheduled command its own issue.
+ *
+ * Laravel's ScheduleRunCommand throws a plain Exception with an identical message shape and stack trace (inside vendor
+ * code) for every failing scheduled command, so Sentry's default trace-based grouping aggregates failures from
+ * unrelated commands (combatlog:detectstaledata, patreon:refreshmembers, ...) into one issue (#3902). Fingerprinting
+ * on the command splits them back apart.
+ *
+ * This lives in a class rather than inline in config/sentry.php because `php artisan config:cache` var_exports every
+ * config value and a Closure is not var_export-able - see the note in that file.
+ */
+class ScheduledCommandFingerprint
+{
+    /**
+     * Fingerprint a scheduled-command failure by the command that failed, leaving every other event untouched.
+     */
+    public static function apply(Event $event, ?EventHint $hint): ?Event
+    {
+        $exception = $hint?->exception;
+
+        if ($exception !== null
+            && preg_match('/^Scheduled command \[(.+)] failed with exit code \[\d+]\.$/', $exception->getMessage(), $matches) === 1) {
+            $command = $matches[1];
+
+            // $command is Illuminate\Console\Application::formatCommandString()'s output: the php
+            // binary and artisan binary, each individually shell-escaped (single-quoted) via
+            // Illuminate\Support\ProcessUtils::escapeArgument(), followed by the actual artisan
+            // command and its arguments. Strip the two quoted binary tokens so the fingerprint (and
+            // the resulting issue title) reflects the command that actually failed rather than an
+            // environment-dependent interpreter path - without hardcoding 'artisan' as a literal,
+            // since ARTISAN_BINARY can override it.
+            if (preg_match("/^'[^']*'\\s+'[^']*'\\s+(.+)$/", $command, $commandMatches) === 1) {
+                $command = $commandMatches[1];
+            }
+
+            $event->setFingerprint(['schedule-run-command-failed', $command]);
+        }
+
+        return $event;
+    }
+}

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -52,34 +52,12 @@ return [
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore_exceptions
     // 'ignore_exceptions' => [],
 
-    // Laravel's ScheduleRunCommand throws a plain Exception with an identical message shape and
-    // stack trace (inside vendor code) for every failing scheduled command, so Sentry's default
-    // trace-based grouping aggregates failures from unrelated commands (combatlog:detectstaledata,
-    // patreon:refreshmembers, ...) into one issue (#3902). Fingerprint on the command so each gets
-    // its own issue instead.
-    'before_send' => function (\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event {
-        $exception = $hint?->exception;
-
-        if ($exception !== null
-            && preg_match('/^Scheduled command \[(.+)] failed with exit code \[\d+]\.$/', $exception->getMessage(), $matches) === 1) {
-            $command = $matches[1];
-
-            // $command is Illuminate\Console\Application::formatCommandString()'s output: the php
-            // binary and artisan binary, each individually shell-escaped (single-quoted) via
-            // Illuminate\Support\ProcessUtils::escapeArgument(), followed by the actual artisan
-            // command and its arguments. Strip the two quoted binary tokens so the fingerprint (and
-            // the resulting issue title) reflects the command that actually failed rather than an
-            // environment-dependent interpreter path - without hardcoding 'artisan' as a literal,
-            // since ARTISAN_BINARY can override it.
-            if (preg_match("/^'[^']*'\\s+'[^']*'\\s+(.+)$/", $command, $commandMatches) === 1) {
-                $command = $commandMatches[1];
-            }
-
-            $event->setFingerprint(['schedule-run-command-failed', $command]);
-        }
-
-        return $event;
-    },
+    // Gives each failing scheduled command its own Sentry issue instead of one shared bucket (#3902) - the rationale
+    // and the message parsing live on the class.
+    // This MUST stay a var_export-able array callable: `php artisan config:cache` (run by the infrastructure
+    // repository) var_exports every config value and dies on a Closure. So no closure here, and no first-class
+    // callable syntax (`ScheduledCommandFingerprint::apply(...)`) either - that is a Closure too.
+    'before_send' => [\App\Logging\Sentry\ScheduledCommandFingerprint::class, 'apply'],
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore_transactions
     'ignore_transactions' => [

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -55,14 +55,27 @@ return [
     // Laravel's ScheduleRunCommand throws a plain Exception with an identical message shape and
     // stack trace (inside vendor code) for every failing scheduled command, so Sentry's default
     // trace-based grouping aggregates failures from unrelated commands (combatlog:detectstaledata,
-    // patreon:refreshmembers, ...) into one issue (#3902). Fingerprint on the command name so each
-    // gets its own issue instead.
+    // patreon:refreshmembers, ...) into one issue (#3902). Fingerprint on the command so each gets
+    // its own issue instead.
     'before_send' => function (\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event {
         $exception = $hint?->exception;
 
         if ($exception !== null
             && preg_match('/^Scheduled command \[(.+)] failed with exit code \[\d+]\.$/', $exception->getMessage(), $matches) === 1) {
-            $event->setFingerprint(['schedule-run-command-failed', $matches[1]]);
+            $command = $matches[1];
+
+            // $command is Illuminate\Console\Application::formatCommandString()'s output: the php
+            // binary and artisan binary, each individually shell-escaped (single-quoted) via
+            // Illuminate\Support\ProcessUtils::escapeArgument(), followed by the actual artisan
+            // command and its arguments. Strip the two quoted binary tokens so the fingerprint (and
+            // the resulting issue title) reflects the command that actually failed rather than an
+            // environment-dependent interpreter path - without hardcoding 'artisan' as a literal,
+            // since ARTISAN_BINARY can override it.
+            if (preg_match("/^'[^']*'\\s+'[^']*'\\s+(.+)$/", $command, $commandMatches) === 1) {
+                $command = $commandMatches[1];
+            }
+
+            $event->setFingerprint(['schedule-run-command-failed', $command]);
         }
 
         return $event;

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -52,6 +52,22 @@ return [
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore_exceptions
     // 'ignore_exceptions' => [],
 
+    // Laravel's ScheduleRunCommand throws a plain Exception with an identical message shape and
+    // stack trace (inside vendor code) for every failing scheduled command, so Sentry's default
+    // trace-based grouping aggregates failures from unrelated commands (combatlog:detectstaledata,
+    // patreon:refreshmembers, ...) into one issue (#3902). Fingerprint on the command name so each
+    // gets its own issue instead.
+    'before_send' => function (\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event {
+        $exception = $hint?->exception;
+
+        if ($exception !== null
+            && preg_match('/^Scheduled command \[(.+)] failed with exit code \[\d+]\.$/', $exception->getMessage(), $matches) === 1) {
+            $event->setFingerprint(['schedule-run-command-failed', $matches[1]]);
+        }
+
+        return $event;
+    },
+
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore_transactions
     'ignore_transactions' => [
         // Ignore Laravel's default health URL

--- a/tests/Unit/App/Logging/SentryConfigTest.php
+++ b/tests/Unit/App/Logging/SentryConfigTest.php
@@ -56,21 +56,53 @@ final class SentryConfigTest extends PublicTestCase
      * Sentry's default trace-based grouping aggregated failures from unrelated commands
      * (combatlog:detectstaledata, patreon:refreshmembers, ...) into one issue. before_send must
      * fingerprint on the command name so each gets its own issue.
+     *
+     * The exception message embeds Illuminate\Console\Application::formatCommandString()'s full
+     * output - the shell-escaped php and artisan binaries prefixed onto the actual command (e.g.
+     * `'/usr/local/bin/php' 'artisan' combatlog:detectstaledata`, confirmed against a real run in
+     * this app's container) - not just the bare command name, so the fixture must reproduce that
+     * shape or a regex bug that captures the whole line (embedding an environment-dependent
+     * interpreter path in the fingerprint) would pass unnoticed.
      */
     #[Test]
     public function beforeSend_givenScheduledCommandFailedException_fingerprintsByCommandName(): void
     {
         // Arrange
         $beforeSend = config('sentry.before_send');
-        $exception  = new Exception('Scheduled command [combatlog:detectstaledata] failed with exit code [1].');
-        $event      = Event::createEvent();
-        $hint       = EventHint::fromArray(['exception' => $exception]);
+        $exception  = new Exception(
+            "Scheduled command ['/usr/local/bin/php' 'artisan' combatlog:detectstaledata] failed with exit code [1].",
+        );
+        $event = Event::createEvent();
+        $hint  = EventHint::fromArray(['exception' => $exception]);
+
+        // Act
+        $result = $beforeSend($event, $hint);
+
+        // Assert - the php/artisan binary tokens are stripped, leaving just the command
+        self::assertSame(['schedule-run-command-failed', 'combatlog:detectstaledata'], $result->getFingerprint());
+    }
+
+    /**
+     * A scheduled command with parameters (Schedule::command()'s compileParameters()) appends them
+     * to the command name space-separated, e.g. `dungeonroute:touch teamId=5` - the fingerprint must
+     * still isolate this from the binary prefix.
+     */
+    #[Test]
+    public function beforeSend_givenScheduledCommandWithParametersFailedException_fingerprintsByCommandAndParameters(): void
+    {
+        // Arrange
+        $beforeSend = config('sentry.before_send');
+        $exception  = new Exception(
+            "Scheduled command ['/usr/local/bin/php' 'artisan' dungeonroute:touch teamId=5] failed with exit code [1].",
+        );
+        $event = Event::createEvent();
+        $hint  = EventHint::fromArray(['exception' => $exception]);
 
         // Act
         $result = $beforeSend($event, $hint);
 
         // Assert
-        self::assertSame(['schedule-run-command-failed', 'combatlog:detectstaledata'], $result->getFingerprint());
+        self::assertSame(['schedule-run-command-failed', 'dungeonroute:touch teamId=5'], $result->getFingerprint());
     }
 
     #[Test]
@@ -80,10 +112,14 @@ final class SentryConfigTest extends PublicTestCase
         $beforeSend = config('sentry.before_send');
 
         $firstEvent = $beforeSend(Event::createEvent(), EventHint::fromArray([
-            'exception' => new Exception('Scheduled command [combatlog:detectstaledata] failed with exit code [1].'),
+            'exception' => new Exception(
+                "Scheduled command ['/usr/local/bin/php' 'artisan' combatlog:detectstaledata] failed with exit code [1].",
+            ),
         ]));
         $secondEvent = $beforeSend(Event::createEvent(), EventHint::fromArray([
-            'exception' => new Exception('Scheduled command [patreon:refreshmembers] failed with exit code [1].'),
+            'exception' => new Exception(
+                "Scheduled command ['/usr/local/bin/php' 'artisan' patreon:refreshmembers] failed with exit code [1].",
+            ),
         ]));
 
         // Assert

--- a/tests/Unit/App/Logging/SentryConfigTest.php
+++ b/tests/Unit/App/Logging/SentryConfigTest.php
@@ -2,12 +2,15 @@
 
 namespace Tests\Unit\App\Logging;
 
+use App\Logging\Sentry\ScheduledCommandFingerprint;
+use Closure;
 use Exception;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
 use Sentry\Event;
 use Sentry\EventHint;
+use Sentry\Options;
 use Tests\TestCases\PublicTestCase;
 
 /**
@@ -65,18 +68,17 @@ final class SentryConfigTest extends PublicTestCase
      * interpreter path in the fingerprint) would pass unnoticed.
      */
     #[Test]
-    public function beforeSend_givenScheduledCommandFailedException_fingerprintsByCommandName(): void
+    public function apply_givenScheduledCommandFailedException_fingerprintsByCommandName(): void
     {
         // Arrange
-        $beforeSend = config('sentry.before_send');
-        $exception  = new Exception(
+        $exception = new Exception(
             "Scheduled command ['/usr/local/bin/php' 'artisan' combatlog:detectstaledata] failed with exit code [1].",
         );
         $event = Event::createEvent();
         $hint  = EventHint::fromArray(['exception' => $exception]);
 
         // Act
-        $result = $beforeSend($event, $hint);
+        $result = ScheduledCommandFingerprint::apply($event, $hint);
 
         // Assert - the php/artisan binary tokens are stripped, leaving just the command
         self::assertSame(['schedule-run-command-failed', 'combatlog:detectstaledata'], $result->getFingerprint());
@@ -88,35 +90,32 @@ final class SentryConfigTest extends PublicTestCase
      * still isolate this from the binary prefix.
      */
     #[Test]
-    public function beforeSend_givenScheduledCommandWithParametersFailedException_fingerprintsByCommandAndParameters(): void
+    public function apply_givenScheduledCommandWithParametersFailedException_fingerprintsByCommandAndParameters(): void
     {
         // Arrange
-        $beforeSend = config('sentry.before_send');
-        $exception  = new Exception(
+        $exception = new Exception(
             "Scheduled command ['/usr/local/bin/php' 'artisan' dungeonroute:touch teamId=5] failed with exit code [1].",
         );
         $event = Event::createEvent();
         $hint  = EventHint::fromArray(['exception' => $exception]);
 
         // Act
-        $result = $beforeSend($event, $hint);
+        $result = ScheduledCommandFingerprint::apply($event, $hint);
 
         // Assert
         self::assertSame(['schedule-run-command-failed', 'dungeonroute:touch teamId=5'], $result->getFingerprint());
     }
 
     #[Test]
-    public function beforeSend_givenDifferentScheduledCommandFailedException_fingerprintsSeparately(): void
+    public function apply_givenDifferentScheduledCommandFailedException_fingerprintsSeparately(): void
     {
         // Arrange - proves two different commands don't collapse into the same fingerprint
-        $beforeSend = config('sentry.before_send');
-
-        $firstEvent = $beforeSend(Event::createEvent(), EventHint::fromArray([
+        $firstEvent = ScheduledCommandFingerprint::apply(Event::createEvent(), EventHint::fromArray([
             'exception' => new Exception(
                 "Scheduled command ['/usr/local/bin/php' 'artisan' combatlog:detectstaledata] failed with exit code [1].",
             ),
         ]));
-        $secondEvent = $beforeSend(Event::createEvent(), EventHint::fromArray([
+        $secondEvent = ScheduledCommandFingerprint::apply(Event::createEvent(), EventHint::fromArray([
             'exception' => new Exception(
                 "Scheduled command ['/usr/local/bin/php' 'artisan' patreon:refreshmembers] failed with exit code [1].",
             ),
@@ -127,32 +126,62 @@ final class SentryConfigTest extends PublicTestCase
     }
 
     #[Test]
-    public function beforeSend_givenUnrelatedException_leavesFingerprintUntouched(): void
+    public function apply_givenUnrelatedException_leavesFingerprintUntouched(): void
     {
         // Arrange
-        $beforeSend = config('sentry.before_send');
-        $event      = Event::createEvent();
-        $hint       = EventHint::fromArray(['exception' => new RuntimeException('Something else broke entirely')]);
+        $event = Event::createEvent();
+        $hint  = EventHint::fromArray(['exception' => new RuntimeException('Something else broke entirely')]);
 
         // Act
-        $result = $beforeSend($event, $hint);
+        $result = ScheduledCommandFingerprint::apply($event, $hint);
 
         // Assert - Sentry's default (trace-based) grouping applies; no custom fingerprint set
         self::assertSame([], $result->getFingerprint());
     }
 
     #[Test]
-    public function beforeSend_givenNoException_returnsEventUnmodified(): void
+    public function apply_givenNoException_returnsEventUnmodified(): void
     {
         // Arrange
-        $beforeSend = config('sentry.before_send');
-        $event      = Event::createEvent();
+        $event = Event::createEvent();
 
         // Act
-        $result = $beforeSend($event, null);
+        $result = ScheduledCommandFingerprint::apply($event, null);
 
         // Assert
         self::assertSame($event, $result);
         self::assertSame([], $result->getFingerprint());
+    }
+
+    /**
+     * `php artisan config:cache` var_exports every config value and throws a LogicException on anything
+     * non-serializable, so a Closure in this config file breaks config caching (which the infrastructure repository
+     * runs on deploy). An array callable survives var_export; first-class callable syntax would not.
+     */
+    #[Test]
+    public function beforeSend_givenTheConfig_isSerializableForConfigCaching(): void
+    {
+        // Act
+        $beforeSend = config('sentry.before_send');
+
+        // Assert
+        self::assertNotInstanceOf(Closure::class, $beforeSend, 'A Closure here breaks `php artisan config:cache`.');
+        self::assertSame([ScheduledCommandFingerprint::class, 'apply'], $beforeSend);
+        // The exact round-trip ConfigCacheCommand performs - a Closure dies here on Closure::__set_state()
+        self::assertSame($beforeSend, eval(sprintf('return %s;', var_export($beforeSend, true))));
+    }
+
+    /**
+     * Being var_export-able is not the same as being accepted by the SDK - Sentry's Options resolver gates
+     * `before_send` on `is_callable`, which rejects an array callable pointing at a non-static method.
+     */
+    #[Test]
+    public function beforeSend_givenTheConfig_isAcceptedBySentryOptions(): void
+    {
+        // Act
+        $options = new Options(['before_send' => config('sentry.before_send')]);
+
+        // Assert
+        self::assertSame(config('sentry.before_send'), $options->getBeforeSendCallback());
     }
 }

--- a/tests/Unit/App/Logging/SentryConfigTest.php
+++ b/tests/Unit/App/Logging/SentryConfigTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Unit\App\Logging;
 
+use Exception;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Sentry\Event;
+use Sentry\EventHint;
 use Tests\TestCases\PublicTestCase;
 
 /**
@@ -44,5 +48,75 @@ final class SentryConfigTest extends PublicTestCase
         // Assert - app.type reads the same APP_TYPE the fallback does
         self::assertSame(config('app.type'), $environment);
         self::assertNotEmpty($environment, 'Without an environment, staging and production issues are indistinguishable.');
+    }
+
+    /**
+     * Guards #3902: Laravel's ScheduleRunCommand throws an identically-shaped Exception (same
+     * message pattern, same vendor-code stack trace) for every failing scheduled command, so
+     * Sentry's default trace-based grouping aggregated failures from unrelated commands
+     * (combatlog:detectstaledata, patreon:refreshmembers, ...) into one issue. before_send must
+     * fingerprint on the command name so each gets its own issue.
+     */
+    #[Test]
+    public function beforeSend_givenScheduledCommandFailedException_fingerprintsByCommandName(): void
+    {
+        // Arrange
+        $beforeSend = config('sentry.before_send');
+        $exception  = new Exception('Scheduled command [combatlog:detectstaledata] failed with exit code [1].');
+        $event      = Event::createEvent();
+        $hint       = EventHint::fromArray(['exception' => $exception]);
+
+        // Act
+        $result = $beforeSend($event, $hint);
+
+        // Assert
+        self::assertSame(['schedule-run-command-failed', 'combatlog:detectstaledata'], $result->getFingerprint());
+    }
+
+    #[Test]
+    public function beforeSend_givenDifferentScheduledCommandFailedException_fingerprintsSeparately(): void
+    {
+        // Arrange - proves two different commands don't collapse into the same fingerprint
+        $beforeSend = config('sentry.before_send');
+
+        $firstEvent = $beforeSend(Event::createEvent(), EventHint::fromArray([
+            'exception' => new Exception('Scheduled command [combatlog:detectstaledata] failed with exit code [1].'),
+        ]));
+        $secondEvent = $beforeSend(Event::createEvent(), EventHint::fromArray([
+            'exception' => new Exception('Scheduled command [patreon:refreshmembers] failed with exit code [1].'),
+        ]));
+
+        // Assert
+        self::assertNotSame($firstEvent->getFingerprint(), $secondEvent->getFingerprint());
+    }
+
+    #[Test]
+    public function beforeSend_givenUnrelatedException_leavesFingerprintUntouched(): void
+    {
+        // Arrange
+        $beforeSend = config('sentry.before_send');
+        $event      = Event::createEvent();
+        $hint       = EventHint::fromArray(['exception' => new RuntimeException('Something else broke entirely')]);
+
+        // Act
+        $result = $beforeSend($event, $hint);
+
+        // Assert - Sentry's default (trace-based) grouping applies; no custom fingerprint set
+        self::assertSame([], $result->getFingerprint());
+    }
+
+    #[Test]
+    public function beforeSend_givenNoException_returnsEventUnmodified(): void
+    {
+        // Arrange
+        $beforeSend = config('sentry.before_send');
+        $event      = Event::createEvent();
+
+        // Act
+        $result = $beforeSend($event, null);
+
+        // Assert
+        self::assertSame($event, $result);
+        self::assertSame([], $result->getFingerprint());
     }
 }


### PR DESCRIPTION
:robot: Closes #3902

Laravel's \`ScheduleRunCommand\` throws a plain \`Exception\` with an identical message shape and stack trace (inside vendor code) for every failing scheduled command, so Sentry's default trace-based grouping aggregated failures from unrelated commands (\`combatlog:detectstaledata\`, \`patreon:refreshmembers\`, and others) into one issue — 2307 events since 2025-12-12, still recurring.

Fix: add a \`before_send\` hook (a documented Sentry Laravel SDK config option, applied automatically to every outgoing event) that matches the \`"Scheduled command [...] failed with exit code [...]"\` message and sets a custom fingerprint including the extracted command name, so each command's failures group into their own Sentry issue instead.

Not addressed here: the issue also flagged that local-dev scheduler failures are reaching the same Sentry project as staging/production, polluting the stream further. That's an \`.env\`/deployment-config question, not a code change — out of scope for this PR.

Added 4 unit tests to the existing \`SentryConfigTest\` (which already covers this config file's other computed values): fingerprints by command name, two different commands fingerprint separately, an unrelated exception leaves the fingerprint untouched (default trace-based grouping still applies), and a null hint returns the event unmodified. Confirmed the fingerprinting tests fail when \`before_send\` is removed.