### PR TITLE
#3945 Revamp the compendium pages into the Field Record design

### DIFF
--- a/app/Models/Spell/Spell.php
+++ b/app/Models/Spell/Spell.php
@@ -44,6 +44,7 @@ use Str;
  * @property Carbon      $fetched_data_at
  *
  * @property string $icon_url
+ * @property string $wowhead_tooltip_data
  *
  * @property GameVersion                           $gameVersion
  * @property EloquentCollection<int, Dungeon>      $dungeons
@@ -70,6 +71,7 @@ class Spell extends CacheModel implements MappingModelInterface
     protected $appends = [
         'icon_url',
         'wowhead_url',
+        'wowhead_tooltip_data',
     ];
 
     protected $fillable = [
@@ -119,6 +121,11 @@ class Spell extends CacheModel implements MappingModelInterface
     public function getWowheadUrlAttribute(): string
     {
         return self::getWowheadLink($this->game_version_id, $this->id, $this->name);
+    }
+
+    public function getWowheadTooltipDataAttribute(): string
+    {
+        return self::getWowheadTooltipData($this->game_version_id, $this->id);
     }
 
     public function setFetchedDataAtAttribute(mixed $value): void
@@ -249,6 +256,25 @@ class Spell extends CacheModel implements MappingModelInterface
         }
 
         return $result;
+    }
+
+    /**
+     * The data-wowhead attribute value for the Wowhead tooltip script. The domain parameter must
+     * match getWowheadLink()'s URL prefix for the same game version, or the hover tooltip shows
+     * retail data while the link points at a classic database.
+     */
+    public static function getWowheadTooltipData(?int $gameVersionId, int $spellId): string
+    {
+        $domain = match ($gameVersionId) {
+            GameVersion::ALL[GameVersion::GAME_VERSION_WRATH]       => 'wrath',
+            GameVersion::ALL[GameVersion::GAME_VERSION_CLASSIC_ERA] => 'classic',
+            GameVersion::ALL[GameVersion::GAME_VERSION_MOP]         => 'mop-classic',
+            default                                                 => null,
+        };
+
+        return $domain === null
+            ? sprintf('spell=%d', $spellId)
+            : sprintf('spell=%d&domain=%s', $spellId, $domain);
     }
 
     /** @param array<int|string, int|string> $mapping */

--- a/lang/en_US/view_compendium.php
+++ b/lang/en_US/view_compendium.php
@@ -64,6 +64,8 @@ return [
         'school_recorded'         => ':spell deals :schools damage',
         'immunity_bypass_added'   => ':spell was observed landing through :property',
         'immunity_bypass_removed' => ':spell was no longer observed landing through :property',
+        'count'                   => ':count event|:count events',
+        'more'                    => 'and :count more',
         'property'                => [
             'aura'   => 'Aura',
             'debuff' => 'Debuff',
@@ -86,8 +88,10 @@ return [
                 'level' => 'Level',
             ],
             'characteristics' => [
-                'title'   => 'Characteristics',
-                'tooltip' => 'What is this NPC affected by?',
+                'title'        => 'Characteristics',
+                'tooltip'      => 'What is this NPC affected by?',
+                'empty'        => 'No characteristics recorded.',
+                'not_observed' => 'Not observed:',
             ],
             'spells' => [
                 'title'                              => 'Spells',

--- a/lang/en_US/view_compendium.php
+++ b/lang/en_US/view_compendium.php
@@ -64,9 +64,17 @@ return [
         'school_recorded'         => ':spell deals :schools damage',
         'immunity_bypass_added'   => ':spell was observed landing through :property',
         'immunity_bypass_removed' => ':spell was no longer observed landing through :property',
-        'count'                   => ':count event|:count events',
-        'more'                    => 'and :count more',
-        'property'                => [
+        // Subject-less variants: used when the row already leads with the spell link as its
+        // subject, so the description does not repeat the spell name
+        'spell_created_no_subject'           => 'Added to database',
+        'counter_added_no_subject'           => 'Can now be countered by :property',
+        'counter_removed_no_subject'         => 'Can no longer be countered by :property',
+        'school_recorded_no_subject'         => 'Deals :schools damage',
+        'immunity_bypass_added_no_subject'   => 'Observed landing through :property',
+        'immunity_bypass_removed_no_subject' => 'No longer observed landing through :property',
+        'count'                              => ':count event|:count events',
+        'more'                               => 'and :count more',
+        'property'                           => [
             'aura'   => 'Aura',
             'debuff' => 'Debuff',
         ],

--- a/resources/assets/css/sections/compendium.css
+++ b/resources/assets/css/sections/compendium.css
@@ -1,7 +1,449 @@
 /**
- * Placeholder: no compendium-specific rules exist yet. The compendium views
- * (resources/views/compendium/**) currently style entirely with stock Bootstrap classes
- * (card/badge/col/btn), so there is nothing to move here from the old grab-bag files (verified by
- * grepping compendium blade files against custom.css/general.css/header.css/map.css during the
- * #3506 CSS reorg). This file is the designated home for compendium CSS going forward.
+ * Compendium — "The Field Record" (#3945).
+ *
+ * Every compendium page reads as one continuous record sheet: an identity band on top, then
+ * labeled register sections (label rail left, content right) separated by hairline rules.
+ * Surfaces sit on the tonal ladder through theme variables (never hardcoded theme hexes) so
+ * darkly, lux and vapor all hold; muted text uses Bootstrap's per-theme --bs-secondary-color
+ * because --theme-light is white in lux and unreadable on light surfaces.
  */
+
+/* ===== Record register skeleton ===== */
+
+.compendium_record_section {
+    display: grid;
+    grid-template-columns: 11rem minmax(0, 1fr);
+    gap: 0 1.5rem;
+    padding: 1.25rem 0;
+    border-top: 1px solid rgba(128, 128, 128, 0.25);
+}
+
+.compendium_record_section:first-child {
+    border-top: 0;
+}
+
+.compendium_record_label {
+    color: var(--bs-secondary-color);
+    font-size: 0.875rem;
+    line-height: 1.4;
+    padding-top: 0.2rem;
+}
+
+.compendium_record_label .fa-info-circle {
+    opacity: 0.6;
+}
+
+.compendium_record_label_sub {
+    font-size: 0.8125rem;
+    margin-top: 0.25rem;
+}
+
+@media (max-width: 767.98px) {
+    .compendium_record_section {
+        display: block;
+    }
+
+    .compendium_record_label {
+        margin-bottom: 0.5rem;
+    }
+}
+
+/* ===== Identity band ===== */
+
+.compendium_identity {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 1.25rem;
+    align-items: center;
+    padding: 1.25rem;
+    background-color: var(--theme-bg-card);
+    border: 1px solid rgba(128, 128, 128, 0.25);
+    border-radius: 0.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.compendium_identity_portrait {
+    width: 88px;
+    height: 88px;
+    border-radius: 0.25rem;
+    border: 1px solid rgba(128, 128, 128, 0.35);
+    flex-shrink: 0;
+}
+
+.compendium_identity_body {
+    flex: 1 1 16rem;
+    min-width: 0;
+}
+
+.compendium_identity_title {
+    margin-bottom: 0.35rem;
+    font-weight: 600;
+}
+
+.compendium_identity_meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+}
+
+.compendium_identity_actions {
+    flex-shrink: 0;
+}
+
+/* Key: value stat chip in the identity band; one tonal rung above the band itself */
+.compendium_chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background-color: var(--theme-bg-card-footer);
+    color: var(--bs-body-color);
+    border-radius: 0.25rem;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+}
+
+.compendium_chip_label {
+    color: var(--bs-secondary-color);
+}
+
+/* ===== Characteristics ===== */
+
+.compendium_characteristics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.compendium_characteristic {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background-color: var(--theme-bg-card);
+    border: 1px solid rgba(128, 128, 128, 0.25);
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.6rem 0.25rem 0.25rem;
+    font-size: 0.875rem;
+    color: var(--bs-body-color);
+}
+
+.compendium_characteristic img {
+    width: 28px;
+    height: 28px;
+    border-radius: 0.2rem;
+}
+
+/* The "not observed" cluster: small grayscale icon-only strip below the active chips */
+.compendium_characteristics_muted {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.75rem;
+}
+
+.compendium_characteristics_muted img {
+    width: 22px;
+    height: 22px;
+    border-radius: 0.2rem;
+    filter: grayscale(100%);
+    opacity: 0.35;
+}
+
+.compendium_characteristics_muted_label {
+    color: var(--bs-secondary-color);
+    font-size: 0.8125rem;
+    margin-right: 0.25rem;
+}
+
+/* ===== Dense data tables ===== */
+
+.compendium_table {
+    width: 100%;
+    font-size: 0.875rem;
+    border-collapse: collapse;
+    margin-bottom: 0;
+}
+
+.compendium_table thead th {
+    background-color: var(--theme-dark);
+    color: var(--bs-secondary-color);
+    font-weight: 400;
+    font-size: 0.8125rem;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid rgba(128, 128, 128, 0.35);
+    text-align: left;
+    vertical-align: bottom;
+}
+
+.compendium_table tbody td {
+    padding: 0.5rem 0.75rem;
+    border-top: 1px solid rgba(128, 128, 128, 0.15);
+    color: var(--bs-body-color);
+    vertical-align: middle;
+}
+
+.compendium_table tbody tr:first-child td {
+    border-top: 0;
+}
+
+.compendium_table tbody tr:hover {
+    background-color: rgba(128, 128, 128, 0.08);
+}
+
+.compendium_table .compendium_table_muted {
+    color: var(--bs-secondary-color);
+}
+
+/* ===== Key-value register (the data plate) ===== */
+
+.compendium_kv {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(10.5rem, 1fr));
+    gap: 1px;
+    background-color: rgba(128, 128, 128, 0.2);
+    border: 1px solid rgba(128, 128, 128, 0.2);
+    border-radius: 0.25rem;
+    overflow: hidden;
+    margin-bottom: 0;
+}
+
+.compendium_kv_item {
+    background-color: var(--theme-dark);
+    padding: 0.6rem 0.75rem;
+}
+
+.compendium_kv_item dt {
+    color: var(--bs-secondary-color);
+    font-size: 0.8125rem;
+    font-weight: 400;
+    margin-bottom: 0.1rem;
+}
+
+.compendium_kv_item dd {
+    margin: 0;
+    color: var(--bs-body-color);
+    font-size: 0.9375rem;
+}
+
+/* ===== Activity log ===== */
+
+.compendium_log_row {
+    display: grid;
+    grid-template-columns: 6.5rem 1.25rem minmax(0, 1fr);
+    gap: 0 0.75rem;
+    padding: 0.45rem 0;
+    border-top: 1px solid rgba(128, 128, 128, 0.12);
+    align-items: center;
+    font-size: 0.875rem;
+}
+
+.compendium_log_row:first-child {
+    border-top: 0;
+}
+
+.compendium_log_time {
+    color: var(--bs-secondary-color);
+    font-size: 0.8125rem;
+    white-space: nowrap;
+}
+
+.compendium_log_time a {
+    color: inherit;
+}
+
+.compendium_log_icon {
+    text-align: center;
+    font-size: 0.8125rem;
+}
+
+.compendium_log_text {
+    color: var(--bs-body-color);
+    min-width: 0;
+}
+
+.compendium_log_text img {
+    width: 20px;
+    height: 20px;
+    border-radius: 0.2rem;
+    vertical-align: -0.3em;
+    margin-right: 0.15rem;
+}
+
+/* Day header used by the activity pages: date left, event count right */
+.compendium_log_day {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.25rem;
+}
+
+.compendium_log_day_title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin-bottom: 0;
+}
+
+.compendium_log_day_count {
+    color: var(--bs-secondary-color);
+    font-size: 0.8125rem;
+    white-space: nowrap;
+}
+
+@media (max-width: 575.98px) {
+    .compendium_log_row {
+        grid-template-columns: 1.25rem minmax(0, 1fr);
+    }
+
+    .compendium_log_time {
+        grid-column: 2;
+        order: 2;
+    }
+}
+
+/* ===== Landing directory ===== */
+
+.compendium_directory {
+    border: 1px solid rgba(128, 128, 128, 0.25);
+    border-radius: 0.25rem;
+    overflow: hidden;
+}
+
+a.compendium_directory_row {
+    display: grid;
+    grid-template-columns: 3rem minmax(0, 1fr) auto;
+    gap: 1rem;
+    align-items: center;
+    padding: 0.9rem 1.1rem;
+    background-color: var(--theme-bg-card);
+    border-top: 1px solid rgba(128, 128, 128, 0.2);
+    color: var(--bs-body-color);
+    text-decoration: none;
+    transition: background-color 0.15s ease;
+}
+
+a.compendium_directory_row:first-child {
+    border-top: 0;
+}
+
+a.compendium_directory_row:hover {
+    background-color: var(--theme-bg-card-footer);
+    color: var(--bs-body-color);
+    text-decoration: none;
+}
+
+.compendium_directory_icon {
+    width: 3rem;
+    height: 3rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--theme-darker);
+    border-radius: 0.25rem;
+    color: var(--theme-link);
+    font-size: 1.15rem;
+}
+
+.compendium_directory_title {
+    font-weight: 600;
+    margin-bottom: 0;
+}
+
+.compendium_directory_count {
+    color: var(--bs-secondary-color);
+    font-size: 0.8125rem;
+    margin-left: 0.5rem;
+}
+
+.compendium_directory_desc {
+    color: var(--bs-secondary-color);
+    font-size: 0.875rem;
+    margin: 0.1rem 0 0;
+}
+
+.compendium_directory_cta {
+    color: var(--theme-link);
+    white-space: nowrap;
+    font-size: 0.875rem;
+}
+
+a.compendium_directory_row:hover .compendium_directory_cta {
+    color: var(--theme-link-hover);
+}
+
+@media (max-width: 575.98px) {
+    a.compendium_directory_row {
+        grid-template-columns: 3rem minmax(0, 1fr);
+    }
+
+    .compendium_directory_cta {
+        display: none;
+    }
+}
+
+/* ===== Class tiles ===== */
+
+a.compendium_class_tile {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.6rem 0.75rem;
+    background-color: var(--theme-bg-card);
+    border: 1px solid rgba(128, 128, 128, 0.25);
+    border-radius: 0.25rem;
+    color: var(--bs-body-color);
+    font-weight: 600;
+    font-size: 0.875rem;
+    text-decoration: none;
+    transition: background-color 0.15s ease;
+    height: 100%;
+}
+
+a.compendium_class_tile:hover {
+    background-color: var(--theme-bg-card-footer);
+    color: var(--bs-body-color);
+    text-decoration: none;
+}
+
+a.compendium_class_tile img {
+    width: 36px;
+    height: 36px;
+    border-radius: 0.25rem;
+    flex-shrink: 0;
+}
+
+/* ===== Index toolbar ===== */
+
+.compendium_toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+    align-items: flex-end;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+}
+
+.compendium_toolbar_filter {
+    flex: 0 1 20rem;
+    min-width: 14rem;
+}
+
+/* DataTables chrome inside a compendium index: align the generated search box and pager
+   with the register language */
+.compendium_datatable div.dt-container div.dt-search {
+    margin-bottom: 0.5rem;
+}
+
+.compendium_datatable div.dt-container div.dt-search input {
+    background-color: var(--theme-dark);
+    color: var(--bs-body-color);
+    border: 1px solid rgba(128, 128, 128, 0.5);
+    border-radius: 0.25rem;
+    padding: 0.3rem 0.6rem;
+}
+
+.compendium_datatable table.dataTable {
+    border-collapse: collapse;
+}

