### PR TITLE
#3949 Fix InfluxDB port and php-cs-fixer traversal breaking fresh setups

### DIFF
--- a/.claude/skills/new-machine-setup/SKILL.md
+++ b/.claude/skills/new-machine-setup/SKILL.md
@@ -153,6 +153,21 @@ git clone git@github.com:RaiderIO/keystone.guru.assets.git   # ~342M tracked (im
 `sh/worktree.sh` also expects `~/Git/private/keystone.guru-worktrees/` as its worktree root; it
 creates that itself on first use.
 
+**Check `~/Git` and `~/Git/private` are owned by you, not root.** If an earlier attempt cloned the
+repo under `sudo`, the parent dirs end up `root:root` while `keystone.guru` itself looks correctly
+owned — so nothing is obviously wrong until the second clone fails with
+`could not create work tree dir 'keystone.guru.assets': Permission denied`. That failure is easy to
+miss because it is routinely piped (`git clone … | tail`), and a pipe reports the *tail* exit code,
+so the clone reads as success. Worse, the missing sibling does not stay missing: the Docker daemon
+runs as root and will happily create `../keystone.guru.assets` as a root-owned empty dir for the
+bind mount, which is exactly the silent-broken-images failure above. Fix ownership before cloning:
+
+```bash
+sudo chown -R "$(id -u):$(id -g)" ~/Git
+# no sudo available? the daemon runs as root, so borrow it:
+docker run --rm -v ~/Git:/git alpine chown -R "$(id -u):$(id -g)" /git
+```
+
 The clone above only brings `images/` and `webfonts/`. The checkout also has a `tiles/` directory
 (~36G, gitignored per `keystone.guru.assets/.gitignore:1`) that is **not** part of the git history —
 map tiles have to be transferred separately (rsync/external drive/etc. from the old machine). See
@@ -309,10 +324,18 @@ nvm use && npm ci && npm run production
 `npm run production` can be memory-hungry; if WSL OOMs, `npm run development` produces a working
 (unminified) build and is fine for dev.
 
+**`npm ci` dies in puppeteer's postinstall if the host has no `unzip`** — the error is
+`Failed to set up chrome-headless-shell … no zip archiver is available`, which reads like a
+puppeteer/network problem rather than the missing phase-1 package it is. Install `unzip` (phase 1)
+and re-run. To unblock without sudo, `PUPPETEER_SKIP_DOWNLOAD=1 npm ci` installs everything else —
+asset builds do not need puppeteer's browser, and the in-container thumbnail path uses the worker
+image's own Chrome. Run `npx puppeteer browsers install` once `unzip` is available.
+
 **Probe:**
 ```bash
 [ -s version ] && echo "version: $(cat version)"
-ls public/js/app.js public/css/app.css        # both exist
+# Assets are version-suffixed from the git rev — there is no unsuffixed app.js/app.css
+ls public/js/app-$(cat version).js public/css/app-$(cat version).css
 docker compose exec -T app php artisan --version
 ```
 
