### PR TITLE
Fix multi-select dungeon picker truncating preselected values to one

### DIFF
--- a/resources/views/common/dungeon/select.blade.php
+++ b/resources/views/common/dungeon/select.blade.php
@@ -167,10 +167,13 @@ $dungeonsSelect = array_filter($dungeonsSelect, static fn($groupOptions) => coun
     @if($label !== false)
         {{ html()->label($label . ($required ? '<span class="form-required">*</span>' : ''), $id) }}
     @endif
-    {{ html()->select($name, $dungeonsSelect, $selected)->attributes(array_merge(['id' => $id],
-        $multiple ? ['multiple' => 'multiple'] : [], [
-            'class' => 'form-control selectpicker', 'data-live-search' => 'true'
-        ])) }}
+    {{ html()->select($name, $dungeonsSelect, $selected)
+        ->when($multiple, fn($select) => $select->multiple())
+        ->attributes([
+            'id'               => $id,
+            'class'            => 'form-control selectpicker',
+            'data-live-search' => 'true',
+        ]) }}
     @if( $showSiegeWarning )
         <div id="siege_of_boralus_faction_warning" class="text-warning mt-2" style="display: none;">
             <i class="fa fa-exclamation-triangle"></i> {{ __('view_common.dungeon.select.siege_of_boralus_warning') }}

--- a/tests/Feature/Controller/Admin/AdminSeasonControllerTest.php
+++ b/tests/Feature/Controller/Admin/AdminSeasonControllerTest.php
@@ -168,6 +168,41 @@ final class AdminSeasonControllerTest extends PublicTestCase
     }
 
     #[Test]
+    public function edit_givenSeasonWithMultipleDungeons_preselectsAllOfThem(): void
+    {
+        // Arrange - a regression test for a real bug: the multi-select builder truncated the
+        // preselected values down to the first one whenever `multiple` was applied as a plain
+        // HTML attribute instead of via the builder's dedicated `multiple()` method.
+        $expansion = Expansion::query()->firstOrFail();
+        $dungeons  = Dungeon::query()->limit(3)->get();
+        $season    = Season::create([
+            'expansion_id'            => $expansion->id,
+            'index'                   => 987,
+            'start'                   => '2026-01-01 00:00:00',
+            'presets'                 => 0,
+            'affix_group_count'       => 4,
+            'start_affix_group_index' => 0,
+            'key_level_min'           => 2,
+            'key_level_max'           => 30,
+        ]);
+        $season->syncDungeons($dungeons->pluck('id')->toArray());
+
+        try {
+            // Act
+            $response = $this->get(route('admin.season.edit', $season));
+
+            // Assert
+            $response->assertOk();
+            foreach ($dungeons as $dungeon) {
+                $response->assertSee(sprintf('value="%d" selected="selected"', $dungeon->id), false);
+            }
+        } finally {
+            $season->syncDungeons([]);
+            $season->delete();
+        }
+    }
+
+    #[Test]
     public function update_givenValidDataWithDungeons_syncsDungeonsAndDefaultsPresetsAndSeasonalAffixId(): void
     {
         // Arrange

--- a/tests/Feature/Controller/Admin/AdminSeasonControllerTest.php
+++ b/tests/Feature/Controller/Admin/AdminSeasonControllerTest.php
@@ -174,7 +174,7 @@ final class AdminSeasonControllerTest extends PublicTestCase
         // preselected values down to the first one whenever `multiple` was applied as a plain
         // HTML attribute instead of via the builder's dedicated `multiple()` method.
         $expansion = Expansion::query()->firstOrFail();
-        $dungeons  = Dungeon::query()->limit(3)->get();
+        $dungeons  = Dungeon::query()->orderBy('id')->limit(3)->get();
         $season    = Season::create([
             'expansion_id'            => $expansion->id,
             'index'                   => 987,
@@ -191,10 +191,12 @@ final class AdminSeasonControllerTest extends PublicTestCase
             // Act
             $response = $this->get(route('admin.season.edit', $season));
 
-            // Assert
+            // Assert - match the option's value AND text together so this can't pass by
+            // accidentally matching the unrelated expansion_id/seasonal_affix_id selects, which
+            // may share the same numeric id as a dungeon.
             $response->assertOk();
             foreach ($dungeons as $dungeon) {
-                $response->assertSee(sprintf('value="%d" selected="selected"', $dungeon->id), false);
+                $response->assertSee(sprintf('value="%d" selected="selected">%s', $dungeon->id, e(__($dungeon->name))), false);
             }
         } finally {
             $season->syncDungeons([]);


### PR DESCRIPTION
:robot: Closes #3952

## Summary
- The season/NPC admin edit pages' dungeon multi-select only ever showed the first linked
  dungeon as selected — `season_dungeons`/`npc_dungeons` data was correct, the rendering was not.
- `spatie/laravel-html`'s `Select::applyValueToOptions()` truncates the preselected values to
  `->take(1)` when the `multiple` HTML attribute isn't present yet. `resources/views/common/dungeon/select.blade.php`
  attached `multiple` via a plain `->attributes([...])` call *after* `html()->select()` had already
  applied the value internally, so the attribute wasn't there yet and every id after the first was
  dropped.
- Fix: use the builder's own `->multiple()` method (conditionally, via `->when($multiple, ...)`),
  which re-runs `applyValueToOptions()` once the attribute is actually set.

## Test plan
- [x] New regression test `edit_givenSeasonWithMultipleDungeons_preselectsAllOfThem` — confirmed it
      fails against the pre-fix blade (reverted the file, saw the assertion fail on the second
      dungeon id) and passes with the fix.
- [x] `AdminSeasonControllerTest` + `AdminToolsNpcControllerTest` green.
- [x] `composer run fix` clean, `composer run analyse` clean.