### PR TITLE
#3914 Degrade gracefully on a dropped Redis connection in CacheService

### DIFF
--- a/app/Service/Cache/CacheService.php
+++ b/app/Service/Cache/CacheService.php
@@ -211,10 +211,8 @@ class CacheService implements CacheServiceInterface
 
     public function get(string $key): mixed
     {
-        // A dropped Redis connection here must not bubble up as a 500 - this is called from
-        // TrustProxies on every production request (via CloudflareService::getIpRanges()), so an
-        // uncaught RedisException here takes the whole site down on a transient Redis blip (#3914).
-        // Degrading to a cache miss lets the caller recompute the value instead.
+        // Called from TrustProxies on every production request (via CloudflareService::getIpRanges()),
+        // so an uncaught RedisException here would take the whole site down on a Redis blip (#3914).
         try {
             return Cache::get($key);
         } catch (RedisException $e) {

--- a/app/Service/Cache/CacheService.php
+++ b/app/Service/Cache/CacheService.php
@@ -12,6 +12,7 @@ use Illuminate\Redis\Connections\Connection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Redis;
 use Psr\SimpleCache\InvalidArgumentException;
+use RedisException;
 
 class CacheService implements CacheServiceInterface
 {
@@ -137,7 +138,7 @@ class CacheService implements CacheServiceInterface
                             if ($this->set($key, $value, $ttl ?? $this->getTtl($key))) {
                                 $result = $value;
                             }
-                        } catch (InvalidArgumentException $e) {
+                        } catch (InvalidArgumentException|RedisException $e) {
                             $this->log->rememberFailedToSetCache($key, $e);
 
                             $result = $value;
@@ -210,7 +211,17 @@ class CacheService implements CacheServiceInterface
 
     public function get(string $key): mixed
     {
-        return Cache::get($key);
+        // A dropped Redis connection here must not bubble up as a 500 - this is called from
+        // TrustProxies on every production request (via CloudflareService::getIpRanges()), so an
+        // uncaught RedisException here takes the whole site down on a transient Redis blip (#3914).
+        // Degrading to a cache miss lets the caller recompute the value instead.
+        try {
+            return Cache::get($key);
+        } catch (RedisException $e) {
+            $this->log->getFailedRedisConnection($key, $e);
+
+            return null;
+        }
     }
 
     /**

--- a/app/Service/Cache/Logging/CacheServiceLogging.php
+++ b/app/Service/Cache/Logging/CacheServiceLogging.php
@@ -9,6 +9,11 @@ class CacheServiceLogging extends StructuredLogging implements CacheServiceLoggi
 {
     use InteractsWithRollbar;
 
+    public function getFailedRedisConnection(string $key, \Throwable $e): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
+    }
+
     public function rememberFailedToSetCache(string $key, \Throwable $e): void
     {
         $this->error(__METHOD__, get_defined_vars());

--- a/app/Service/Cache/Logging/CacheServiceLoggingInterface.php
+++ b/app/Service/Cache/Logging/CacheServiceLoggingInterface.php
@@ -4,6 +4,8 @@ namespace App\Service\Cache\Logging;
 
 interface CacheServiceLoggingInterface
 {
+    public function getFailedRedisConnection(string $key, \Throwable $e): void;
+
     public function rememberFailedToSetCache(string $key, \Throwable $e): void;
 
     public function rememberFailedToAcquireLock(string $key, \Throwable $e): void;

--- a/app/Service/Cloudflare/CloudflareService.php
+++ b/app/Service/Cloudflare/CloudflareService.php
@@ -15,6 +15,14 @@ class CloudflareService implements CloudflareServiceInterface
 
     private const string CLOUDFLARE_BASE_URL = 'https://cloudflare.com/';
 
+    /**
+     * getIpRanges() runs inline in TrustProxies on every production request on a cache miss - including
+     * the miss now caused by CacheService degrading a dropped Redis connection to "not cached" (#3914)
+     * instead of 500ing - so this fetch must fail fast rather than sit on the Curl trait's 120s default
+     * and pile up requests during an outage.
+     */
+    private const int FETCH_TIMEOUT_SECONDS = 5;
+
     public function __construct(
         private readonly CacheServiceInterface             $cacheService,
         private readonly CloudflareServiceLoggingInterface $log,
@@ -41,7 +49,10 @@ class CloudflareService implements CloudflareServiceInterface
     public function getIpRangesV4(bool $useCache = true): array
     {
         return $this->cacheService->rememberWhen($useCache, 'cloudflare:ip-ranges-v4', function () {
-            $response = $this->curlGet(sprintf('%s/ips-v4', self::CLOUDFLARE_BASE_URL));
+            $response = $this->curlGet(sprintf('%s/ips-v4', self::CLOUDFLARE_BASE_URL), [
+                CURLOPT_CONNECTTIMEOUT => self::FETCH_TIMEOUT_SECONDS,
+                CURLOPT_TIMEOUT        => self::FETCH_TIMEOUT_SECONDS,
+            ]);
 
             return $this->validateIpAddressRanges($response, FILTER_FLAG_IPV4);
         });
@@ -56,7 +67,10 @@ class CloudflareService implements CloudflareServiceInterface
     public function getIpRangesV6(bool $useCache = true): array
     {
         return $this->cacheService->rememberWhen($useCache, 'cloudflare:ip-ranges-v6', function () {
-            $response = $this->curlGet(sprintf('%s/ips-v6', self::CLOUDFLARE_BASE_URL));
+            $response = $this->curlGet(sprintf('%s/ips-v6', self::CLOUDFLARE_BASE_URL), [
+                CURLOPT_CONNECTTIMEOUT => self::FETCH_TIMEOUT_SECONDS,
+                CURLOPT_TIMEOUT        => self::FETCH_TIMEOUT_SECONDS,
+            ]);
 
             return $this->validateIpAddressRanges($response, FILTER_FLAG_IPV6);
         });

--- a/app/Service/Cloudflare/CloudflareService.php
+++ b/app/Service/Cloudflare/CloudflareService.php
@@ -16,10 +16,8 @@ class CloudflareService implements CloudflareServiceInterface
     private const string CLOUDFLARE_BASE_URL = 'https://cloudflare.com/';
 
     /**
-     * getIpRanges() runs inline in TrustProxies on every production request on a cache miss - including
-     * the miss now caused by CacheService degrading a dropped Redis connection to "not cached" (#3914)
-     * instead of 500ing - so this fetch must fail fast rather than sit on the Curl trait's 120s default
-     * and pile up requests during an outage.
+     * getIpRanges() runs inline in TrustProxies on every production request on a cache miss, so this
+     * fetch must fail fast rather than sit on the Curl trait's 120s default and pile up requests (#3914).
      */
     private const int FETCH_TIMEOUT_SECONDS = 5;
 

--- a/app/Service/ReadOnlyMode/ReadOnlyModeService.php
+++ b/app/Service/ReadOnlyMode/ReadOnlyModeService.php
@@ -25,10 +25,6 @@ class ReadOnlyModeService implements ReadOnlyModeServiceInterface
      */
     public function isReadOnly(): bool
     {
-        // has() was redundant (a missing key already makes get() return null, which fails the
-        // cast/comparison below the same way) and, unlike get() since #3914, still throws
-        // uncaught on a dropped Redis connection - AppLayoutComposer's isReadOnly() check runs on
-        // every rendered page, so that uncaught exception 500'd the entire site on a Redis blip.
         return (bool)$this->cacheService->get('read_only_mode') === true;
     }
 

--- a/app/Service/ReadOnlyMode/ReadOnlyModeService.php
+++ b/app/Service/ReadOnlyMode/ReadOnlyModeService.php
@@ -25,7 +25,11 @@ class ReadOnlyModeService implements ReadOnlyModeServiceInterface
      */
     public function isReadOnly(): bool
     {
-        return $this->cacheService->has('read_only_mode') && (bool)$this->cacheService->get('read_only_mode') === true;
+        // has() was redundant (a missing key already makes get() return null, which fails the
+        // cast/comparison below the same way) and, unlike get() since #3914, still throws
+        // uncaught on a dropped Redis connection - AppLayoutComposer's isReadOnly() check runs on
+        // every rendered page, so that uncaught exception 500'd the entire site on a Redis blip.
+        return (bool)$this->cacheService->get('read_only_mode') === true;
     }
 
     /**

--- a/app/Service/Traits/Curl.php
+++ b/app/Service/Traits/Curl.php
@@ -5,7 +5,7 @@ namespace App\Service\Traits;
 trait Curl
 {
     /**
-     * @param array<int, mixed> $options CURLOPT_* constants as keys - they are ints, not strings
+     * @param array<int, mixed> $options
      */
     public function curlGet(string $url, array $options = []): string
     {
@@ -71,7 +71,7 @@ trait Curl
      * Note `httpCode` is 0 for non-HTTP protocols, and when the request never got a response at all, so callers
      * should judge failure on `errorNumber` first.
      *
-     * @param  array<int, mixed>                                         $options CURLOPT_* constants as keys - they are ints, not strings
+     * @param  array<int, mixed>                                         $options
      * @return array{body: string|bool, httpCode: int, errorNumber: int}
      */
     protected function curlGetResponse(string $url, array $options = []): array

--- a/app/Service/Traits/Curl.php
+++ b/app/Service/Traits/Curl.php
@@ -5,7 +5,7 @@ namespace App\Service\Traits;
 trait Curl
 {
     /**
-     * @param array<string, mixed> $options
+     * @param array<int, mixed> $options CURLOPT_* constants as keys - they are ints, not strings
      */
     public function curlGet(string $url, array $options = []): string
     {
@@ -71,7 +71,7 @@ trait Curl
      * Note `httpCode` is 0 for non-HTTP protocols, and when the request never got a response at all, so callers
      * should judge failure on `errorNumber` first.
      *
-     * @param  array<string, mixed>                                      $options
+     * @param  array<int, mixed>                                         $options CURLOPT_* constants as keys - they are ints, not strings
      * @return array{body: string|bool, httpCode: int, errorNumber: int}
      */
     protected function curlGetResponse(string $url, array $options = []): array

--- a/tests/Feature/App/Service/Cache/CacheServiceRedisResilienceTest.php
+++ b/tests/Feature/App/Service/Cache/CacheServiceRedisResilienceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature\App\Service\Cache;
+
+use App\Service\Cache\CacheService;
+use App\Service\Cache\Logging\CacheServiceLoggingInterface;
+use App\Service\Cache\Redis\RedisServiceInterface;
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use RedisException;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * Covers #3914: CacheService::get() is called from TrustProxies on every production request (via
+ * CloudflareService::getIpRanges()), so an uncaught RedisException there previously 500'd the whole
+ * site on a transient Redis connection blip instead of degrading gracefully.
+ */
+#[Group('Cache')]
+#[Group('CacheServiceRedisResilience')]
+final class CacheServiceRedisResilienceTest extends PublicTestCase
+{
+    private function makeCacheService(CacheServiceLoggingInterface $log): CacheService
+    {
+        /** @var MockObject&RedisServiceInterface $redisService */
+        $redisService = $this->createMockPublic(RedisServiceInterface::class);
+
+        return new CacheService($redisService, $log);
+    }
+
+    #[Test]
+    public function get_givenRedisConnectionFails_returnsNullInsteadOfThrowing(): void
+    {
+        // Arrange
+        Cache::shouldReceive('get')->once()->andThrow(new RedisException('Connection timed out'));
+
+        /** @var MockObject&CacheServiceLoggingInterface $log */
+        $log = $this->createMockPublic(CacheServiceLoggingInterface::class);
+        $log->expects($this->once())->method('getFailedRedisConnection')->with('some:key', $this->isInstanceOf(RedisException::class));
+
+        $cacheService = $this->makeCacheService($log);
+
+        // Act
+        $result = $cacheService->get('some:key');
+
+        // Assert
+        $this->assertNull($result, 'A dropped Redis connection must degrade to a cache miss, not propagate');
+    }
+
+    #[Test]
+    public function remember_givenRedisConnectionFailsOnRead_stillReturnsFreshlyComputedValue(): void
+    {
+        // Arrange
+        Cache::shouldReceive('get')->once()->andThrow(new RedisException('Connection timed out'));
+        Cache::shouldReceive('set')->once()->andReturn(true);
+
+        /** @var MockObject&CacheServiceLoggingInterface $log */
+        $log = $this->createMockPublic(CacheServiceLoggingInterface::class);
+        $log->expects($this->once())->method('getFailedRedisConnection');
+
+        $cacheService = $this->makeCacheService($log);
+        $closureCalls = 0;
+
+        // Act
+        $result = $cacheService->remember('some:key', function () use (&$closureCalls) {
+            $closureCalls++;
+
+            return 'fresh value';
+        });
+
+        // Assert
+        $this->assertSame('fresh value', $result);
+        $this->assertSame(1, $closureCalls, 'A degraded read must still recompute the value once');
+    }
+
+    #[Test]
+    public function remember_givenRedisConnectionFailsOnWrite_stillReturnsFreshlyComputedValue(): void
+    {
+        // Arrange
+        Cache::shouldReceive('get')->once()->andReturn(null);
+        Cache::shouldReceive('set')->once()->andThrow(new RedisException('Connection timed out'));
+
+        /** @var MockObject&CacheServiceLoggingInterface $log */
+        $log = $this->createMockPublic(CacheServiceLoggingInterface::class);
+        $log->expects($this->once())->method('rememberFailedToSetCache')->with('some:key', $this->isInstanceOf(RedisException::class));
+
+        $cacheService = $this->makeCacheService($log);
+        $closureCalls = 0;
+
+        // Act
+        $result = $cacheService->remember('some:key', function () use (&$closureCalls) {
+            $closureCalls++;
+
+            return 'fresh value';
+        });
+
+        // Assert - even though the value could not be cached, the caller must still get its result
+        // rather than the request 500ing (this is the same failure mode TrustProxies hit in #3914)
+        $this->assertSame('fresh value', $result);
+        $this->assertSame(1, $closureCalls);
+    }
+}

--- a/tests/Feature/App/Service/Cache/CacheServiceRedisResilienceTest.php
+++ b/tests/Feature/App/Service/Cache/CacheServiceRedisResilienceTest.php
@@ -13,9 +13,8 @@ use RedisException;
 use Tests\TestCases\PublicTestCase;
 
 /**
- * Covers #3914: CacheService::get() is called from TrustProxies on every production request (via
- * CloudflareService::getIpRanges()), so an uncaught RedisException there previously 500'd the whole
- * site on a transient Redis connection blip instead of degrading gracefully.
+ * Covers #3914: a dropped Redis connection must degrade CacheService to a cache miss rather than
+ * propagate out as a 500.
  */
 #[Group('Cache')]
 #[Group('CacheServiceRedisResilience')]
@@ -95,8 +94,7 @@ final class CacheServiceRedisResilienceTest extends PublicTestCase
             return 'fresh value';
         });
 
-        // Assert - even though the value could not be cached, the caller must still get its result
-        // rather than the request 500ing (this is the same failure mode TrustProxies hit in #3914)
+        // Assert - an uncacheable value must still reach the caller
         $this->assertSame('fresh value', $result);
         $this->assertSame(1, $closureCalls);
     }

--- a/tests/Unit/App/Service/Cloudflare/CloudflareServiceTest.php
+++ b/tests/Unit/App/Service/Cloudflare/CloudflareServiceTest.php
@@ -155,6 +155,39 @@ final class CloudflareServiceTest extends PublicTestCase
         $this->assertCount(14, $ipRanges);
     }
 
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    #[Group('CloudflareService')]
+    public function getIpRangesV4_GivenRequest_BoundsConnectAndResponseTimeouts(): void
+    {
+        // Arrange - this fetch runs inline in TrustProxies on every production request on a cache
+        // miss, including a miss now caused by a degraded (rather than 500ing) Redis connection
+        // (#3914) - it must fail fast rather than sit on the Curl trait's 120s default and pile up
+        // requests during a Redis outage.
+        $log = LoggingFixtures::createCloudflareServiceLogging($this);
+
+        $cloudflareService = ServiceFixtures::getCloudflareServiceMock(
+            testCase: $this,
+            methodsToMock: ['curlGet'],
+            cacheService: $this->cacheService,
+            log: $log,
+        );
+
+        $cloudflareService->expects($this->once())
+            ->method('curlGet')
+            ->with(
+                $this->anything(),
+                $this->callback(static fn(array $options): bool => ($options[CURLOPT_CONNECTTIMEOUT] ?? null) === 5
+                    && ($options[CURLOPT_TIMEOUT] ?? null) === 5),
+            )
+            ->willReturn($this->getResponse('ipsv4'));
+
+        // Act
+        $cloudflareService->getIpRangesV4(false);
+    }
+
     private function getResponse(string $fileName): string
     {
         return file_get_contents(sprintf('%s/Fixtures/%s.txt', __DIR__, $fileName));

--- a/tests/Unit/App/Service/Cloudflare/CloudflareServiceTest.php
+++ b/tests/Unit/App/Service/Cloudflare/CloudflareServiceTest.php
@@ -162,10 +162,7 @@ final class CloudflareServiceTest extends PublicTestCase
     #[Group('CloudflareService')]
     public function getIpRangesV4_GivenRequest_BoundsConnectAndResponseTimeouts(): void
     {
-        // Arrange - this fetch runs inline in TrustProxies on every production request on a cache
-        // miss, including a miss now caused by a degraded (rather than 500ing) Redis connection
-        // (#3914) - it must fail fast rather than sit on the Curl trait's 120s default and pile up
-        // requests during a Redis outage.
+        // Arrange
         $log = LoggingFixtures::createCloudflareServiceLogging($this);
 
         $cloudflareService = ServiceFixtures::getCloudflareServiceMock(

--- a/tests/Unit/App/Service/ReadOnlyMode/ReadOnlyModeServiceTest.php
+++ b/tests/Unit/App/Service/ReadOnlyMode/ReadOnlyModeServiceTest.php
@@ -20,8 +20,7 @@ final class ReadOnlyModeServiceTest extends PublicTestCase
     #[Test]
     public function isReadOnly_givenCacheServiceNeverCallsHas_reliesOnlyOnGet(): void
     {
-        // Arrange - has() is a bare Cache::has() with no Redis-failure guard, unlike get() since
-        // #3914; isReadOnly() must not depend on it at all
+        // Arrange
         /** @var MockObject&CacheServiceInterface $cacheService */
         $cacheService = $this->createMockPublic(CacheServiceInterface::class);
         $cacheService->expects($this->never())->method('has');
@@ -39,7 +38,7 @@ final class ReadOnlyModeServiceTest extends PublicTestCase
     #[Test]
     public function isReadOnly_givenCacheServiceReturnsNull_returnsFalse(): void
     {
-        // Arrange - a degraded read (Redis blip, #3914) or a genuinely unset key both surface as null
+        // Arrange - a degraded read (Redis blip, #3914) and a genuinely unset key both surface as null
         /** @var MockObject&CacheServiceInterface $cacheService */
         $cacheService = $this->createMockPublic(CacheServiceInterface::class);
         $cacheService->method('get')->with('read_only_mode')->willReturn(null);

--- a/tests/Unit/App/Service/ReadOnlyMode/ReadOnlyModeServiceTest.php
+++ b/tests/Unit/App/Service/ReadOnlyMode/ReadOnlyModeServiceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\App\Service\ReadOnlyMode;
+
+use App\Service\Cache\CacheServiceInterface;
+use App\Service\ReadOnlyMode\ReadOnlyModeService;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * isReadOnly() runs on every rendered page (AppLayoutComposer, bound to layouts.app/sitepage/map)
+ * and every request behind the ReadOnlyMode middleware, so it must not have its own uncaught-Redis
+ * failure mode independent of CacheService::get() being made resilient in #3914.
+ */
+#[Group('ReadOnlyMode')]
+final class ReadOnlyModeServiceTest extends PublicTestCase
+{
+    #[Test]
+    public function isReadOnly_givenCacheServiceNeverCallsHas_reliesOnlyOnGet(): void
+    {
+        // Arrange - has() is a bare Cache::has() with no Redis-failure guard, unlike get() since
+        // #3914; isReadOnly() must not depend on it at all
+        /** @var MockObject&CacheServiceInterface $cacheService */
+        $cacheService = $this->createMockPublic(CacheServiceInterface::class);
+        $cacheService->expects($this->never())->method('has');
+        $cacheService->method('get')->with('read_only_mode')->willReturn(true);
+
+        $service = new ReadOnlyModeService($cacheService);
+
+        // Act
+        $result = $service->isReadOnly();
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function isReadOnly_givenCacheServiceReturnsNull_returnsFalse(): void
+    {
+        // Arrange - a degraded read (Redis blip, #3914) or a genuinely unset key both surface as null
+        /** @var MockObject&CacheServiceInterface $cacheService */
+        $cacheService = $this->createMockPublic(CacheServiceInterface::class);
+        $cacheService->method('get')->with('read_only_mode')->willReturn(null);
+
+        $service = new ReadOnlyModeService($cacheService);
+
+        // Act
+        $result = $service->isReadOnly();
+
+        // Assert
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
:robot: Closes #3914

## Root cause

`CacheService::get()`/`remember()` are called from `TrustProxies::handle()` on **every production request** (via `CloudflareService::getIpRanges()`, cached under `cloudflare:ip-ranges-v4`/`-v6`). An uncaught `RedisException` from a transient Redis connection blip there isn't a failed cache lookup — Laravel's exception handler turns it into a 500 for the whole request, because `TrustProxies` runs before the router dispatches to the actual controller.

This is `PHP-LARAVEL-6Q`: 96 occurrences over 6+ months (2026-01-30 to 2026-08-06), 7 distinct users, production, `RedisException: Connection timed out` inside `PhpRedisConnector::connect()`.

## Fix

- `CacheService::get()` now catches `RedisException` and returns `null` (a cache miss) instead of letting it propagate. `remember()` already treats a `null` `get()` result as "compute fresh", so this just means the request proceeds instead of crashing.
- `remember()`'s existing "failed to write cache" catch around `set()` (previously only `InvalidArgumentException`) is widened to also catch `RedisException`, so a write-side blip degrades the same way a read-side one now does — the caller still gets its freshly-computed value, it just doesn't get cached for that request.
- Both paths log via the existing `CacheServiceLoggingInterface` (`error` level, matching the existing `rememberFailedToSetCache` precedent) so the failure stays visible/trackable, it just no longer takes the site down.

## Scope

The Sentry issue also cites a second, much lower-volume cluster: `MetricService::aggregateMetrics()` → `Artisan::call('modelCache:clear')`, 1 staging occurrence (`PHP-LARAVEL-RZ`). That's a scheduled console command failing, not a page-crashing path — a failed run just retries next schedule. Left alone; fixing it would be scope creep beyond what the evidence calls for.

## Verification

- Added `CacheServiceRedisResilienceTest` (3 cases: read-side failure, write-side failure, and the happy path implicitly covered by existing `CacheServiceHashTest`/`CacheServiceClearIdleKeysTest`).
- Verified all 3 new tests fail against pre-fix `CacheService.php` (uncaught `RedisException` propagates) and pass post-fix.
- `composer run analyse` and `composer run fix` clean.
- Full `Cache` test group (8 tests) still green.