@@ -387,7 +410,7 @@ provision, and tests run against this seeded data (see the `writing-tests` skill
 
 **Probe:**
 ```bash
-docker compose exec -T app php artisan tinker --execute 'echo User::count()." users, ".Dungeon::count()." dungeons";'
+docker compose exec -T app php artisan tinker --execute 'echo \App\Models\User::count()." users, ".\App\Models\Dungeon::count()." dungeons";'
 ```
 Expect 3 users and a few hundred dungeons. Zero dungeons = the seed did not finish.
 
@@ -416,9 +439,25 @@ MySQL 34006 / 34007.
 Do not report the machine as ready until all six pass. Fix failures here rather than noting them.
 
 1. **Site renders**: `curl -s http://localhost:8008 | grep -q "Keystone.guru"`.
-2. **A map renders**: use the `headless-browser-verify` skill against a dungeon explore page and
-   look at the screenshot with `Read`. Tiles must be visible (they come from the CDN), enemies must
-   be plotted. A blank grey map means `ASSETS_BASE_URL` is wrong.
+2. **A map renders**: use the `headless-browser-verify` skill against a dungeon explore page (e.g.
+   `/explore/retail/court-of-stars`) and look at the screenshot with `Read`. Tiles must be visible
+   (they come from the CDN), enemies must be plotted. A blank grey map means `ASSETS_BASE_URL` is
+   wrong.
+
+   That skill's `chrome` service is defined in `docker-compose.worktree.yml`, which the **main**
+   checkout's `docker compose` does not load — `--profile chrome up -d chrome` there fails with
+   "no such service". Run it standalone on the stack network instead (with
+   `ASSETS_BASE_URL` on the CDN the socat asset forward is unnecessary):
+
+   ```bash
+   docker run -d --name ksg-chrome --network keystoneguru_keystone.guru \
+       --network-alias chrome --shm-size 1gb chromedp/headless-shell:latest
+   ```
+
+   Expect ~10 `Unable to find enemy patrol <id> that is coupled to enemy <id>` console errors on
+   some dungeons. Those are stale cross-mapping-version references in the tracked seeder data
+   (~53 of 7319 patrol-carrying enemies; zero patrols missing outright), not a bad seed — the map
+   still plots every enemy. Do not chase them.
 3. **Login works**: `admin@app.com` / `password`.
 4. **Tests are green**:
    ```bash
@@ -483,6 +522,8 @@ laptop are deliberately not carried over.
 | `error getting credentials` on pull/build | `~/.docker/config.json` has `"credsStore": "wincred.exe"`, which flakes over WSL interop | Back up `config.json`, delete the `credsStore` key, pull/build, restore |
 | `docker compose up` panics in `monitor.Start` | Rancher-bundled compose 5.0.1 | Install compose ≥ 5.1.0 into `~/.docker/cli-plugins/` and remove `cliPluginsExtraDirs` from `~/.docker/config.json` (Rancher rewrites it on update — re-remove) |
 | `sudo: you do not exist in the passwd database`; MDT tests all fail | Image built with wrong `PUID`/`PGID`, so no matching `ksg` user | Fix `.env`, `docker compose build app`, `docker compose up -d --force-recreate` |
+| Every `Scheduler` test fails with `cURL error 7: Failed to connect to influxdb port <n>` | `INFLUXDB_PORT` is not the container-internal `8086`. `docker-compose.yml` publishes influx on the host as **8096**, but `INFLUXDB_HOST=influxdb` is the service name, so the internal port is what counts | Set `INFLUXDB_PORT=8086`. (`.env.docker.example` shipped `3000` until this was fixed — an old `.env` restored from a bundle may be *more* correct than the example) |
+| `composer run fix` aborts: `RecursiveDirectoryIterator(...#innodb_temp): Permission denied` | php-cs-fixer descended into the bind-mounted MySQL data dirs under `docker-compose/`, whose internals are owned by the container's mysql uid | `docker-compose` must be in the finder's `exclude()` in `.php-cs-fixer.php`. Note `ignoreVCSIgnored(true)` does **not** help — Finder filters results only after traversal has already failed |
 | Every page 504s; `git status` shows root-owned files | Something ran as root and wrote root-owned files into the bind mount; php-fpm then loops on logging exceptions | `sudo chown -R $(id -u):$(id -g) storage/logs storage/framework` and check `PUID`/`PGID` |
 | `Unable to locate file in Vite manifest` / stale JS in browser | Assets not built, or `version` stale | `npm run production` (writes `version` from the git rev) |
 | PHPStan red locally, green in CI | Local `vendor/` drifted from `composer.lock` | `docker compose exec -T app composer install` |

--- a/.claude/skills/new-machine-setup/SKILL.md
+++ b/.claude/skills/new-machine-setup/SKILL.md
@@ -450,9 +450,15 @@ Do not report the machine as ready until all six pass. Fix failures here rather 
    `ASSETS_BASE_URL` on the CDN the socat asset forward is unnecessary):
 
    ```bash
-   docker run -d --name ksg-chrome --network keystoneguru_keystone.guru \
+   # The network is named <compose project>_<network>; derive it rather than hardcoding it.
+   NET=$(docker network ls --format '{{.Name}}' | grep keystone)
+   docker rm -f ksg-chrome 2>/dev/null   # idempotent: re-running would hit a name conflict
+   docker run -d --rm --name ksg-chrome --network "$NET" \
        --network-alias chrome --shm-size 1gb chromedp/headless-shell:latest
    ```
+
+   Tear it down with `docker rm -f ksg-chrome` when the probe is done. It is not part of the compose
+   stack, so `docker compose down` leaves it running.
 
    Expect ~10 `Unable to find enemy patrol <id> that is coupled to enemy <id>` console errors on
    some dungeons. Those are stale cross-mapping-version references in the tracked seeder data

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -66,7 +66,9 @@ ASSETS_BASE_URL_INTERNAL=http://app-assets
 TELESCOPE_ENABLED=false
 
 INFLUXDB_HOST=influxdb
-INFLUXDB_PORT=3000
+# Container-internal port. docker-compose.yml publishes it on the host as 8096 to avoid a
+# conflict, but INFLUXDB_HOST is the service name, so this must stay the internal 8086.
+INFLUXDB_PORT=8086
 INFLUXDB_DBNAME=local
 INFLUXDB_USER=admin
 INFLUXDB_PASSWORD=admin123

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -4,8 +4,13 @@ use ErickSkrauch\PhpCsFixer\Fixers as ErickSkrauchFixers;
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
-    // It legit breaks views if you let it try to fix them - it removes needed imports
-    ->exclude(['vendor', 'node_modules', 'storage', 'bootstrap/cache', 'resources/views'])
+    // It legit breaks views if you let it try to fix them - it removes needed imports.
+    // docker-compose holds no PHP, but it does hold the bind-mounted MySQL data dirs, whose
+    // internal dirs (e.g. mysql-combatlog/#innodb_temp) are owned by the container's mysql uid
+    // and unreadable on the host - descending into them aborts the entire run with
+    // "RecursiveDirectoryIterator(...): Permission denied". Excluding is what stops the descent:
+    // ignoreVCS()/ignoreVCSIgnored() only filter results, after the traversal has already failed.
+    ->exclude(['vendor', 'node_modules', 'storage', 'bootstrap/cache', 'resources/views', 'docker-compose'])
     ->name('*.php')
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);


