### PR TITLE
#3935 Anchor Awakened Obelisk rift-skip enemy lookup to the icon's floor, not enemy_pack_id

### DIFF
--- a/app/Service/MDT/Import/RiftOffsetImporter.php
+++ b/app/Service/MDT/Import/RiftOffsetImporter.php
@@ -77,12 +77,16 @@ class RiftOffsetImporter
             $obeliskMapIcon = $npcIdToMapIconMapping[$npcId];
 
             try {
-                // Find out the floor where the NPC is standing on
+                // Find out the floor where the NPC is standing on. Anchored to the obelisk map
+                // icon's own floor rather than filtered by enemy_pack_id: some dungeons only carry
+                // an unpacked Enemy row for this NPC on their current mapping version (packed rows
+                // exist only on older ones - #3935), and the same npc_id can additionally be placed
+                // on multiple floors of the same dungeon, so the obelisk icon's floor is the only
+                // reliable disambiguator between those duplicates.
                 /** @var Enemy $enemy */
                 $enemy = Enemy::where('npc_id', $npcId)
                     ->where('mapping_version_id', $importStringRiftOffsets->getMappingVersion()->id)
-                    ->whereNotNull('enemy_pack_id')
-                    ->whereIn('floor_id', $floorIds)
+                    ->where('floor_id', $obeliskMapIcon->floor_id)
                     ->firstOrFail();
 
                 if (isset($mdtXy['sublevel'])) {
@@ -135,10 +139,10 @@ class RiftOffsetImporter
             } catch (ImportWarning $warning) {
                 $importStringRiftOffsets->getWarnings()->add($warning);
             } catch (ModelNotFoundException) {
-                // No enemy matching this NPC (packed, on the mapping version's floors) resolved -
-                // whether because the clone genuinely isn't in this mapping version, or (the common
-                // case seen while triaging #3915) it exists but with no enemy_pack_id on the current
-                // mapping version. Skip this one obelisk skip rather than 500ing the whole import.
+                // No enemy matching this NPC on the obelisk icon's floor resolved for this mapping
+                // version - the clone genuinely isn't seeded there (e.g. #3935: several BFA
+                // dungeons never carry this NPC at all). Skip this one obelisk skip rather than
+                // 500ing the whole import.
                 $importStringRiftOffsets->getWarnings()->add(new ImportWarning(
                     __('services.mdt.io.import_string.category.awakened_obelisks'),
                     __(

--- a/tests/Feature/App/Service/MDT/Import/RiftOffsetImporterTest.php
+++ b/tests/Feature/App/Service/MDT/Import/RiftOffsetImporterTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature\App\Service\MDT\Import;
 
 use App\Models\Dungeon;
 use App\Models\Enemy;
+use App\Models\MapIcon;
+use App\Models\MapIconType;
 use App\Service\MDT\Import\RiftOffsetImporter;
 use App\Service\MDT\Models\ImportStringRiftOffsets;
 use Illuminate\Support\Collection;
@@ -15,24 +17,139 @@ use Tests\TestCases\PublicTestCase;
 #[Group('RiftOffsetImporter')]
 final class RiftOffsetImporterTest extends PublicTestCase
 {
-    private const string DUNGEON_KEY   = 'theunderrot';
-    private const int    BRUTAL_NPC_ID = 161124;
+    private const string DUNGEON_KEY_UNPACKED_ONLY = 'theunderrot';
+    private const string DUNGEON_KEY_NO_ENEMY      = 'ataldazar';
+    private const string DUNGEON_KEY_MULTI_FLOOR   = 'toldagor';
+    private const int    BRUTAL_NPC_ID             = 161124;
 
     /**
-     * Guards #3915: an MDT import string's rift offsets reference a fixed set of Awakened Obelisk
-     * NPC ids. The underlying Enemy::where(...)->firstOrFail() query requires a *packed*
-     * (enemy_pack_id not null) row - when the current mapping version's dungeon has the Obelisk map
-     * icons placed but no such row for one of those NPC ids (real seeded case: The Underrot's
-     * current mapping version has an unpacked Enemy row for the Brutal obelisk NPC, not none at
-     * all - packed rows only exist on older mapping versions per the seeder data), it must not
-     * surface an uncaught ModelNotFoundException - it should be recorded as a warning and that one
-     * skip omitted instead.
+     * Guards #3935: the underlying Enemy lookup used to require a *packed* (enemy_pack_id not
+     * null) row, which several BFA dungeons' current mapping versions never carry for these NPC
+     * ids (packed rows only exist on older mapping versions per the seeder data) - even though an
+     * unpacked row for the same NPC, on the same floor as the Obelisk map icon, does exist. The
+     * lookup must resolve that unpacked row instead of surfacing a ModelNotFoundException.
+     */
+    #[Test]
+    public function parseRiftOffsets_givenRiftEnemyOnlyUnpackedOnCurrentMappingVersion_resolvesEnemyAndAddsMapIcon(): void
+    {
+        // Arrange
+        $dungeon        = Dungeon::where('key', self::DUNGEON_KEY_UNPACKED_ONLY)->firstOrFail();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+
+        // Pin the test's premise explicitly, so a future data/query change fails loudly here with
+        // the reason, instead of as a confusing assertion failure a few lines down.
+        $expectedEnemy = Enemy::where('npc_id', self::BRUTAL_NPC_ID)
+            ->where('mapping_version_id', $mappingVersion->id)
+            ->firstOrFail(); // throws if the seeded premise (an Enemy row exists at all) breaks
+        $this->assertNull(
+            $expectedEnemy->enemy_pack_id,
+            sprintf(
+                'Test premise no longer holds: NPC %d now has a packed Enemy row on %s\'s current mapping version (%d)',
+                self::BRUTAL_NPC_ID,
+                self::DUNGEON_KEY_UNPACKED_ONLY,
+                $mappingVersion->id,
+            ),
+        );
+
+        $importStringRiftOffsets = new ImportStringRiftOffsets(
+            warnings:       new Collection(),
+            dungeon:        $dungeon,
+            mappingVersion: $mappingVersion,
+            seasonalIndex:  null,
+            riftOffsets:    [
+                1 => [
+                    self::BRUTAL_NPC_ID => ['x' => 50.0, 'y' => 50.0],
+                ],
+            ],
+            week: 1,
+        );
+
+        /** @var RiftOffsetImporter $importer */
+        $importer = app(RiftOffsetImporter::class);
+
+        // Act
+        $result = $importer->parseRiftOffsets($importStringRiftOffsets);
+
+        // Assert - resolved successfully, on the enemy's (and thus the obelisk icon's) floor
+        $this->assertCount(0, $result->getWarnings());
+        $this->assertCount(1, $result->getMapIcons());
+        $this->assertCount(1, $result->getPaths());
+        $this->assertSame($expectedEnemy->floor_id, $result->getMapIcons()->first()['floor_id']);
+        $this->assertSame($expectedEnemy->floor_id, $result->getPaths()->first()['floor_id']);
+    }
+
+    /**
+     * Guards the multi-floor disambiguation this NPC lookup relies on: the same npc_id can be
+     * placed on more than one floor of the same dungeon (real seeded case: Tol Dagor). Anchoring
+     * the lookup to the Obelisk map icon's own floor - rather than an arbitrary match across every
+     * floor of the dungeon - must resolve the enemy on that same floor, not a different one.
+     */
+    #[Test]
+    public function parseRiftOffsets_givenRiftNpcPlacedOnMultipleFloors_resolvesEnemyOnObeliskIconFloor(): void
+    {
+        // Arrange
+        $dungeon        = Dungeon::where('key', self::DUNGEON_KEY_MULTI_FLOOR)->firstOrFail();
+        $mappingVersion = $dungeon->getCurrentMappingVersion();
+        $floorIds       = $dungeon->floors->pluck('id');
+
+        $obeliskMapIcon = MapIcon::where(
+            'map_icon_type_id',
+            MapIconType::ALL[MapIconType::MAP_ICON_TYPE_AWAKENED_OBELISK_BRUTAL],
+        )->whereIn('floor_id', $floorIds)->firstOrFail();
+
+        // Pin the test's premise explicitly: this NPC must actually be placed on more than one
+        // floor of this dungeon, otherwise this test isn't exercising the disambiguation at all.
+        $distinctFloors = Enemy::where('npc_id', self::BRUTAL_NPC_ID)
+            ->where('mapping_version_id', $mappingVersion->id)
+            ->whereIn('floor_id', $floorIds)
+            ->distinct()
+            ->pluck('floor_id');
+        $this->assertGreaterThan(
+            1,
+            $distinctFloors->count(),
+            sprintf(
+                'Test premise no longer holds: NPC %d is no longer placed on multiple floors of %s\'s current mapping version (%d)',
+                self::BRUTAL_NPC_ID,
+                self::DUNGEON_KEY_MULTI_FLOOR,
+                $mappingVersion->id,
+            ),
+        );
+
+        $importStringRiftOffsets = new ImportStringRiftOffsets(
+            warnings:       new Collection(),
+            dungeon:        $dungeon,
+            mappingVersion: $mappingVersion,
+            seasonalIndex:  null,
+            riftOffsets:    [
+                1 => [
+                    self::BRUTAL_NPC_ID => ['x' => 50.0, 'y' => 50.0],
+                ],
+            ],
+            week: 1,
+        );
+
+        /** @var RiftOffsetImporter $importer */
+        $importer = app(RiftOffsetImporter::class);
+
+        // Act
+        $result = $importer->parseRiftOffsets($importStringRiftOffsets);
+
+        // Assert - resolved on the obelisk icon's own floor, not an arbitrary one of the duplicates
+        $this->assertCount(0, $result->getWarnings());
+        $this->assertCount(1, $result->getMapIcons());
+        $this->assertSame($obeliskMapIcon->floor_id, $result->getMapIcons()->first()['floor_id']);
+    }
+
+    /**
+     * Guards #3915: when the NPC genuinely isn't seeded anywhere on the current mapping version
+     * (real seeded case: Atal'Dazar), the lookup must not surface an uncaught
+     * ModelNotFoundException - it should be recorded as a warning and that one skip omitted instead.
      */
     #[Test]
     public function parseRiftOffsets_givenRiftEnemyNotInCurrentMappingVersion_addsWarningInsteadOfThrowing(): void
     {
         // Arrange
-        $dungeon        = Dungeon::where('key', self::DUNGEON_KEY)->firstOrFail();
+        $dungeon        = Dungeon::where('key', self::DUNGEON_KEY_NO_ENEMY)->firstOrFail();
         $mappingVersion = $dungeon->getCurrentMappingVersion();
 
         // Pin the test's premise explicitly, so a future data/query change that makes this NPC
@@ -42,12 +159,11 @@ final class RiftOffsetImporterTest extends PublicTestCase
             0,
             Enemy::where('npc_id', self::BRUTAL_NPC_ID)
                 ->where('mapping_version_id', $mappingVersion->id)
-                ->whereNotNull('enemy_pack_id')
                 ->count(),
             sprintf(
-                'Test premise no longer holds: NPC %d now has a packed Enemy row on %s\'s current mapping version (%d)',
+                'Test premise no longer holds: NPC %d now has an Enemy row on %s\'s current mapping version (%d)',
                 self::BRUTAL_NPC_ID,
-                self::DUNGEON_KEY,
+                self::DUNGEON_KEY_NO_ENEMY,
                 $mappingVersion->id,
             ),
         );
@@ -95,7 +211,7 @@ final class RiftOffsetImporterTest extends PublicTestCase
     public function parseRiftOffsets_givenUnrecognizedRiftNpcId_skipsWithoutThrowing(): void
     {
         // Arrange
-        $dungeon        = Dungeon::where('key', self::DUNGEON_KEY)->firstOrFail();
+        $dungeon        = Dungeon::where('key', self::DUNGEON_KEY_UNPACKED_ONLY)->firstOrFail();
         $mappingVersion = $dungeon->getCurrentMappingVersion();
 
         $importStringRiftOffsets = new ImportStringRiftOffsets(

--- a/tests/Feature/App/Service/MDT/Import/RiftOffsetImporterTest.php
+++ b/tests/Feature/App/Service/MDT/Import/RiftOffsetImporterTest.php
@@ -8,6 +8,7 @@ use App\Models\MapIcon;
 use App\Models\MapIconType;
 use App\Service\MDT\Import\RiftOffsetImporter;
 use App\Service\MDT\Models\ImportStringRiftOffsets;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -92,10 +93,18 @@ final class RiftOffsetImporterTest extends PublicTestCase
         $mappingVersion = $dungeon->getCurrentMappingVersion();
         $floorIds       = $dungeon->floors->pluck('id');
 
+        // Mirror parseRiftOffsets()'s own seasonal_index predicate: with no import string season
+        // set, this dungeon has more than one Brutal obelisk icon on the current mapping version's
+        // floors, and only this predicate (not row order) picks the one the importer would.
         $obeliskMapIcon = MapIcon::where(
             'map_icon_type_id',
             MapIconType::ALL[MapIconType::MAP_ICON_TYPE_AWAKENED_OBELISK_BRUTAL],
-        )->whereIn('floor_id', $floorIds)->firstOrFail();
+        )
+            ->whereIn('floor_id', $floorIds)
+            ->where(static function (Builder $query) {
+                $query->whereNull('seasonal_index')->orWhere('seasonal_index', 1);
+            })
+            ->firstOrFail();
 
         // Pin the test's premise explicitly: this NPC must actually be placed on more than one
         // floor of this dungeon, otherwise this test isn't exercising the disambiguation at all.
@@ -113,6 +122,22 @@ final class RiftOffsetImporterTest extends PublicTestCase
                 self::DUNGEON_KEY_MULTI_FLOOR,
                 $mappingVersion->id,
             ),
+        );
+
+        // Pin the property that makes this test non-vacuous: a floor-unfiltered lookup (the
+        // pre-#3935 disambiguation, minus the enemy_pack_id filter) must land on a *different*
+        // floor than the obelisk icon's, otherwise this test would still pass even without the
+        // floor anchor this PR adds.
+        $firstMatchingEnemyRegardlessOfFloor = Enemy::where('npc_id', self::BRUTAL_NPC_ID)
+            ->where('mapping_version_id', $mappingVersion->id)
+            ->whereIn('floor_id', $floorIds)
+            ->orderBy('id')
+            ->firstOrFail();
+        $this->assertNotSame(
+            $obeliskMapIcon->floor_id,
+            $firstMatchingEnemyRegardlessOfFloor->floor_id,
+            'Test premise no longer holds: a floor-unfiltered enemy lookup now agrees with the '
+            . 'obelisk icon\'s floor, so this test no longer exercises the floor-anchoring disambiguation.',
         );
 
         $importStringRiftOffsets = new ImportStringRiftOffsets(


### PR DESCRIPTION
Closes #3935

:robot: `RiftOffsetImporter::parseRiftOffsets()` resolved an Awakened Obelisk skip's target Enemy via `whereNotNull('enemy_pack_id')`. Per #3935's investigation, packed rows for these 4 hardcoded obelisk NPC ids only exist on **older** mapping versions of most BFA dungeons - so this lookup silently failed (as a warning, since #3933) for essentially every dungeon's current mapping version.

## Investigated: is `enemy_pack_id` even load-bearing?

No - only `$enemy->floor_id`/`$enemy->floor` are read afterward. But naively dropping the filter isn't safe either: some dungeons (Tol Dagor, Shrine of the Storm) place the same obelisk NPC on *multiple floors*, so an unqualified lookup can land on the wrong one.

**Fix**: anchor the lookup to the obelisk `MapIcon`'s own floor (`$obeliskMapIcon->floor_id`) instead of filtering by pack membership. This is the correct disambiguator regardless of pack data: the NPC being looked up *is* the obelisk the icon represents, and the icon's floor is exactly where the gateway line needs to land.

## Blast radius (swept all `expansion_id=2` dungeons with an obelisk MapIcon seeded, all 4 NPC ids, current mapping version, resolving the icon exactly as the importer does including the `seasonal_index` predicate)

Cold review caught that my first pass at this table was wrong - the packed-row disambiguation in Tol Dagor and Shrine of the Storm was **not** correct pre-fix, it just happened to not throw:

| Dungeon | Before (packed-row filter) | After (icon-floor anchor) |
|---|---|---|
| freehold | FAIL (no packed row) | resolves on floor 43 (fixed) |
| theunderrot | FAIL (no packed row) | resolves on floor 51 (fixed) |
| shrineofthestorm | resolved, but on floor 46 (wrong - icon is on floor 45) | resolves on floor 45 (icon's floor - **also fixed**, not just preserved) |
| toldagor | resolved, but on floor 59 for all 4 obelisks (wrong - icons are on floors 53/58/55/57) | resolves each obelisk on its own icon's floor (**also fixed**) |
| ataldazar, kingsrest, siegeofboralus, templeofsethraliss, themotherlode, waycrestmanor, mechagonworkshop | FAIL (NPC not seeded on this mapping version at all) | still FAIL - unchanged, out of scope (needs seeder data, not a query fix) |

So this fix repairs the gateway floor for **4 dungeons outright** (freehold, theunderrot newly resolve; shrineofthestorm, toldagor now land on the correct floor instead of a wrong one that happened not to throw) and leaves ~7 dungeons unchanged where the NPC simply isn't seeded on the current mapping version at all - flagging per the issue's "needs a maintainer call" note, since fixing those needs seeder/mapping data, not a code change. Given the fix here is small and strictly improves correctness, it seemed worth landing regardless of that remaining gap.

One dependency worth noting: the obelisk `MapIcon` lookup above isn't scoped to `mapping_version_id`, so it resolves the *oldest* mapping version's icon (e.g. Underrot picks the icon from mapping version 21 while the current version is 158). This was harmless before since pack membership drove enemy resolution; now the icon's floor does. It holds on today's seeded data (verified: no dungeon regresses from resolving to failing), but rests on obelisk icons never having moved floors across a dungeon's mapping versions.

Also per the issue: `MDTExportStringService` comments this feature as "Legacy" (export direction only) - this fix doesn't touch export.

## Test plan
- [x] `RiftOffsetImporterTest`: added coverage for (a) unpacked-only resolution (The Underrot), (b) multi-floor disambiguation via the obelisk icon's floor, mirroring the importer's `seasonal_index` predicate and pinning that the floor-unfiltered lookup would otherwise disagree (Tol Dagor), (c) genuine absence still warns instead of throwing (Atal'Dazar, replacing the old pinned-negative-premise dungeon since it now resolves)
- [x] `composer run fix` / `composer run analyse` clean
- [x] `php artisan test --group=MDT` - 232 passed