--- a/resources/assets/js/handlebars/spell_template.handlebars
+++ b/resources/assets/js/handlebars/spell_template.handlebars
@@ -1,4 +1,4 @@
-<a href="{{compendium_url}}"{{#if spell_id}} data-wowhead="spell={{spell_id}}" data-wh-iconize-link="false"{{/if}}>
+<a href="{{compendium_url}}"{{#if wowhead_tooltip_data}} data-wowhead="{{wowhead_tooltip_data}}" data-wh-iconize-link="false"{{/if}}>
     <img src="{{icon_url}}" width="20" height="20" class="me-1" loading="lazy"/>
     {{name}}
 </a>

--- a/resources/assets/js/handlebars/spell_template.handlebars
+++ b/resources/assets/js/handlebars/spell_template.handlebars
@@ -1,4 +1,4 @@
-<a href="{{compendium_url}}"{{#if spell_id}} data-wowhead="spell={{spell_id}}"{{/if}}>
+<a href="{{compendium_url}}"{{#if spell_id}} data-wowhead="spell={{spell_id}}" data-wh-iconize-link="false"{{/if}}>
     <img src="{{icon_url}}" width="20" height="20" class="me-1" loading="lazy"/>
     {{name}}
 </a>

--- a/resources/assets/js/handlebars/spell_template.handlebars
+++ b/resources/assets/js/handlebars/spell_template.handlebars
@@ -1,4 +1,4 @@
-<a href="{{compendium_url}}">
+<a href="{{compendium_url}}"{{#if spell_id}} data-wowhead="spell={{spell_id}}"{{/if}}>
     <img src="{{icon_url}}" width="20" height="20" class="me-1" loading="lazy"/>
     {{name}}
 </a>

--- a/resources/views/common/spell/link.blade.php
+++ b/resources/views/common/spell/link.blade.php
@@ -8,6 +8,6 @@ use App\Models\Spell\Spell;
  */
 $size ??= 20;
 ?>
-<a href="{{ route('spell.compendium.show', $spell) }}"><img src="{{ $spell->icon_url }}"
+<a href="{{ route('spell.compendium.show', $spell) }}" data-wowhead="spell={{ $spell->id }}"><img src="{{ $spell->icon_url }}"
          width="{{ $size }}" height="{{ $size }}"
          class="me-1" loading="lazy" alt=""/>{{ __($spell->name) }}</a>

--- a/resources/views/common/spell/link.blade.php
+++ b/resources/views/common/spell/link.blade.php
@@ -8,6 +8,6 @@ use App\Models\Spell\Spell;
  */
 $size ??= 20;
 ?>
-<a href="{{ route('spell.compendium.show', $spell) }}" data-wowhead="spell={{ $spell->id }}" data-wh-iconize-link="false"><img src="{{ $spell->icon_url }}"
+<a href="{{ route('spell.compendium.show', $spell) }}" data-wowhead="{{ $spell->wowhead_tooltip_data }}" data-wh-iconize-link="false"><img src="{{ $spell->icon_url }}"
          width="{{ $size }}" height="{{ $size }}"
          class="me-1" loading="lazy" alt=""/>{{ __($spell->name) }}</a>

--- a/resources/views/common/spell/link.blade.php
+++ b/resources/views/common/spell/link.blade.php
@@ -8,6 +8,6 @@ use App\Models\Spell\Spell;
  */
 $size ??= 20;
 ?>
-<a href="{{ route('spell.compendium.show', $spell) }}" data-wowhead="spell={{ $spell->id }}"><img src="{{ $spell->icon_url }}"
+<a href="{{ route('spell.compendium.show', $spell) }}" data-wowhead="spell={{ $spell->id }}" data-wh-iconize-link="false"><img src="{{ $spell->icon_url }}"
          width="{{ $size }}" height="{{ $size }}"
          class="me-1" loading="lazy" alt=""/>{{ __($spell->name) }}</a>

--- a/resources/views/compendium/activity/index.blade.php
+++ b/resources/views/compendium/activity/index.blade.php
@@ -28,11 +28,12 @@ use Illuminate\Support\Collection;
     @else
         @foreach($dates->items() as $date)
                 <?php /** @var string $date */ ?>
-            <div class="mb-5">
+            <div class="mb-4">
                 @include('compendium.activity.sections.event_list', [
                     'events'         => $eventsByDay[$date],
                     'date'           => $date,
                     'contextDungeon' => $contextDungeon,
+                    'limit'          => 15,
                 ])
             </div>
         @endforeach

--- a/resources/views/compendium/activity/sections/event_list.blade.php
+++ b/resources/views/compendium/activity/sections/event_list.blade.php
@@ -18,4 +18,5 @@ use Illuminate\Support\Collection;
     'showSpellSubject' => true,
     'contextDungeon'   => $contextDungeon,
     'date'             => $date,
+    'limit'            => $limit ?? null,
 ])

--- a/resources/views/compendium/activity/sections/event_list.blade.php
+++ b/resources/views/compendium/activity/sections/event_list.blade.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
  * @var Collection<int, CombatLogNpcEvent|CombatLogSpellEvent> $events
  * @var string                                                 $date           Y-m-d string
  * @var Dungeon                                                $contextDungeon
+ * @var int|null                                               $limit          Optional row cap, passed through to the shared event list
  */
 ?>
 @include('compendium.sections.event_list', [

--- a/resources/views/compendium/class/index.blade.php
+++ b/resources/views/compendium/class/index.blade.php
@@ -17,16 +17,13 @@ use Illuminate\Support\Collection;
     <div class="row">
         @foreach($characterClasses as $characterClass)
             <?php /** @var CharacterClass $characterClass */ ?>
-            <div class="col-6 col-sm-4 col-md-3 col-lg-2 mb-4">
-                <a href="{{ route('compendium.class.show', $characterClass) }}" class="text-decoration-none">
-                    <div class="card h-100 text-center py-3 px-2">
-                        <img src="{{ $characterClass->icon_url }}"
-                             width="56" height="56"
-                             alt="{{ __($characterClass->name) }}"
-                             loading="lazy"
-                             class="mx-auto mb-2 rounded"/>
-                        <div class="fw-bold small">{{ __($characterClass->name) }}</div>
-                    </div>
+            <div class="col-6 col-sm-4 col-md-3 col-lg-2 mb-3">
+                <a href="{{ route('compendium.class.show', $characterClass) }}" class="compendium_class_tile">
+                    <img src="{{ $characterClass->icon_url }}"
+                         width="48" height="48"
+                         alt="{{ __($characterClass->name) }}"
+                         loading="lazy"/>
+                    <span>{{ __($characterClass->name) }}</span>
                 </a>
             </div>
         @endforeach

--- a/resources/views/compendium/class/sections/spell-npc-table.blade.php
+++ b/resources/views/compendium/class/sections/spell-npc-table.blade.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Collection;
  */
 ?>
 <div class="table-responsive">
-    <table class="table table-sm table-striped">
+    <table class="compendium_table">
         <thead>
         <tr>
             <th width="35%">{{ __($tableSpellHeader) }}</th>
@@ -26,7 +26,7 @@ use Illuminate\Support\Collection;
             <?php /** @var Spell $tableSpell */ ?>
             <?php $castingNpcs = $tableNpcsBySpellId->get($tableSpell->id, collect()); ?>
             <tr>
-                <td>@include('common.spell.link', ['spell' => $tableSpell])</td>
+                <td class="text-nowrap">@include('common.spell.link', ['spell' => $tableSpell])</td>
                 <td>
                     @if($castingNpcs->isEmpty())
                         <span class="text-muted">{{ __('view_compendium.class.show.no_npcs') }}</span>

--- a/resources/views/compendium/class/show.blade.php
+++ b/resources/views/compendium/class/show.blade.php
@@ -33,16 +33,17 @@ use Illuminate\Support\Collection;
 
 @section('content')
     {{-- Header --}}
-    <div class="row mb-4">
-        <div class="col-auto">
-            <img src="{{ $characterClass->icon_url }}"
-                 width="64" height="64"
-                 alt="{{ __($characterClass->name) }}"
-                 loading="lazy"
-                 class="rounded"/>
-        </div>
-        <div class="col">
-            <h2 class="mb-1">{{ __($characterClass->name) }}</h2>
+    <div class="compendium_identity">
+        <img src="{{ $characterClass->icon_url }}"
+             width="88" height="88"
+             alt="{{ __($characterClass->name) }}"
+             loading="lazy"
+             class="compendium_identity_portrait"/>
+        <div class="compendium_identity_body">
+            <h2 class="compendium_identity_title">{{ __($characterClass->name) }}</h2>
+            <div class="compendium_identity_meta">
+                <span class="compendium_chip">{{ __($contextDungeon->name) }}</span>
+            </div>
         </div>
     </div>
 
@@ -51,7 +52,7 @@ use Illuminate\Support\Collection;
         <p class="text-muted">{{ __('view_compendium.class.show.no_spells') }}</p>
     @else
         <div class="table-responsive">
-            <table class="table table-sm table-striped">
+            <table class="compendium_table">
                 <thead>
                 <tr>
                     <th width="25%">{{ __('view_compendium.class.show.table_header_spell') }}</th>
@@ -64,7 +65,7 @@ use Illuminate\Support\Collection;
                     <?php /** @var Spell $spell */ ?>
                     <?php $affectedNpcs = $npcsByCharacteristicId->get($spell->characteristic_id, collect()); ?>
                     <tr>
-                        <td>@include('common.spell.link', ['spell' => $spell])</td>
+                        <td class="text-nowrap">@include('common.spell.link', ['spell' => $spell])</td>
                         <td>
                             @if($spell->characteristic)
                                 <img src="{{ ksgAssetImage(sprintf('spells/%s.jpg', $spell->characteristic->icon_name)) }}"
@@ -93,8 +94,6 @@ use Illuminate\Support\Collection;
 
     {{-- Counterable abilities (Vanish / Shadowmeld / ...) --}}
     @if(!empty($counterSections))
-        <h3 class="mt-4">{{ __('view_compendium.class.show.counters.title') }}</h3>
-
         @foreach($counterSections as $counterSection)
             <?php
             /** @var SpellCounterDefinitionInterface $definition */
@@ -106,30 +105,37 @@ use Illuminate\Support\Collection;
             $npcsBySpellId = $counterSection['npcsBySpellId'];
             $counterKey    = Spell::ALL_COUNTERS[$definition->getCounterBit()];
             ?>
-            <div class="mb-4">
-                <h5 class="mb-2">
-                    <img src="{{ ksgAssetImage(sprintf('spells/%s.jpg', $definition->getIconName())) }}"
-                         width="20" height="20"
-                         loading="lazy"
-                         class="rounded me-1"
-                         alt="{{ __('spellcounters.' . $counterKey) }}"/>{{ __('spellcounters.' . $counterKey) }}
-                    @if($raceName !== null)
-                        <span class="badge text-bg-secondary ms-1">
-                            {{ __('view_compendium.class.show.counters.racial', ['race' => __($raceName)]) }}
-                        </span>
+            <div class="compendium_record_section @if($loop->first) mt-4 @endif">
+                <div class="compendium_record_label">
+                    @if($loop->first)
+                        {{ __('view_compendium.class.show.counters.title') }}
                     @endif
-                </h5>
+                </div>
+                <div>
+                    <h5 class="mb-2">
+                        <img src="{{ ksgAssetImage(sprintf('spells/%s.jpg', $definition->getIconName())) }}"
+                             width="20" height="20"
+                             loading="lazy"
+                             class="rounded me-1"
+                             alt="{{ __('spellcounters.' . $counterKey) }}"/>{{ __('spellcounters.' . $counterKey) }}
+                        @if($raceName !== null)
+                            <span class="badge text-bg-secondary ms-1">
+                                {{ __('view_compendium.class.show.counters.racial', ['race' => __($raceName)]) }}
+                            </span>
+                        @endif
+                    </h5>
 
-                @if($counterSpells->isEmpty())
-                    <p class="text-muted">{{ __('view_compendium.class.show.counters.no_spells') }}</p>
-                @else
-                    @include('compendium.class.sections.spell-npc-table', [
-                        'tableSpells'        => $counterSpells,
-                        'tableNpcsBySpellId' => $npcsBySpellId,
-                        'tableSpellHeader'   => 'view_compendium.class.show.counters.table_header_spell',
-                        'tableNpcsHeader'    => 'view_compendium.class.show.counters.table_header_npcs',
-                    ])
-                @endif
+                    @if($counterSpells->isEmpty())
+                        <p class="text-muted mb-0">{{ __('view_compendium.class.show.counters.no_spells') }}</p>
+                    @else
+                        @include('compendium.class.sections.spell-npc-table', [
+                            'tableSpells'        => $counterSpells,
+                            'tableNpcsBySpellId' => $npcsBySpellId,
+                            'tableSpellHeader'   => 'view_compendium.class.show.counters.table_header_spell',
+                            'tableNpcsHeader'    => 'view_compendium.class.show.counters.table_header_npcs',
+                        ])
+                    @endif
+                </div>
             </div>
         @endforeach
     @endif
@@ -142,24 +148,33 @@ use Illuminate\Support\Collection;
         /** @var Collection<int, Collection<int, Npc>> $reflectNpcsBySpellId */
         $reflectNpcsBySpellId = $reflectSection['npcsBySpellId'];
         ?>
-        <h3 class="mt-4">
-            <img src="{{ ksgAssetImage(sprintf('spells/%s.jpg', $reflectSection['iconName'])) }}"
-                 width="24" height="24"
-                 loading="lazy"
-                 class="rounded me-1"
-                 alt="{{ __('view_compendium.class.show.reflect.title') }}"/>{{ __('view_compendium.class.show.reflect.title') }}
-        </h3>
-        <p class="text-muted">{{ __('view_compendium.class.show.reflect.description') }}</p>
+        <div class="compendium_record_section">
+            <div class="compendium_record_label">
+                {{ __('view_compendium.class.show.reflect.title') }}
+                <div class="compendium_record_label_sub">
+                    {{ __('view_compendium.class.show.reflect.description') }}
+                </div>
+            </div>
+            <div>
+                <h5 class="mb-2">
+                    <img src="{{ ksgAssetImage(sprintf('spells/%s.jpg', $reflectSection['iconName'])) }}"
+                         width="20" height="20"
+                         loading="lazy"
+                         class="rounded me-1"
+                         alt="{{ __('view_compendium.class.show.reflect.title') }}"/>{{ __('view_compendium.class.show.reflect.title') }}
+                </h5>
 
-        @if($reflectSpells->isEmpty())
-            <p class="text-muted">{{ __('view_compendium.class.show.reflect.no_spells') }}</p>
-        @else
-            @include('compendium.class.sections.spell-npc-table', [
-                'tableSpells'        => $reflectSpells,
-                'tableNpcsBySpellId' => $reflectNpcsBySpellId,
-                'tableSpellHeader'   => 'view_compendium.class.show.reflect.table_header_spell',
-                'tableNpcsHeader'    => 'view_compendium.class.show.reflect.table_header_npcs',
-            ])
-        @endif
+                @if($reflectSpells->isEmpty())
+                    <p class="text-muted mb-0">{{ __('view_compendium.class.show.reflect.no_spells') }}</p>
+                @else
+                    @include('compendium.class.sections.spell-npc-table', [
+                        'tableSpells'        => $reflectSpells,
+                        'tableNpcsBySpellId' => $reflectNpcsBySpellId,
+                        'tableSpellHeader'   => 'view_compendium.class.show.reflect.table_header_spell',
+                        'tableNpcsHeader'    => 'view_compendium.class.show.reflect.table_header_npcs',
+                    ])
+                @endif
+            </div>
+        </div>
     @endif
 @endsection

--- a/resources/views/compendium/index.blade.php
+++ b/resources/views/compendium/index.blade.php
@@ -52,19 +52,6 @@ $howItWorks = [
 @endsection
 
 @section('content')
-    {{--
-    Direction contract (#3945, "The Field Record"):
-    THESIS: the Compendium is a field record - one continuous, dense record sheet per subject;
-      it refuses the icon-card dashboard arrangement.
-    OWN-WORLD: DESIGN.md's War Room (tonal ladder via theme variables, Keystone Green accent,
-      hairline registers, sturdy controls); no new palette or faces.
-    STORY: a player looks up a thing, reads its record, trusts the combat-log-backed data.
-    FIRST VIEWPORT: intro line, then a four-row directory register (icon plate / title+count /
-      description / go), data-source panel below.
-    FORM: field-record register, candidate 5 of the grounded list, seed key f2671375.
-    FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review,
-      the verdict, and DESIGN.md.
-    --}}
     <div class="row justify-content-center">
         <div class="col-12 col-lg-8 text-center">
             <p class="lead">{{ __('view_compendium.index.intro') }}</p>

--- a/resources/views/compendium/index.blade.php
+++ b/resources/views/compendium/index.blade.php
@@ -4,7 +4,7 @@
  * @var array{npc: int, spell: int, class: int} $stats
  */
 
-$cards = [
+$sections = [
     [
         'icon'     => 'fa-dragon',
         'title'    => __('view_compendium.index.cards.npc.title'),
@@ -52,73 +52,81 @@ $howItWorks = [
 @endsection
 
 @section('content')
+    {{--
+    Direction contract (#3945, "The Field Record"):
+    THESIS: the Compendium is a field record - one continuous, dense record sheet per subject;
+      it refuses the icon-card dashboard arrangement.
+    OWN-WORLD: DESIGN.md's War Room (tonal ladder via theme variables, Keystone Green accent,
+      hairline registers, sturdy controls); no new palette or faces.
+    STORY: a player looks up a thing, reads its record, trusts the combat-log-backed data.
+    FIRST VIEWPORT: intro line, then a four-row directory register (icon plate / title+count /
+      description / go), data-source panel below.
+    FORM: field-record register, candidate 5 of the grounded list, seed key f2671375.
+    FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review,
+      the verdict, and DESIGN.md.
+    --}}
     <div class="row justify-content-center">
-        <div class="col-12 col-lg-10 text-center">
+        <div class="col-12 col-lg-8 text-center">
             <p class="lead">{{ __('view_compendium.index.intro') }}</p>
         </div>
     </div>
 
-    <div class="row mt-4">
-        @foreach($cards as $card)
-            <div class="col-12 col-md-6 col-lg-3 mb-4">
-                <div class="card h-100 text-center">
-                    <div class="card-body d-flex flex-column">
-                        <div class="mb-3">
-                            <i class="fas {{ $card['icon'] }} fa-3x"></i>
-                        </div>
-                        <h5 class="card-title fw-bold">{{ $card['title'] }}</h5>
-                        <div class="text-muted small mb-2">{{ $card['subtitle'] }}</div>
-                        <p class="card-text flex-grow-1">{{ $card['text'] }}</p>
-                        <a href="{{ $card['route'] }}" class="btn btn-primary mt-2">
-                            {{ $card['cta'] }} <i class="fas fa-arrow-right"></i>
-                        </a>
-                    </div>
-                </div>
+    <div class="row justify-content-center mt-4">
+        <div class="col-12 col-lg-8">
+            <div class="compendium_directory">
+                @foreach($sections as $section)
+                    <a href="{{ $section['route'] }}" class="compendium_directory_row">
+                        <span class="compendium_directory_icon">
+                            <i class="fas {{ $section['icon'] }}"></i>
+                        </span>
+                        <span>
+                            <span class="compendium_directory_title">{{ $section['title'] }}</span>
+                            <span class="compendium_directory_count">{{ $section['subtitle'] }}</span>
+                            <p class="compendium_directory_desc">{{ $section['text'] }}</p>
+                        </span>
+                        <span class="compendium_directory_cta">
+                            {{ $section['cta'] }} <i class="fas fa-arrow-right"></i>
+                        </span>
+                    </a>
+                @endforeach
             </div>
-        @endforeach
+        </div>
     </div>
 
     <div class="row justify-content-center mt-4">
-        <div class="col-12 col-lg-10">
-            <div class="card">
-                <div class="card-body">
-                    <div class="row align-items-center">
-                        <div class="col-12 col-md">
-                            <h5 class="fw-bold mb-2">
-                                <i class="fas fa-bolt"></i> {{ __('view_compendium.index.data_source.title') }}
-                            </h5>
-                            <p class="mb-3 mb-md-0">{{ __('view_compendium.index.data_source.description') }}</p>
-                        </div>
-                        <div class="col-12 col-md-auto text-center">
-                            <a href="https://raider.io/addon" target="_blank" rel="noopener"
-                               class="btn btn-accent">
-                                <i class="fas fa-download"></i> {{ __('view_compendium.index.data_source.cta') }}
-                            </a>
-                        </div>
-                    </div>
+        <div class="col-12 col-lg-8">
+            <div class="compendium_identity mb-0">
+                <span class="compendium_directory_icon">
+                    <i class="fas fa-bolt"></i>
+                </span>
+                <div class="compendium_identity_body">
+                    <h5 class="compendium_identity_title">{{ __('view_compendium.index.data_source.title') }}</h5>
+                    <p class="mb-0">{{ __('view_compendium.index.data_source.description') }}</p>
+                </div>
+                <div class="compendium_identity_actions">
+                    <a href="https://raider.io/addon" target="_blank" rel="noopener"
+                       class="btn btn-accent">
+                        <i class="fas fa-download"></i> {{ __('view_compendium.index.data_source.cta') }}
+                    </a>
                 </div>
             </div>
         </div>
     </div>
 
-    <div class="row justify-content-center mt-5">
-        <div class="col-12 col-lg-10 text-center">
-            <h4 class="fw-bold mb-4">{{ __('view_compendium.index.how_it_works.title') }}</h4>
-            <div class="row">
-                @foreach($howItWorks as $step)
-                    <div class="col-12 col-md-4 mb-4 mb-md-0">
-                        <div class="mb-2">
-                            <i class="fas {{ $step['icon'] }} fa-2x"></i>
-                        </div>
-                        <h6 class="fw-bold">
-                            {{ __(sprintf('view_compendium.index.how_it_works.%s.title', $step['key'])) }}
-                        </h6>
-                        <p class="text-muted">
-                            {{ __(sprintf('view_compendium.index.how_it_works.%s.description', $step['key'])) }}
-                        </p>
+    <div class="row justify-content-center mt-5 mb-4">
+        <div class="col-12 col-lg-8">
+            <h4 class="fw-bold mb-2">{{ __('view_compendium.index.how_it_works.title') }}</h4>
+            @foreach($howItWorks as $step)
+                <div class="compendium_record_section">
+                    <div class="compendium_record_label">
+                        <i class="fas {{ $step['icon'] }} me-1"></i>
+                        {{ __(sprintf('view_compendium.index.how_it_works.%s.title', $step['key'])) }}
                     </div>
-                @endforeach
-            </div>
+                    <div>
+                        {{ __(sprintf('view_compendium.index.how_it_works.%s.description', $step['key'])) }}
+                    </div>
+                </div>
+            @endforeach
         </div>
     </div>
 @endsection

--- a/resources/views/compendium/npc/index.blade.php
+++ b/resources/views/compendium/npc/index.blade.php
@@ -79,7 +79,7 @@ use App\Models\Npc\NpcClassification;
                             return data.filter((spell) => !spell.hidden_on_map).map(function (spell) {
                                 return spellTemplate({
                                     compendium_url: `${spellShowBaseUrl}/${spell.id}-${slugify(lang.get(spell.name))}`,
-                                    spell_id: spell.id,
+                                    wowhead_tooltip_data: spell.wowhead_tooltip_data,
                                     icon_url: spell.icon_url,
                                     name: lang.get(spell.name),
                                 });

--- a/resources/views/compendium/npc/index.blade.php
+++ b/resources/views/compendium/npc/index.blade.php
@@ -79,6 +79,7 @@ use App\Models\Npc\NpcClassification;
                             return data.filter((spell) => !spell.hidden_on_map).map(function (spell) {
                                 return spellTemplate({
                                     compendium_url: `${spellShowBaseUrl}/${spell.id}-${slugify(lang.get(spell.name))}`,
+                                    spell_id: spell.id,
                                     icon_url: spell.icon_url,
                                     name: lang.get(spell.name),
                                 });

--- a/resources/views/compendium/npc/index.blade.php
+++ b/resources/views/compendium/npc/index.blade.php
@@ -111,8 +111,8 @@ use App\Models\Npc\NpcClassification;
 @endsection
 
 @section('content')
-    <div class="row mb-3">
-        <div class="col-md-4">
+    <div class="compendium_toolbar">
+        <div class="compendium_toolbar_filter">
             @include('common.dungeon.select', [
                 'id'       => 'compendium_filter_dungeon',
                 'label'    => false,
@@ -124,13 +124,15 @@ use App\Models\Npc\NpcClassification;
         </div>
     </div>
 
-    <table id="compendium_npc_table" class="tablesorter default_table table-striped">
-        <thead>
-        <tr>
-            <th width="25%">{{ __('view_compendium.npc.index.table_header_name') }}</th>
-            <th width="25%">{{ __('view_compendium.npc.index.table_header_dungeons') }}</th>
-            <th width="50%">{{ __('view_compendium.npc.index.table_header_spells') }}</th>
-        </tr>
-        </thead>
-    </table>
+    <div class="compendium_datatable">
+        <table id="compendium_npc_table" class="tablesorter default_table compendium_table">
+            <thead>
+            <tr>
+                <th width="25%">{{ __('view_compendium.npc.index.table_header_name') }}</th>
+                <th width="25%">{{ __('view_compendium.npc.index.table_header_dungeons') }}</th>
+                <th width="50%">{{ __('view_compendium.npc.index.table_header_spells') }}</th>
+            </tr>
+            </thead>
+        </table>
+    </div>
 @endsection

--- a/resources/views/compendium/npc/sections/characteristics.blade.php
+++ b/resources/views/compendium/npc/sections/characteristics.blade.php
@@ -5,37 +5,43 @@ use App\Models\Npc\Npc;
 use Illuminate\Support\Collection;
 
 /**
+ * The section title + tooltip live in the parent record section's label rail (see show.blade.php).
+ *
  * @var Npc                             $npc
  * @var Collection<int, Characteristic> $allCharacteristics
  */
+
+$npcCharacteristicIds = $npc->characteristics->pluck('id')->flip();
+
+[$active, $inactive] = $allCharacteristics->partition(fn(Characteristic $characteristic) => $npcCharacteristicIds->has($characteristic->id));
 ?>
-{{-- Characteristics --}}
-<?php $npcCharacteristicIds = $npc->characteristics->pluck('id')->flip(); ?>
-<div class="row mb-4">
-    <div class="col">
-        <div class="row g-0">
-            <div class="col-auto">
-                <h4>{{ __('view_compendium.npc.sections.characteristics.title') }}</h4>
-            </div>
-            <div class="col ms-1">
-                <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                   title="{{ __('view_compendium.npc.sections.characteristics.tooltip') }}"></i>
-            </div>
-        </div>
-        <div class="d-flex flex-wrap">
-            @foreach($allCharacteristics as $characteristic)
-                <?php /** @var Characteristic $characteristic */ ?>
-                <?php $hasCharacteristic = $npcCharacteristicIds->has($characteristic->id); ?>
-                <div class="me-2 mb-2 text-center" style="width: 48px;"
-                     data-bs-toggle="tooltip" data-bs-placement="top" title="{{ __($characteristic->name) }}">
-                    <img src="{{ ksgAssetImage(sprintf('spells/%s.jpg', $characteristic->icon_name)) }}"
-                         width="36" height="36"
-                         loading="lazy"
-                         class="rounded"
-                         style="{{ $hasCharacteristic ? '' : 'filter: grayscale(100%); opacity: 0.35;' }}"
-                         alt="{{ __($characteristic->name) }}"/>
-                </div>
-            @endforeach
-        </div>
+@if($active->isNotEmpty())
+    <div class="compendium_characteristics">
+        @foreach($active as $characteristic)
+            <?php /** @var Characteristic $characteristic */ ?>
+            <span class="compendium_characteristic">
+                <img src="{{ ksgAssetImage(sprintf('spells/%s.jpg', $characteristic->icon_name)) }}"
+                     width="28" height="28"
+                     loading="lazy"
+                     alt="{{ __($characteristic->name) }}"/>
+                {{ __($characteristic->name) }}
+            </span>
+        @endforeach
     </div>
-</div>
+@else
+    <p class="text-muted mb-0">{{ __('view_compendium.npc.sections.characteristics.empty') }}</p>
+@endif
+
+@if($inactive->isNotEmpty())
+    <div class="compendium_characteristics_muted">
+        <span class="compendium_characteristics_muted_label">{{ __('view_compendium.npc.sections.characteristics.not_observed') }}</span>
+        @foreach($inactive as $characteristic)
+            <?php /** @var Characteristic $characteristic */ ?>
+            <img src="{{ ksgAssetImage(sprintf('spells/%s.jpg', $characteristic->icon_name)) }}"
+                 width="22" height="22"
+                 loading="lazy"
+                 data-bs-toggle="tooltip" data-bs-placement="top" title="{{ __($characteristic->name) }}"
+                 alt="{{ __($characteristic->name) }}"/>
+        @endforeach
+    </div>
+@endif

--- a/resources/views/compendium/npc/sections/event_feed.blade.php
+++ b/resources/views/compendium/npc/sections/event_feed.blade.php
@@ -5,16 +5,13 @@ use App\Models\CombatLog\CombatLogSpellEvent;
 use Illuminate\Support\Collection;
 
 /**
+ * The section title lives in the parent record section's label rail (see show.blade.php).
+ *
  * @var Collection<int, CombatLogNpcEvent|CombatLogSpellEvent> $eventFeed
  */
 ?>
-<div class="row mb-4">
-    <div class="col">
-        <h4>{{ __('view_compendium.npc.sections.event_feed.title') }}</h4>
-        @include('compendium.sections.event_list', [
-            'events'   => $eventFeed,
-            'emptyKey' => 'view_compendium.npc.sections.event_feed.empty',
-            'showSpellSubject' => true,
-        ])
-    </div>
-</div>
+@include('compendium.sections.event_list', [
+    'events'   => $eventFeed,
+    'emptyKey' => 'view_compendium.npc.sections.event_feed.empty',
+    'showSpellSubject' => true,
+])

--- a/resources/views/compendium/npc/sections/header.blade.php
+++ b/resources/views/compendium/npc/sections/header.blade.php
@@ -24,46 +24,46 @@ foreach (['dangerous', 'truesight', /*'bursting', 'bolstering', 'sanguine',*/ 'r
     }
 }
 ?>
-<div class="row mb-4">
-    <div class="col-auto">
-        <img src="{{ ksgAsset($npc->enemy_portrait_url) }}"
-             width="64" height="64"
-             alt="{{ __($npc->name) }}"
-             loading="lazy"
-             class="rounded"/>
-    </div>
-    <div class="col">
-        <h2 class="mb-1">{{ __($npc->name) }}</h2>
-        <div>
-            <span class="badge {{ $classificationBadge }} me-1">
+<div class="compendium_identity">
+    <img src="{{ ksgAsset($npc->enemy_portrait_url) }}"
+         width="88" height="88"
+         alt="{{ __($npc->name) }}"
+         loading="lazy"
+         class="compendium_identity_portrait"/>
+    <div class="compendium_identity_body">
+        <h2 class="compendium_identity_title">{{ __($npc->name) }}</h2>
+        <div class="compendium_identity_meta">
+            <span class="badge {{ $classificationBadge }}">
                 {{ __($npc->classification->name) }}
             </span>
+            @foreach($flags as $flag)
+                <span class="badge text-bg-warning">{{ $flag }}</span>
+            @endforeach
             @if($npc->level)
-                <span class="badge text-bg-secondary me-1">
-                    {{ __('view_compendium.npc.sections.header.level') }} {{ $npc->level }}
+                <span class="compendium_chip">
+                    <span class="compendium_chip_label">{{ __('view_compendium.npc.sections.header.level') }}</span>
+                    {{ $npc->level }}
                 </span>
             @endif
             @if($currentNpcHealth)
-                <span class="badge text-bg-secondary me-1">
-                    {{ number_format($currentNpcHealth->health) }} HP
+                <span class="compendium_chip">
+                    <span class="compendium_chip_label">HP</span>
+                    {{ number_format($currentNpcHealth->health) }}
                 </span>
             @endif
-            <span class="badge text-bg-secondary me-1">
+            <span class="compendium_chip">
                 {{ __(sprintf('npcaggressiveness.%s', $npc->aggressiveness)) }}
             </span>
             @if($npc->type)
-                <span class="badge text-bg-secondary me-1">
+                <span class="compendium_chip">
                     {{ $npc->type->type }}
                 </span>
             @endif
 {{--            @if($npc->class)--}}
-{{--                <span class="badge text-bg-secondary me-1">--}}
+{{--                <span class="compendium_chip">--}}
 {{--                    {{ __(sprintf('npcclasses.%s', $npc->class->key)) }}--}}
 {{--                </span>--}}
 {{--            @endif--}}
-            @foreach($flags as $flag)
-                <span class="badge text-bg-warning me-1">{{ $flag }}</span>
-            @endforeach
         </div>
     </div>
 </div>

--- a/resources/views/compendium/npc/sections/spells.blade.php
+++ b/resources/views/compendium/npc/sections/spells.blade.php
@@ -4,73 +4,69 @@ use App\Models\Npc\Npc;
 use App\Models\Spell\Spell;
 
 /**
+ * The section title lives in the parent record section's label rail (see show.blade.php).
+ *
  * @var Npc $npc
  */
 ?>
-{{-- Spells --}}
-<div class="row mb-4">
-    <div class="col">
-        <h4>{{ __('view_compendium.npc.sections.spells.title') }}</h4>
-        @if($npc->spells->isNotEmpty())
-            <div class="table-responsive">
-                <table class="table table-sm mt-2">
-                    <thead>
-                    <tr>
-                        <th>{{ __('view_compendium.npc.sections.spells.header_name') }}</th>
-                        <th>
-                            {{ __('view_compendium.npc.sections.spells.header_schools') }}
-                            <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                               title="{{ __('view_compendium.npc.sections.spells.header_schools_tooltip') }}"></i>
-                        </th>
-                        <th>
-                            {{ __('view_compendium.npc.sections.spells.header_miss_types') }}
-                            <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                               title="{{ __('view_compendium.npc.sections.spells.header_miss_types_tooltip') }}"></i>
-                        </th>
-                        <th>
-                            {{ __('view_compendium.npc.sections.spells.header_counters') }}
-                            <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                               title="{{ __('view_compendium.npc.sections.spells.header_counters_tooltip') }}"></i>
-                        </th>
-                        <th>
-                            {{ __('view_compendium.npc.sections.spells.header_bypasses_immunities') }}
-                            <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                               title="{{ __('view_compendium.npc.sections.spells.header_bypasses_immunities_tooltip') }}"></i>
-                        </th>
-                        <th>
-                            {{ __('view_compendium.npc.sections.spells.header_dispel_type') }}
-                            <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                               title="{{ __('view_compendium.npc.sections.spells.header_dispel_type_tooltip') }}"></i>
-                        </th>
-                        <th>{{ __('view_compendium.npc.sections.spells.header_mechanic') }}</th>
-                        <th>{{ __('view_compendium.npc.sections.spells.header_cast_time') }}</th>
-                        <th>{{ __('view_compendium.npc.sections.spells.header_duration') }}</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    @foreach($npc->spells as $spell)
-                        <?php /** @var Spell $spell */ ?>
-                        @if($spell->hidden_on_map)
-                            @continue
-                        @endif
+@if($npc->spells->isNotEmpty())
+    <div class="table-responsive">
+        <table class="compendium_table">
+            <thead>
+            <tr>
+                <th>{{ __('view_compendium.npc.sections.spells.header_name') }}</th>
+                <th>
+                    {{ __('view_compendium.npc.sections.spells.header_schools') }}
+                    <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
+                       title="{{ __('view_compendium.npc.sections.spells.header_schools_tooltip') }}"></i>
+                </th>
+                <th>
+                    {{ __('view_compendium.npc.sections.spells.header_miss_types') }}
+                    <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
+                       title="{{ __('view_compendium.npc.sections.spells.header_miss_types_tooltip') }}"></i>
+                </th>
+                <th>
+                    {{ __('view_compendium.npc.sections.spells.header_counters') }}
+                    <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
+                       title="{{ __('view_compendium.npc.sections.spells.header_counters_tooltip') }}"></i>
+                </th>
+                <th>
+                    {{ __('view_compendium.npc.sections.spells.header_bypasses_immunities') }}
+                    <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
+                       title="{{ __('view_compendium.npc.sections.spells.header_bypasses_immunities_tooltip') }}"></i>
+                </th>
+                <th>
+                    {{ __('view_compendium.npc.sections.spells.header_dispel_type') }}
+                    <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
+                       title="{{ __('view_compendium.npc.sections.spells.header_dispel_type_tooltip') }}"></i>
+                </th>
+                <th>{{ __('view_compendium.npc.sections.spells.header_mechanic') }}</th>
+                <th>{{ __('view_compendium.npc.sections.spells.header_cast_time') }}</th>
+                <th>{{ __('view_compendium.npc.sections.spells.header_duration') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach($npc->spells as $spell)
+                <?php /** @var Spell $spell */ ?>
+                @if($spell->hidden_on_map)
+                    @continue
+                @endif
 
-                        <tr>
-                            <td>@include('common.spell.link', ['spell' => $spell, 'size' => 24])</td>
-                            <td>{{ Spell::maskToReadableString(Spell::ALL_SCHOOLS, $spell->schools_mask, 'spellschools') }}</td>
-                            <td>{{ Spell::maskToReadableString(Spell::ALL_MISS_TYPES, $spell->miss_types_mask, 'spellmisstypes') }}</td>
-                            <td>{{ Spell::maskToReadableString(Spell::ALL_COUNTERS, $spell->counters_mask, 'spellcounters') }}</td>
-                            <td>{{ Spell::maskToReadableString(Spell::ALL_IMMUNITIES, $spell->bypasses_immunities_mask, 'spellimmunities') }}</td>
-                            <td>{{ __($spell->dispel_type) }}</td>
-                            <td>{{ __($spell->mechanic) }}</td>
-                            <td>{{ $spell->cast_time > 0 ? ($spell->cast_time / 1000) . 's' : '-' }}</td>
-                            <td>{{ $spell->duration > 0 ? ($spell->duration / 1000) . 's' : '-' }}</td>
-                        </tr>
-                    @endforeach
-                    </tbody>
-                </table>
-            </div>
-        @else
-            <p class="text-muted">{{ __('view_compendium.npc.sections.spells.empty') }}</p>
-        @endif
+                <tr>
+                    <td class="text-nowrap">@include('common.spell.link', ['spell' => $spell, 'size' => 24])</td>
+                    <td>{{ Spell::maskToReadableString(Spell::ALL_SCHOOLS, $spell->schools_mask, 'spellschools') }}</td>
+                    <td>{{ Spell::maskToReadableString(Spell::ALL_MISS_TYPES, $spell->miss_types_mask, 'spellmisstypes') }}</td>
+                    <td>{{ Spell::maskToReadableString(Spell::ALL_COUNTERS, $spell->counters_mask, 'spellcounters') }}</td>
+                    <td>{{ Spell::maskToReadableString(Spell::ALL_IMMUNITIES, $spell->bypasses_immunities_mask, 'spellimmunities') }}</td>
+                    <td>{{ __($spell->dispel_type) }}</td>
+                    <td>{{ __($spell->mechanic) }}</td>
+                    <td>{{ $spell->cast_time > 0 ? ($spell->cast_time / 1000) . 's' : '-' }}</td>
+                    <td>{{ $spell->duration > 0 ? ($spell->duration / 1000) . 's' : '-' }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
     </div>
-</div>
+@else
+    <p class="text-muted mb-0">{{ __('view_compendium.npc.sections.spells.empty') }}</p>
+@endif

--- a/resources/views/compendium/npc/show.blade.php
+++ b/resources/views/compendium/npc/show.blade.php
@@ -28,9 +28,32 @@ use App\Models\Npc\NpcHealth;
 @section('content')
     @include('compendium.npc.sections.header')
 
-    @include('compendium.npc.sections.characteristics')
+    <div class="compendium_record_section">
+        <div class="compendium_record_label">
+            {{ __('view_compendium.npc.sections.characteristics.title') }}
+            <i class="fas fa-info-circle ms-1" data-bs-toggle="tooltip" data-bs-placement="top"
+               title="{{ __('view_compendium.npc.sections.characteristics.tooltip') }}"></i>
+        </div>
+        <div>
+            @include('compendium.npc.sections.characteristics')
+        </div>
+    </div>
 
-    @include('compendium.npc.sections.spells')
+    <div class="compendium_record_section">
+        <div class="compendium_record_label">
+            {{ __('view_compendium.npc.sections.spells.title') }}
+        </div>
+        <div>
+            @include('compendium.npc.sections.spells')
+        </div>
+    </div>
 
-    @include('compendium.npc.sections.event_feed')
+    <div class="compendium_record_section">
+        <div class="compendium_record_label">
+            {{ __('view_compendium.npc.sections.event_feed.title') }}
+        </div>
+        <div>
+            @include('compendium.npc.sections.event_feed')
+        </div>
+    </div>
 @endsection

--- a/resources/views/compendium/sections/event_list.blade.php
+++ b/resources/views/compendium/sections/event_list.blade.php
@@ -74,9 +74,20 @@ $spellPropertyName = static function (SpellProperty $property): string {
     return __('spellmisstypes.' . substr($property->value, 5));
 };
 
-$eventDescription = static function (CombatLogNpcEvent|CombatLogSpellEvent $event) use ($spellPropertyName): string {
+/**
+ * Returns HTML: spell names inside descriptions render as links to their compendium page, so
+ * every interpolated plain string is escaped here and the caller prints with {!! !!}.
+ * When the row already leads with the spell as its subject link ($subjectShown), the
+ * description switches to the subject-less wording instead of repeating the spell name.
+ */
+$eventDescription = static function (CombatLogNpcEvent|CombatLogSpellEvent $event, bool $subjectShown) use ($spellPropertyName): string {
     if ($event instanceof CombatLogNpcEvent) {
-        $modelName = $event->model ? __($event->model->getAttribute('name')) : sprintf('#%d', $event->model_id);
+        $model = $event->model;
+
+        // An assigned spell has its own compendium page - render the name as a spell link
+        $modelName = $model instanceof Spell
+            ? view('common.spell.link', ['spell' => $model])->render()
+            : e($model ? __($model->getAttribute('name')) : sprintf('#%d', $event->model_id));
 
         return match ($event->event_type) {
             CombatLogNpcEventType::CharacteristicAdded => __('view_compendium.event.characteristic_added', ['name' => $modelName]),
@@ -85,16 +96,22 @@ $eventDescription = static function (CombatLogNpcEvent|CombatLogSpellEvent $even
         };
     }
 
-    $spellName = $event->spell ? __($event->spell->name) : sprintf('#%d', $event->spell_id);
+    $spellName = e($event->spell ? __($event->spell->name) : sprintf('#%d', $event->spell_id));
 
     // Counters and immunity bypasses are properties of what a *player* can do about the spell, so the generic
     // "Affected by :property" wording does not fit them
     [$addedKey, $removedKey] = match (true) {
-        $event->property?->isCounter() === true => [
+        $event->property?->isCounter() === true => $subjectShown ? [
+            'view_compendium.event.counter_added_no_subject',
+            'view_compendium.event.counter_removed_no_subject',
+        ] : [
             'view_compendium.event.counter_added',
             'view_compendium.event.counter_removed',
         ],
-        $event->property?->isImmunityBypass() === true => [
+        $event->property?->isImmunityBypass() === true => $subjectShown ? [
+            'view_compendium.event.immunity_bypass_added_no_subject',
+            'view_compendium.event.immunity_bypass_removed_no_subject',
+        ] : [
             'view_compendium.event.immunity_bypass_added',
             'view_compendium.event.immunity_bypass_removed',
         ],
@@ -105,21 +122,27 @@ $eventDescription = static function (CombatLogNpcEvent|CombatLogSpellEvent $even
     };
 
     return match ($event->event_type) {
-        CombatLogSpellEventType::SpellCreated => __('view_compendium.event.spell_created', ['spell' => $spellName]),
+        CombatLogSpellEventType::SpellCreated => __(
+            $subjectShown ? 'view_compendium.event.spell_created_no_subject' : 'view_compendium.event.spell_created',
+            ['spell' => $spellName]
+        ),
         CombatLogSpellEventType::PropertyChanged => __($addedKey, [
             'spell'    => $spellName,
-            'property' => $spellPropertyName($event->property)
+            'property' => e($spellPropertyName($event->property))
         ]),
         CombatLogSpellEventType::PropertyRemoved => __($removedKey, [
             'spell'    => $spellName,
-            'property' => $spellPropertyName($event->property)
+            'property' => e($spellPropertyName($event->property))
         ]),
-        CombatLogSpellEventType::SchoolRecorded => __('view_compendium.event.school_recorded', [
-            'spell'   => $spellName,
-            'schools' => $event->spell
-                ? Spell::maskToReadableString(Spell::ALL_SCHOOLS, $event->spell->schools_mask, 'spellschools')
-                : '-',
-        ]),
+        CombatLogSpellEventType::SchoolRecorded => __(
+            $subjectShown ? 'view_compendium.event.school_recorded_no_subject' : 'view_compendium.event.school_recorded',
+            [
+                'spell'   => $spellName,
+                'schools' => e($event->spell
+                    ? Spell::maskToReadableString(Spell::ALL_SCHOOLS, $event->spell->schools_mask, 'spellschools')
+                    : '-'),
+            ]
+        ),
     };
 };
 
@@ -164,6 +187,7 @@ $eventSubjectHtml = static function (CombatLogNpcEvent|CombatLogSpellEvent $even
                 <?php /** @var CombatLogNpcEvent|CombatLogSpellEvent $event */ ?>
                 <?php $anchorId = $eventAnchorId($event); ?>
                 <?php $glyph = $eventGlyph($event); ?>
+                <?php $subjectHtml = $shouldShowSubject($event) ? $eventSubjectHtml($event) : ''; ?>
             <div @if($contextDungeon) id="{{ $anchorId }}" @endif class="compendium_log_row">
                 <span class="compendium_log_time">
                     @if($contextDungeon)
@@ -178,10 +202,10 @@ $eventSubjectHtml = static function (CombatLogNpcEvent|CombatLogSpellEvent $even
                     <i class="{{ $glyph['icon'] }}"></i>
                 </span>
                 <span class="compendium_log_text">
-                    @if($shouldShowSubject($event))
-                        <span class="me-1">{!! $eventSubjectHtml($event) !!}</span>
+                    @if($subjectHtml !== '')
+                        <span class="me-1">{!! $subjectHtml !!}</span>
                     @endif
-                    <span>{{ $eventDescription($event) }}</span>
+                    <span>{!! $eventDescription($event, $subjectHtml !== '') !!}</span>
                 </span>
             </div>
         @endforeach

--- a/resources/views/compendium/sections/event_list.blade.php
+++ b/resources/views/compendium/sections/event_list.blade.php
@@ -18,48 +18,40 @@ use Illuminate\Support\Carbon;
  * @var bool                                                   $showSpellSubject Whether to render the Spell icon+name before the description on Spell events
  * @var Dungeon|null                                           $contextDungeon   When set, the timestamp becomes a link to the activity day page
  * @var string|null                                            $date             Y-m-d date string, required when $contextDungeon is set
+ * @var int|null                                               $limit            Cap the rendered rows; the remainder collapses into an "and :count more" link to the day page
  */
 
 $showNpcSubject   ??= false;
 $showSpellSubject ??= false;
 $contextDungeon   ??= null;
 $date             ??= null;
+$limit            ??= null;
+
+$hiddenCount    = $limit !== null ? max(0, $events->count() - $limit) : 0;
+$displayedEvents = $hiddenCount > 0 ? $events->take($limit) : $events;
 
 $shouldShowSubject = (static fn(CombatLogNpcEvent|CombatLogSpellEvent $event): bool => $event instanceof CombatLogNpcEvent ? $showNpcSubject : $showSpellSubject);
 
-$eventTypeIcon = (static fn(CombatLogNpcEvent|CombatLogSpellEvent $event): string => $event instanceof CombatLogNpcEvent ? 'fas fa-dragon' : 'fas fa-magic');
-
-$eventBadgeClass = static function (CombatLogNpcEvent|CombatLogSpellEvent $event): string {
+/**
+ * One colored icon per event type carries the add/change/remove semantics in the log's icon
+ * column (the old badge-block + type-icon pair collapsed into a single glyph).
+ *
+ * @return array{icon: string, color: string}
+ */
+$eventGlyph = static function (CombatLogNpcEvent|CombatLogSpellEvent $event): array {
     if ($event instanceof CombatLogNpcEvent) {
         return match ($event->event_type) {
-            CombatLogNpcEventType::CharacteristicAdded => 'success',
-            CombatLogNpcEventType::CharacteristicRemoved => 'danger',
-            CombatLogNpcEventType::SpellAssigned => 'info',
+            CombatLogNpcEventType::CharacteristicAdded => ['icon' => 'fas fa-plus', 'color' => 'text-success'],
+            CombatLogNpcEventType::CharacteristicRemoved => ['icon' => 'fas fa-minus', 'color' => 'text-danger'],
+            CombatLogNpcEventType::SpellAssigned => ['icon' => 'fas fa-bolt', 'color' => 'text-info'],
         };
     }
 
     return match ($event->event_type) {
-        CombatLogSpellEventType::SpellCreated => 'info',
-        CombatLogSpellEventType::PropertyChanged => 'warning',
-        CombatLogSpellEventType::PropertyRemoved => 'danger',
-        CombatLogSpellEventType::SchoolRecorded => 'info',
-    };
-};
-
-$eventIcon = static function (CombatLogNpcEvent|CombatLogSpellEvent $event): string {
-    if ($event instanceof CombatLogNpcEvent) {
-        return match ($event->event_type) {
-            CombatLogNpcEventType::CharacteristicAdded => 'fas fa-plus',
-            CombatLogNpcEventType::CharacteristicRemoved => 'fas fa-minus',
-            CombatLogNpcEventType::SpellAssigned => 'fas fa-bolt',
-        };
-    }
-
-    return match ($event->event_type) {
-        CombatLogSpellEventType::SpellCreated => 'fas fa-plus',
-        CombatLogSpellEventType::PropertyChanged => 'fas fa-arrow-up',
-        CombatLogSpellEventType::PropertyRemoved => 'fas fa-times',
-        CombatLogSpellEventType::SchoolRecorded => 'fas fa-plus',
+        CombatLogSpellEventType::SpellCreated => ['icon' => 'fas fa-plus', 'color' => 'text-info'],
+        CombatLogSpellEventType::PropertyChanged => ['icon' => 'fas fa-arrow-up', 'color' => 'text-warning'],
+        CombatLogSpellEventType::PropertyRemoved => ['icon' => 'fas fa-times', 'color' => 'text-danger'],
+        CombatLogSpellEventType::SchoolRecorded => ['icon' => 'fas fa-plus', 'color' => 'text-info'],
     };
 };
 
@@ -154,45 +146,57 @@ $eventSubjectHtml = static function (CombatLogNpcEvent|CombatLogSpellEvent $even
 };
 ?>
 @isset($date)
-    <h4 id="day-{{ $date }}">
-        <a href="{{ route('compendium.activity.day', ['dungeon' => $contextDungeon, 'date' => $date]) }}">
-            {{ Carbon::parse($date)->format('F j, Y') }}
-        </a>
-    </h4>
+    <div class="compendium_log_day" id="day-{{ $date }}">
+        <h4 class="compendium_log_day_title">
+            <a href="{{ route('compendium.activity.day', ['dungeon' => $contextDungeon, 'date' => $date]) }}">
+                {{ Carbon::parse($date)->format('F j, Y') }}
+            </a>
+        </h4>
+        <span class="compendium_log_day_count">
+            {{ trans_choice('view_compendium.event.count', $events->count()) }}
+        </span>
+    </div>
 @endisset
 
 @if($events->isNotEmpty())
-    <ul class="list-unstyled mb-0">
-        @foreach($events as $event)
+    <div>
+        @foreach($displayedEvents as $event)
                 <?php /** @var CombatLogNpcEvent|CombatLogSpellEvent $event */ ?>
                 <?php $anchorId = $eventAnchorId($event); ?>
-            <li @if($contextDungeon) id="{{ $anchorId }}" @endif class="d-flex align-items-start mb-2">
-                <span class="text-muted me-1" style="min-width: 14px; text-align: center;">
-                    <i class="{{ $eventTypeIcon($event) }}" style="font-size: .75rem;"></i>
+                <?php $glyph = $eventGlyph($event); ?>
+            <div @if($contextDungeon) id="{{ $anchorId }}" @endif class="compendium_log_row">
+                <span class="compendium_log_time">
+                    @if($contextDungeon)
+                        <a href="{{ route('compendium.activity.day', ['dungeon' => $contextDungeon, 'date' => $date]) }}#{{ $anchorId }}">
+                            {{ $event->created_at->diffForHumans() }}
+                        </a>
+                    @else
+                        {{ $event->created_at->diffForHumans() }}
+                    @endif
                 </span>
-                <span class="badge text-bg-{{ $eventBadgeClass($event) }} me-2 mt-1" style="min-width: 20px;">
-                    <i class="{{ $eventIcon($event) }}"></i>
+                <span class="compendium_log_icon {{ $glyph['color'] }}">
+                    <i class="{{ $glyph['icon'] }}"></i>
                 </span>
-                <div>
+                <span class="compendium_log_text">
                     @if($shouldShowSubject($event))
                         <span class="me-1">{!! $eventSubjectHtml($event) !!}</span>
                     @endif
                     <span>{{ $eventDescription($event) }}</span>
-                    <small class="text-muted ms-1">
-                        -
-                        @if($contextDungeon)
-                            <a href="{{ route('compendium.activity.day', ['dungeon' => $contextDungeon, 'date' => $date]) }}#{{ $anchorId }}"
-                               class="text-muted">
-                                {{ $event->created_at->diffForHumans() }}
-                            </a>
-                        @else
-                            {{ $event->created_at->diffForHumans() }}
-                        @endif
-                    </small>
-                </div>
-            </li>
+                </span>
+            </div>
         @endforeach
-    </ul>
+        @if($hiddenCount > 0 && $contextDungeon !== null && $date !== null)
+            <div class="compendium_log_row">
+                <span class="compendium_log_time"></span>
+                <span class="compendium_log_icon text-muted"><i class="fas fa-ellipsis-h"></i></span>
+                <span class="compendium_log_text">
+                    <a href="{{ route('compendium.activity.day', ['dungeon' => $contextDungeon, 'date' => $date]) }}">
+                        {{ __('view_compendium.event.more', ['count' => $hiddenCount]) }}
+                    </a>
+                </span>
+            </div>
+        @endif
+    </div>
 @else
     <p class="text-muted">{{ __($emptyKey) }}</p>
 @endif

--- a/resources/views/compendium/sections/event_list.blade.php
+++ b/resources/views/compendium/sections/event_list.blade.php
@@ -77,6 +77,8 @@ $spellPropertyName = static function (SpellProperty $property): string {
 /**
  * Returns HTML: spell names inside descriptions render as links to their compendium page, so
  * every interpolated plain string is escaped here and the caller prints with {!! !!}.
+ * That means the translation lines themselves are part of the HTML trust boundary: lang files
+ * (en_US in-repo, other locales via the managed translation pipeline) render unescaped.
  * When the row already leads with the spell as its subject link ($subjectShown), the
  * description switches to the subject-less wording instead of repeating the spell name.
  */
@@ -209,14 +211,18 @@ $eventSubjectHtml = static function (CombatLogNpcEvent|CombatLogSpellEvent $even
                 </span>
             </div>
         @endforeach
-        @if($hiddenCount > 0 && $contextDungeon !== null && $date !== null)
+        @if($hiddenCount > 0)
             <div class="compendium_log_row">
                 <span class="compendium_log_time"></span>
                 <span class="compendium_log_icon text-muted"><i class="fas fa-ellipsis-h"></i></span>
                 <span class="compendium_log_text">
-                    <a href="{{ route('compendium.activity.day', ['dungeon' => $contextDungeon, 'date' => $date]) }}">
+                    @if($contextDungeon !== null && $date !== null)
+                        <a href="{{ route('compendium.activity.day', ['dungeon' => $contextDungeon, 'date' => $date]) }}">
+                            {{ __('view_compendium.event.more', ['count' => $hiddenCount]) }}
+                        </a>
+                    @else
                         {{ __('view_compendium.event.more', ['count' => $hiddenCount]) }}
-                    </a>
+                    @endif
                 </span>
             </div>
         @endif

--- a/resources/views/compendium/spell/index.blade.php
+++ b/resources/views/compendium/spell/index.blade.php
@@ -55,7 +55,7 @@ use App\Models\Npc\NpcClassification;
                         'render': function (data, type, row) {
                             return spellTemplate({
                                 compendium_url: `${spellShowBaseUrl}/${row.id}-${slugify(data ?? '')}`,
-                                spell_id: row.id,
+                                wowhead_tooltip_data: row.wowhead_tooltip_data,
                                 icon_url: row.icon_url,
                                 name: data ?? '',
                             });

--- a/resources/views/compendium/spell/index.blade.php
+++ b/resources/views/compendium/spell/index.blade.php
@@ -109,8 +109,8 @@ use App\Models\Npc\NpcClassification;
 @endsection
 
 @section('content')
-    <div class="row mb-3">
-        <div class="col-md-4">
+    <div class="compendium_toolbar">
+        <div class="compendium_toolbar_filter">
             @include('common.dungeon.select', [
                 'id'          => 'compendium_filter_dungeon',
                 'label'       => false,
@@ -122,13 +122,15 @@ use App\Models\Npc\NpcClassification;
         </div>
     </div>
 
-    <table id="compendium_spell_table" class="tablesorter default_table table-striped">
-        <thead>
-        <tr>
-            <th width="25%">{{ __('view_compendium.spell.index.table_header_name') }}</th>
-            <th width="25%">{{ __('view_compendium.spell.index.table_header_dungeons') }}</th>
-            <th width="50%">{{ __('view_compendium.spell.index.table_header_used_by') }}</th>
-        </tr>
-        </thead>
-    </table>
+    <div class="compendium_datatable">
+        <table id="compendium_spell_table" class="tablesorter default_table compendium_table">
+            <thead>
+            <tr>
+                <th width="25%">{{ __('view_compendium.spell.index.table_header_name') }}</th>
+                <th width="25%">{{ __('view_compendium.spell.index.table_header_dungeons') }}</th>
+                <th width="50%">{{ __('view_compendium.spell.index.table_header_used_by') }}</th>
+            </tr>
+            </thead>
+        </table>
+    </div>
 @endsection

--- a/resources/views/compendium/spell/index.blade.php
+++ b/resources/views/compendium/spell/index.blade.php
@@ -55,6 +55,7 @@ use App\Models\Npc\NpcClassification;
                         'render': function (data, type, row) {
                             return spellTemplate({
                                 compendium_url: `${spellShowBaseUrl}/${row.id}-${slugify(data ?? '')}`,
+                                spell_id: row.id,
                                 icon_url: row.icon_url,
                                 name: data ?? '',
                             });
@@ -95,6 +96,11 @@ use App\Models\Npc\NpcClassification;
                             window.location.href = `${spellShowBaseUrl}/${data.id}-${slugify(data.name)}`;
                         }
                     });
+                },
+                'drawCallback': function () {
+                    if (typeof $WowheadPower !== 'undefined') {
+                        $WowheadPower.refreshLinks();
+                    }
                 },
                 'language': $.extend({}, lang.messages[`${lang.locale}.datatables`], {
                     'emptyTable': lang.get('js.datatable_no_spells_in_table'),

--- a/resources/views/compendium/spell/sections/details.blade.php
+++ b/resources/views/compendium/spell/sections/details.blade.php
@@ -3,59 +3,66 @@
 use App\Models\Spell\Spell;
 
 /**
+ * The section title lives in the parent record section's label rail (see show.blade.php).
+ * Rendered as a key-value register instead of a one-row, eight-column table.
+ *
  * @var Spell $spell
  */
+
+$details = [
+    [
+        'label'   => __('view_compendium.spell.sections.details.header_schools'),
+        'tooltip' => __('view_compendium.spell.sections.details.header_schools_tooltip'),
+        'value'   => Spell::maskToReadableString(Spell::ALL_SCHOOLS, $spell->schools_mask, 'spellschools') ?: '-',
+    ],
+    [
+        'label'   => __('view_compendium.spell.sections.details.header_miss_types'),
+        'tooltip' => __('view_compendium.spell.sections.details.header_miss_types_tooltip'),
+        'value'   => Spell::maskToReadableString(Spell::ALL_MISS_TYPES, $spell->miss_types_mask, 'spellmisstypes') ?: '-',
+    ],
+    [
+        'label'   => __('view_compendium.spell.sections.details.header_counters'),
+        'tooltip' => __('view_compendium.spell.sections.details.header_counters_tooltip'),
+        'value'   => Spell::maskToReadableString(Spell::ALL_COUNTERS, $spell->counters_mask, 'spellcounters') ?: '-',
+    ],
+    [
+        'label'   => __('view_compendium.spell.sections.details.header_bypasses_immunities'),
+        'tooltip' => __('view_compendium.spell.sections.details.header_bypasses_immunities_tooltip'),
+        'value'   => Spell::maskToReadableString(Spell::ALL_IMMUNITIES, $spell->bypasses_immunities_mask, 'spellimmunities') ?: '-',
+    ],
+    [
+        'label'   => __('view_compendium.spell.sections.details.header_dispel_type'),
+        'tooltip' => __('view_compendium.spell.sections.details.header_dispel_type_tooltip'),
+        'value'   => $spell->dispel_type ? __($spell->dispel_type) : '-',
+    ],
+    [
+        'label'   => __('view_compendium.spell.sections.details.header_mechanic'),
+        'tooltip' => null,
+        'value'   => $spell->mechanic ? __($spell->mechanic) : '-',
+    ],
+    [
+        'label'   => __('view_compendium.spell.sections.details.header_cast_time'),
+        'tooltip' => null,
+        'value'   => $spell->cast_time > 0 ? ($spell->cast_time / 1000) . 's' : '-',
+    ],
+    [
+        'label'   => __('view_compendium.spell.sections.details.header_duration'),
+        'tooltip' => null,
+        'value'   => $spell->duration > 0 ? ($spell->duration / 1000) . 's' : '-',
+    ],
+];
 ?>
-<div class="row mb-4">
-    <div class="col">
-        <h4>{{ __('view_compendium.spell.sections.details.title') }}</h4>
-        <div class="table-responsive">
-            <table class="table table-sm mt-2">
-                <thead>
-                <tr>
-                    <th>
-                        {{ __('view_compendium.spell.sections.details.header_schools') }}
-                        <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                           title="{{ __('view_compendium.spell.sections.details.header_schools_tooltip') }}"></i>
-                    </th>
-                    <th>
-                        {{ __('view_compendium.spell.sections.details.header_miss_types') }}
-                        <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                           title="{{ __('view_compendium.spell.sections.details.header_miss_types_tooltip') }}"></i>
-                    </th>
-                    <th>
-                        {{ __('view_compendium.spell.sections.details.header_counters') }}
-                        <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                           title="{{ __('view_compendium.spell.sections.details.header_counters_tooltip') }}"></i>
-                    </th>
-                    <th>
-                        {{ __('view_compendium.spell.sections.details.header_bypasses_immunities') }}
-                        <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                           title="{{ __('view_compendium.spell.sections.details.header_bypasses_immunities_tooltip') }}"></i>
-                    </th>
-                    <th>
-                        {{ __('view_compendium.spell.sections.details.header_dispel_type') }}
-                        <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                           title="{{ __('view_compendium.spell.sections.details.header_dispel_type_tooltip') }}"></i>
-                    </th>
-                    <th>{{ __('view_compendium.spell.sections.details.header_mechanic') }}</th>
-                    <th>{{ __('view_compendium.spell.sections.details.header_cast_time') }}</th>
-                    <th>{{ __('view_compendium.spell.sections.details.header_duration') }}</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td>{{ Spell::maskToReadableString(Spell::ALL_SCHOOLS, $spell->schools_mask, 'spellschools') ?: '-' }}</td>
-                    <td>{{ Spell::maskToReadableString(Spell::ALL_MISS_TYPES, $spell->miss_types_mask, 'spellmisstypes') ?: '-' }}</td>
-                    <td>{{ Spell::maskToReadableString(Spell::ALL_COUNTERS, $spell->counters_mask, 'spellcounters') ?: '-' }}</td>
-                    <td>{{ Spell::maskToReadableString(Spell::ALL_IMMUNITIES, $spell->bypasses_immunities_mask, 'spellimmunities') ?: '-' }}</td>
-                    <td>{{ $spell->dispel_type ? __($spell->dispel_type) : '-' }}</td>
-                    <td>{{ $spell->mechanic ? __($spell->mechanic) : '-' }}</td>
-                    <td>{{ $spell->cast_time > 0 ? ($spell->cast_time / 1000) . 's' : '-' }}</td>
-                    <td>{{ $spell->duration > 0 ? ($spell->duration / 1000) . 's' : '-' }}</td>
-                </tr>
-                </tbody>
-            </table>
+<dl class="compendium_kv">
+    @foreach($details as $detail)
+        <div class="compendium_kv_item">
+            <dt>
+                {{ $detail['label'] }}
+                @if($detail['tooltip'])
+                    <i class="fas fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top"
+                       title="{{ $detail['tooltip'] }}"></i>
+                @endif
+            </dt>
+            <dd>{{ $detail['value'] }}</dd>
         </div>
-    </div>
-</div>
+    @endforeach
+</dl>

--- a/resources/views/compendium/spell/sections/dungeons.blade.php
+++ b/resources/views/compendium/spell/sections/dungeons.blade.php
@@ -2,35 +2,21 @@
 
 use App\Models\Dungeon;
 use App\Models\Spell\Spell;
-use Illuminate\Support\Collection;
 
 /**
- * @var Spell                    $spell
- * @var Collection<int, Dungeon> $spell ->dungeons
+ * The section title lives in the parent record section's label rail (see show.blade.php).
+ * A one-column table earned nothing; the dungeons render as a chip list.
+ *
+ * @var Spell $spell
  */
 ?>
-<div class="row mb-4">
-    <div class="col">
-        <h4>{{ __('view_compendium.spell.sections.dungeons.title') }}</h4>
-        @if($spell->dungeons->isNotEmpty())
-            <div class="table-responsive">
-                <table class="table table-sm mt-2">
-                    <thead>
-                    <tr>
-                        <th>{{ __('view_compendium.spell.sections.dungeons.header_name') }}</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    @foreach($spell->dungeons as $dungeon)
-                        <tr>
-                            <td>{{ __($dungeon->name) }}</td>
-                        </tr>
-                    @endforeach
-                    </tbody>
-                </table>
-            </div>
-        @else
-            <p class="text-muted">{{ __('view_compendium.spell.sections.dungeons.empty') }}</p>
-        @endif
+@if($spell->dungeons->isNotEmpty())
+    <div class="compendium_identity_meta">
+        @foreach($spell->dungeons as $dungeon)
+            <?php /** @var Dungeon $dungeon */ ?>
+            <span class="compendium_chip">{{ __($dungeon->name) }}</span>
+        @endforeach
     </div>
-</div>
+@else
+    <p class="text-muted mb-0">{{ __('view_compendium.spell.sections.dungeons.empty') }}</p>
+@endif

--- a/resources/views/compendium/spell/sections/event_feed.blade.php
+++ b/resources/views/compendium/spell/sections/event_feed.blade.php
@@ -5,16 +5,13 @@ use App\Models\CombatLog\CombatLogSpellEvent;
 use Illuminate\Support\Collection;
 
 /**
+ * The section title lives in the parent record section's label rail (see show.blade.php).
+ *
  * @var Collection<int, CombatLogNpcEvent|CombatLogSpellEvent> $eventFeed
  */
 ?>
-<div class="row mb-4">
-    <div class="col">
-        <h4>{{ __('view_compendium.spell.sections.event_feed.title') }}</h4>
-        @include('compendium.sections.event_list', [
-            'events'         => $eventFeed,
-            'emptyKey'       => 'view_compendium.spell.sections.event_feed.empty',
-            'showNpcSubject' => true,
-        ])
-    </div>
-</div>
+@include('compendium.sections.event_list', [
+    'events'         => $eventFeed,
+    'emptyKey'       => 'view_compendium.spell.sections.event_feed.empty',
+    'showNpcSubject' => true,
+])

--- a/resources/views/compendium/spell/sections/header.blade.php
+++ b/resources/views/compendium/spell/sections/header.blade.php
@@ -6,48 +6,46 @@ use App\Models\Spell\Spell;
  * @var Spell $spell
  */
 ?>
-<div class="row mb-4">
-    <div class="col-auto">
-        <img src="{{ $spell->icon_url }}"
-             width="64" height="64"
-             alt="{{ __($spell->name) }}"
-             loading="lazy"
-             class="rounded"/>
-    </div>
-    <div class="col">
-        <h2 class="mb-1">{{ __($spell->name) }}</h2>
-        <div>
-            @if($spell->schools_mask > 0)
-                <span class="badge text-bg-secondary me-1">
-                    {{ Spell::maskToReadableString(Spell::ALL_SCHOOLS, $spell->schools_mask, 'spellschools') }}
-                </span>
-            @endif
-            @if($spell->dispel_type)
-                <span class="badge text-bg-secondary me-1">
-                    {{ __($spell->dispel_type) }}
-                </span>
-            @endif
-            @if($spell->mechanic)
-                <span class="badge text-bg-secondary me-1">
-                    {{ __($spell->mechanic) }}
-                </span>
-            @endif
+<div class="compendium_identity">
+    <img src="{{ $spell->icon_url }}"
+         width="88" height="88"
+         alt="{{ __($spell->name) }}"
+         loading="lazy"
+         class="compendium_identity_portrait"/>
+    <div class="compendium_identity_body">
+        <h2 class="compendium_identity_title">{{ __($spell->name) }}</h2>
+        <div class="compendium_identity_meta">
             @if($spell->aura)
-                <span class="badge text-bg-info me-1">
+                <span class="badge text-bg-info">
                     {{ __('view_compendium.spell.sections.header.aura') }}
                 </span>
             @endif
             @if($spell->debuff)
-                <span class="badge text-bg-danger me-1">
+                <span class="badge text-bg-danger">
                     {{ __('view_compendium.spell.sections.header.debuff') }}
                 </span>
             @endif
+            @if($spell->schools_mask > 0)
+                <span class="compendium_chip">
+                    {{ Spell::maskToReadableString(Spell::ALL_SCHOOLS, $spell->schools_mask, 'spellschools') }}
+                </span>
+            @endif
+            @if($spell->dispel_type)
+                <span class="compendium_chip">
+                    {{ __($spell->dispel_type) }}
+                </span>
+            @endif
+            @if($spell->mechanic)
+                <span class="compendium_chip">
+                    {{ __($spell->mechanic) }}
+                </span>
+            @endif
         </div>
-        <div class="mt-2">
-            <a href="{{ $spell->wowhead_url }}" target="_blank" rel="noopener" class="btn btn-sm btn-secondary" data-wh-icon-size="small">
-                {{ __('view_compendium.spell.show.wowhead') }}
-                <i class="fas fa-external-link-alt ms-1"></i>
-            </a>
-        </div>
+    </div>
+    <div class="compendium_identity_actions">
+        <a href="{{ $spell->wowhead_url }}" target="_blank" rel="noopener" class="btn btn-sm btn-secondary" data-wh-icon-size="small">
+            {{ __('view_compendium.spell.show.wowhead') }}
+            <i class="fas fa-external-link-alt ms-1"></i>
+        </a>
     </div>
 </div>

--- a/resources/views/compendium/spell/sections/npcs.blade.php
+++ b/resources/views/compendium/spell/sections/npcs.blade.php
@@ -5,34 +5,31 @@ use App\Models\Spell\Spell;
 use Illuminate\Support\Collection;
 
 /**
+ * The section title lives in the parent record section's label rail (see show.blade.php).
+ *
  * @var Spell                $spell
  * @var Collection<int, Npc> $npcs
  */
 ?>
-<div class="row mb-4">
-    <div class="col">
-        <h4>{{ __('view_compendium.spell.sections.npcs.title') }}</h4>
-        @if($npcs->isNotEmpty())
-            <div class="table-responsive">
-                <table class="table table-sm mt-2">
-                    <thead>
-                    <tr>
-                        <th>{{ __('view_compendium.spell.sections.npcs.header_name') }}</th>
-                        <th>{{ __('view_compendium.spell.sections.npcs.header_dungeons') }}</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    @foreach($npcs as $npc)
-                        <tr>
-                            <td>@include('common.npc.link', ['npc' => $npc])</td>
-                            <td>{{ $npc->dungeons->map(fn($d) => __($d->name))->join(', ') ?: '-' }}</td>
-                        </tr>
-                    @endforeach
-                    </tbody>
-                </table>
-            </div>
-        @else
-            <p class="text-muted">{{ __('view_compendium.spell.sections.npcs.empty') }}</p>
-        @endif
+@if($npcs->isNotEmpty())
+    <div class="table-responsive">
+        <table class="compendium_table">
+            <thead>
+            <tr>
+                <th>{{ __('view_compendium.spell.sections.npcs.header_name') }}</th>
+                <th>{{ __('view_compendium.spell.sections.npcs.header_dungeons') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach($npcs as $npc)
+                <tr>
+                    <td class="text-nowrap">@include('common.npc.link', ['npc' => $npc])</td>
+                    <td>{{ $npc->dungeons->map(fn($d) => __($d->name))->join(', ') ?: '-' }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
     </div>
-</div>
+@else
+    <p class="text-muted mb-0">{{ __('view_compendium.spell.sections.npcs.empty') }}</p>
+@endif

--- a/resources/views/compendium/spell/show.blade.php
+++ b/resources/views/compendium/spell/show.blade.php
@@ -33,11 +33,39 @@ use Illuminate\Support\Collection;
 @section('content')
     @include('compendium.spell.sections.header')
 
-    @include('compendium.spell.sections.details')
+    <div class="compendium_record_section">
+        <div class="compendium_record_label">
+            {{ __('view_compendium.spell.sections.details.title') }}
+        </div>
+        <div>
+            @include('compendium.spell.sections.details')
+        </div>
+    </div>
 
-    @include('compendium.spell.sections.dungeons')
+    <div class="compendium_record_section">
+        <div class="compendium_record_label">
+            {{ __('view_compendium.spell.sections.dungeons.title') }}
+        </div>
+        <div>
+            @include('compendium.spell.sections.dungeons')
+        </div>
+    </div>
 
-    @include('compendium.spell.sections.npcs')
+    <div class="compendium_record_section">
+        <div class="compendium_record_label">
+            {{ __('view_compendium.spell.sections.npcs.title') }}
+        </div>
+        <div>
+            @include('compendium.spell.sections.npcs')
+        </div>
+    </div>
 
-    @include('compendium.spell.sections.event_feed')
+    <div class="compendium_record_section">
+        <div class="compendium_record_label">
+            {{ __('view_compendium.spell.sections.event_feed.title') }}
+        </div>
+        <div>
+            @include('compendium.spell.sections.event_feed')
+        </div>
+    </div>
 @endsection

--- a/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
+++ b/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
@@ -3,9 +3,19 @@
 namespace Tests\Feature\Controller\Compendium;
 
 use App\Features\NpcCompendium;
+use App\Models\Characteristic;
+use App\Models\CombatLog\CombatLogNpcEvent;
+use App\Models\CombatLog\CombatLogNpcEventType;
+use App\Models\CombatLog\CombatLogSpellEvent;
+use App\Models\CombatLog\CombatLogSpellEventType;
+use App\Models\CombatLog\SpellProperty;
 use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
+use App\Models\Npc\NpcSpell;
+use App\Models\Spell\Spell;
 use App\Models\User;
 use App\Service\Season\SeasonServiceInterface;
+use Illuminate\Support\Facades\DB;
 use Laravel\Pennant\Feature;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -15,6 +25,8 @@ use Tests\TestCases\PublicTestCase;
 #[Group('Compendium')]
 final class NpcCompendiumControllerActivityTest extends PublicTestCase
 {
+    private const int TEST_SPELL_ID = 9995098;
+
     private Dungeon $dungeon;
 
     #[\Override]
@@ -24,6 +36,11 @@ final class NpcCompendiumControllerActivityTest extends PublicTestCase
 
         $this->actingAs(User::findOrFail(1));
         Feature::define(NpcCompendium::class, true);
+
+        // Clean up sentinel rows a previously aborted run may have left behind
+        CombatLogSpellEvent::query()->where('spell_id', self::TEST_SPELL_ID)->delete();
+        NpcSpell::query()->where('spell_id', self::TEST_SPELL_ID)->delete();
+        Spell::query()->where('id', self::TEST_SPELL_ID)->delete();
 
         // Must be a dungeon of the CURRENT season - that is what the controller scopes to, and it
         // redirects away from anything else. Taking the highest season id instead breaks as soon as an
@@ -86,6 +103,102 @@ final class NpcCompendiumControllerActivityTest extends PublicTestCase
 
         // Assert
         $response->assertOk();
+    }
+
+    #[Test]
+    public function activity_givenMoreEventsThanTheDayLimit_rendersCollapsedMoreLink(): void
+    {
+        // Arrange - 17 events on one day; the activity index caps each day at 15 rows. The index
+        // paginates dates newest-first, so the date must sort ahead of any other data (local dev
+        // DBs can hold demo events on recent dates) or the day under test never renders on page 1.
+        $uniqueDate       = '2027-01-01';
+        $npcId            = DB::table('npc_dungeons')->where('dungeon_id', $this->dungeon->id)->value('npc_id');
+        $characteristicId = Characteristic::query()->orderBy('id')->value('id');
+
+        // A previously aborted run's leftovers on this date would skew the overflow count
+        CombatLogNpcEvent::query()->where('npc_id', $npcId)->whereDate('created_at', $uniqueDate)->delete();
+
+        $eventIds = [];
+        for ($i = 0; $i < 17; $i++) {
+            // insert(), not create(): created_at is not fillable so create() silently drops it
+            $eventIds[] = CombatLogNpcEvent::query()->insertGetId([
+                'npc_id'      => $npcId,
+                'event_type'  => CombatLogNpcEventType::CharacteristicAdded->value,
+                'model_class' => Characteristic::class,
+                'model_id'    => $characteristicId,
+                'created_at'  => $uniqueDate . ' 12:00:00',
+            ]);
+        }
+
+        try {
+            // Act
+            $response = $this->get(route('compendium.activity', $this->dungeon));
+
+            // Assert - the two overflow rows collapse into a link to the day page
+            $response->assertOk();
+            $response->assertSee(__('view_compendium.event.more', ['count' => 2]));
+            $response->assertSee(route('compendium.activity.day', ['dungeon' => $this->dungeon, 'date' => $uniqueDate]));
+        } finally {
+            CombatLogNpcEvent::query()->whereIn('id', $eventIds)->delete();
+        }
+    }
+
+    #[Test]
+    public function activityDay_givenSpellEventWithSubjectShown_rendersSpellLinkAndNoSubjectDescription(): void
+    {
+        // Arrange - a classic-era spell assigned to a dungeon NPC, with a counter event on a unique day
+        $uniqueDate = '2025-06-16';
+        $npcId      = DB::table('npc_dungeons')->where('dungeon_id', $this->dungeon->id)->value('npc_id');
+
+        $spell = Spell::create([
+            'id'              => self::TEST_SPELL_ID,
+            'game_version_id' => GameVersion::ALL[GameVersion::GAME_VERSION_CLASSIC_ERA],
+            'dispel_type'     => '',
+            'mechanic'        => '',
+            'icon_name'       => '',
+            'name'            => 'TestActivityDaySpell',
+            'schools_mask'    => 1,
+            'miss_types_mask' => 0,
+            'aura'            => false,
+            'debuff'          => false,
+            'cast_time'       => 0,
+            'duration'        => 0,
+            'selectable'      => false,
+            'hidden_on_map'   => false,
+            'fetched_data_at' => now(),
+        ]);
+        NpcSpell::create(['npc_id' => $npcId, 'spell_id' => self::TEST_SPELL_ID]);
+
+        // insert(), not create(): created_at is not fillable so create() silently drops it
+        $eventId = CombatLogSpellEvent::query()->insertGetId([
+            'spell_id'   => self::TEST_SPELL_ID,
+            'event_type' => CombatLogSpellEventType::PropertyChanged->value,
+            'property'   => SpellProperty::CounterVanish->value,
+            'created_at' => $uniqueDate . ' 12:00:00',
+        ]);
+
+        try {
+            // Act
+            $response = $this->get(route('compendium.activity.day', ['dungeon' => $this->dungeon, 'date' => $uniqueDate]));
+
+            // Assert - the spell renders as the subject link (with game-version-aware Wowhead tooltip
+            // data) and the description switches to the subject-less wording
+            $response->assertOk();
+            $response->assertSee(route('spell.compendium.show', $spell));
+            $response->assertSee('data-wowhead="spell=' . self::TEST_SPELL_ID . '&amp;domain=classic"', false);
+            $response->assertSee(__('view_compendium.event.counter_added_no_subject', [
+                'spell'    => 'TestActivityDaySpell',
+                'property' => __('spellcounters.vanish'),
+            ]));
+            $response->assertDontSee(__('view_compendium.event.counter_added', [
+                'spell'    => 'TestActivityDaySpell',
+                'property' => __('spellcounters.vanish'),
+            ]));
+        } finally {
+            CombatLogSpellEvent::query()->where('id', $eventId)->delete();
+            NpcSpell::query()->where('spell_id', self::TEST_SPELL_ID)->delete();
+            Spell::query()->where('id', self::TEST_SPELL_ID)->delete();
+        }
     }
 
     #[Test]


### PR DESCRIPTION
Closes #3945

:robot: Redesigns all `/compendium` pages within the site's incumbent visual system ("The War Room", per the new `DESIGN.md`). Every page now reads as one continuous **field record**: an identity band on top, then labeled register sections (label rail left, content right) separated by hairline rules, everything on the theme-variable tonal ladder — no hardcoded theme hexes, so darkly, lux and vapor all hold from one rule set. Content is factually unchanged; two lang keys were added (`event.count`, `event.more`, plus characteristics `empty`/`not_observed` labels).

Highlights:
- Landing: icon-card grid → **directory register** (icon plate / title+count / description / go), data-source panel, "how it works" register rows.
- NPC/spell detail: identity band with portrait + classification badges + stat chips; characteristics as **labeled chips** with a muted "not observed" strip; spell details table (1 row × 8 columns) → **key-value data plate**; event feeds → aligned **log rows** with a fixed time column and one colored glyph per event type.
- Indexes: DataTables restyled into the register language (Dungeon Black header row, hairline dividers); class picker tiles restyled on the ladder.
- Activity: day headers with event counts; the index caps each day at 15 rows with an "and :count more" link to the day page (day page still shows everything).

Local verification used fabricated combat-log-derived demo data (the isolated worktree DB has none); the seed script is kept out of the diff. Note: `spells/ability_mage_invisibility.jpg` is missing from the asset set (pre-existing, visible on class pages as a broken icon) — not addressed here.

| | Before | After |
|---|---|---|
| Landing | ![before](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3945-before-index.png) | ![after](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3945-after-index.png) |
| NPC record | ![before](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3945-before-npc-show.png) | ![after](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3945-after-npc-show.png) |
| Spell record | ![before](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3945-before-spell-show.png) | ![after](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3945-after-spell-show.png) |

Activity index (after): ![activity](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3945-after-activity.png)

Theme sanity — lux: ![lux](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3945-after-npc-show-lux.png) · vapor: ![vapor](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3945-after-npc-show-vapor.png) · mobile: ![mobile](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3945-after-npc-show-mobile.png)

Status: design-iteration draft — Wotuu is reviewing the direction first; cold review + full checklist follow once the direction is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111gac1BcpqYNzAMjvvqFA6