### PR DESCRIPTION
:robot: Closes #3949

Two defects in tracked files, found while bringing up a development machine from a clean state.
Both are invisible on an already-working machine — a pre-existing `.env` and a warm toolchain mask
them — and both bite anyone setting up from scratch.

## 1. `.env.docker.example` had the wrong InfluxDB port

`INFLUXDB_PORT=3000` -> `8086`.

The container listens on **8086** internally; `docker-compose.yml:376` publishes it on the host as
`8096` to avoid a conflict. `INFLUXDB_HOST=influxdb` is the compose service name, so the value must
be the *internal* port — neither the published `8096` nor `3000` (which looks like a Grafana port
that crept in).

Every `SchedulerCommand` subclass writes a metric via `SavesToInfluxDB`, so the wrong port took out
the whole `Tests\Feature\Console\Commands\Scheduler` tree — **15 failures**, all
`cURL error 7: Failed to connect to influxdb port 3000`.

A `.env` restored from an old backup has `8086` and is therefore *more* correct than the example it
is supposed to be derived from, which is why this stayed hidden.

## 2. `composer run fix` was broken outright

The finder in `.php-cs-fixer.php` scanned `__DIR__` while excluding only `vendor`, `node_modules`,
`storage`, `bootstrap/cache`, `resources/views` — so it descended into `docker-compose/`, which
holds the bind-mounted MySQL data dirs. Directories MySQL creates there (e.g.
`mysql-combatlog/#innodb_temp`) are owned by the container's mysql uid with mode `0750`, so the
traversal aborted the entire run:

```
RecursiveDirectoryIterator::__construct(/var/www/docker-compose/mysql-combatlog/#innodb_temp):
Failed to open directory: Permission denied
Script php-cs-fixer fix handling the fix event returned with error code 1
```

`.claude/CLAUDE.md` requires `composer run fix` after every task, so on a fresh machine that step
could not be performed at all.

**Worth knowing:** the intuitive fix, `->ignoreVCSIgnored(true)`, does **not** work — even though
the data dirs *are* gitignored (`.gitignore:41-45`). Symfony Finder applies it as a filter over
*results*, after `RecursiveDirectoryIterator` has already tried to descend, so it still throws. Only
`exclude()` prevents the descent. I tried `ignoreVCSIgnored` first and it failed; the comment in the
diff records that so the next person does not repeat it.

Excluding the whole directory is safe — there is no PHP under it:
`git ls-files -- docker-compose | grep -c '\.php$'` -> `0`.

## 3. `new-machine-setup` skill corrections

The skill asks to be corrected in-session when reality disagrees. Folded in both fixes above as
troubleshooting rows, plus probes that could not pass as written:

| Correction | Why it mattered |
|---|---|
| Assets are version-suffixed (`app-<sha>.js`), not `app.js` | Phase 6 probe could never pass |
| `\App\Models\Dungeon`, not `Dungeon` | Phase 7 tinker probe errored `Class "Dungeon" not found` |
| `chrome` service lives in `docker-compose.worktree.yml` | Not loaded by the main checkout, so `--profile chrome` fails there |
| `npm ci` needs host `unzip` | Puppeteer postinstall failure reads like a network problem |
| Root-owned `~/Git` breaks the assets clone | Piped clones (`\| tail`) hide the failure; Docker then creates a root-owned empty dir — the silently-broken-images trap the skill already warns about |
| `Unable to find enemy patrol` console errors are benign | Stale cross-mapping-version refs in tracked seeder data (53 of 7319); not a bad seed |

## Verification

Run in this worktree:

- `composer run fix` -> `Fixed 0 of 3886 files` (i.e. the repo had no drift; the tool simply could
  never get far enough to say so)
- `composer run analyse` -> `[OK] No errors`
- `php artisan test --filter=Scheduler` -> 19 passed, 1 skipped (was 15 failures)
- Full suite on the repaired machine -> **1968 passed**, 1 failed

The single remaining failure is `Tests\Unit\MapTiles\MapTilesExistenceTest`, the documented
known-good one: it asserts `keystone.guru.assets/tiles/` (~36G, gitignored, in no repo) exists on
disk. Unrelated to this change.

## Note on tests

No new automated test accompanies this. Both changes are to build/config files that the suite does
not load — `.env.docker.example` is a template consumed only by humans setting up a machine, and
`.php-cs-fixer.php` configures the formatter itself. The fixes are verified by running the actual
tools, as above. Happy to add a guard test if you would prefer one.