### PR TITLE
Fix 6 pre-existing Ajax test failures caused by unreachable local Reverb host

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -40,6 +40,13 @@
              test, so every controller test that injects the interface stays unaffected. -->
         <env name="REVERB_HOST" value="http://127.0.0.1" force="true"/>
         <env name="REVERB_PORT" value="6001" force="true"/>
+        <!-- Local .env has BROADCAST_CONNECTION=reverb, whose driver calls Laravel's broadcast()
+             straight at REVERB_HOST above - unreachable by design, so it throws a BroadcastException
+             through any controller that broadcasts (and a few controllers catch that alongside
+             unrelated exceptions, turning it into a false-negative response instead of a network
+             error - see #3940). Force the 'log' driver so broadcast() writes to the log instead of
+             making a real HTTP call, matching the fire-and-forget behavior no test relies on. -->
+        <env name="BROADCAST_CONNECTION" value="log" force="true"/>
         <!-- The 'tmp_file' store (RemembersToFile, used by ViewService among others) is a file cache that
              CACHE_STORE does not cover. Without this the tests read, write and flush the cache of the
              application running out of the same checkout. -->


### PR DESCRIPTION
Closes #3940

:robot:

## Summary
- `phpunit.xml` pins `REVERB_HOST=http://127.0.0.1` (unreachable by design, so
  `ReverbHttpApiService`'s constructor gets a parseable Guzzle base URI instead of throwing
  `MalformedUriException`). Local `.env` sets `BROADCAST_CONNECTION=reverb`, so Laravel's
  `broadcast()` helper also targets that same unreachable host - throwing a `BroadcastException`
  through any controller action that broadcasts after a successful mutation.
- 4 of the 6 originally-reported failures (`AjaxEnemyForcesCheckpointControllerTest`, via
  `AjaxEnemyController`) surfaced that exception directly.
- The other 2, which the issue asked to investigate as a **separate** root cause
  (`AjaxArrowControllerTest > delete`, `AjaxPathControllerTest > store`), turned out to be the
  **same** root cause - those two methods just swallow the `BroadcastException` inside a broader
  `catch (\Exception)`, turning a successful delete/update into a false `404`.
- Fix: force `BROADCAST_CONNECTION=log` for tests in `phpunit.xml`, alongside the existing
  `REVERB_HOST`/`REVERB_PORT` overrides. No test asserts on the broadcast actually reaching a
  listener, so writing it to the log instead of a real HTTP call is a safe, minimal change. This
  also improves CI's behavior in the same direction (was `redis`, now `log` - no external dep,
  same "don't crash on broadcast" effect).
- Filed #3941 as a follow-up: the false-404-on-broadcast-failure pattern this exposed
  (`AjaxArrowController::delete()`, `AjaxPathController::store()`/`delete()`, and a couple of
  uncaught call sites) is a real, narrow production bug independent of this test-infra fix, but
  touches ~20 controllers - out of scope for this MR, which is just the local/CI test-environment
  fix #3940 asked for.

## Test plan
- [x] `docker compose exec -T app php artisan test --compact --filter="AjaxArrowControllerTest|AjaxEnemyForcesCheckpointControllerTest|AjaxPathControllerTest"` - 16 passed (was 6 failed, 10 passed)
- [x] Full suite (`php artisan test --compact`) - all green except the known,
      worktree-environment-only `MapTilesExistenceTest` failure (excluded from CI, unrelated to
      this change - see project memory `project_maptiles_worktree_env_fail`)
- [x] Confirmed the pre-fix baseline reproduces the original 6+1 failures on this branch before
      the `phpunit.xml` change (verified via `git stash`)

---
Cold review skipped under the trivial-change rule (config-only change to phpunit.xml, 7 lines, no schema/auth/security/UI impact, covered by the passing test suite).