### PR TITLE
#3941 Wrap every controller broadcast() failure in its own narrow catch

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxArrowController.php
+++ b/app/Http/Controllers/Ajax/AjaxArrowController.php
@@ -124,7 +124,11 @@ class AjaxArrowController extends Controller
                     /** @var \App\Models\User $user */
                     $user = Auth::getUser();
 
-                    broadcast(new ArrowDeletedEvent($dungeonRoute, $user, $arrow));
+                    try {
+                        broadcast(new ArrowDeletedEvent($dungeonRoute, $user, $arrow));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 $this->dungeonRouteChanged($dungeonRoute, $arrow, null);

--- a/app/Http/Controllers/Ajax/AjaxBrushlineController.php
+++ b/app/Http/Controllers/Ajax/AjaxBrushlineController.php
@@ -128,7 +128,11 @@ class AjaxBrushlineController extends Controller
                     /** @var \App\Models\User $user */
                     $user = Auth::getUser();
 
-                    broadcast(new BrushlineDeletedEvent($dungeonRoute, $user, $brushline));
+                    try {
+                        broadcast(new BrushlineDeletedEvent($dungeonRoute, $user, $brushline));
+                    } catch (BroadcastException) {
+                        // We don't really care if the broadcast fails, so just catch the exception and move on
+                    }
                 }
 
                 $this->dungeonRouteChanged($dungeonRoute, $brushline, null);

--- a/app/Http/Controllers/Ajax/AjaxDungeonFloorSwitchMarkerController.php
+++ b/app/Http/Controllers/Ajax/AjaxDungeonFloorSwitchMarkerController.php
@@ -11,6 +11,7 @@ use App\Models\Mapping\MappingVersion;
 use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -43,7 +44,12 @@ class AjaxDungeonFloorSwitchMarkerController extends AjaxMappingModelBaseControl
                 if (Auth::check()) {
                     /** @var User $user */
                     $user = Auth::getUser();
-                    broadcast(new DungeonFloorSwitchMarkerDeletedEvent($dungeon, $user, $dungeonFloorSwitchMarker));
+
+                    try {
+                        broadcast(new DungeonFloorSwitchMarkerDeletedEvent($dungeon, $user, $dungeonFloorSwitchMarker));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 // Trigger mapping changed event so the mapping gets saved across all environments

--- a/app/Http/Controllers/Ajax/AjaxEnemyController.php
+++ b/app/Http/Controllers/Ajax/AjaxEnemyController.php
@@ -18,6 +18,7 @@ use App\Service\Coordinates\CoordinatesServiceInterface;
 use DB;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -192,7 +193,12 @@ class AjaxEnemyController extends AjaxMappingModelBaseController
                     if (Auth::check()) {
                         /** @var User $user */
                         $user = Auth::getUser();
-                        broadcast(new EnemyDeletedEvent($enemy->floor->dungeon, $user, $enemy));
+
+                        try {
+                            broadcast(new EnemyDeletedEvent($enemy->floor->dungeon, $user, $enemy));
+                        } catch (BroadcastException) {
+                            // Ignore broadcast failures
+                        }
                     }
                 }
 

--- a/app/Http/Controllers/Ajax/AjaxEnemyForcesCheckpointController.php
+++ b/app/Http/Controllers/Ajax/AjaxEnemyForcesCheckpointController.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use DB;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -62,7 +63,12 @@ class AjaxEnemyForcesCheckpointController extends AjaxMappingModelBaseController
                     if (Auth::check()) {
                         /** @var User $user */
                         $user = Auth::user();
-                        broadcast(new EnemyForcesCheckpointDeletedEvent($enemyForcesCheckpoint->floor->dungeon, $user, $enemyForcesCheckpoint));
+
+                        try {
+                            broadcast(new EnemyForcesCheckpointDeletedEvent($enemyForcesCheckpoint->floor->dungeon, $user, $enemyForcesCheckpoint));
+                        } catch (BroadcastException) {
+                            // Ignore broadcast failures
+                        }
                     }
                 }
 

--- a/app/Http/Controllers/Ajax/AjaxEnemyPackController.php
+++ b/app/Http/Controllers/Ajax/AjaxEnemyPackController.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use DB;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -49,7 +50,12 @@ class AjaxEnemyPackController extends AjaxMappingModelBaseController
                 if (Auth::check()) {
                     /** @var User $user */
                     $user = Auth::getUser();
-                    broadcast(new EnemyPackDeletedEvent($enemyPack->floor->dungeon, $user, $enemyPack));
+
+                    try {
+                        broadcast(new EnemyPackDeletedEvent($enemyPack->floor->dungeon, $user, $enemyPack));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 $result = response()->noContent();

--- a/app/Http/Controllers/Ajax/AjaxEnemyPatrolController.php
+++ b/app/Http/Controllers/Ajax/AjaxEnemyPatrolController.php
@@ -13,6 +13,7 @@ use App\Models\Polyline;
 use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -78,7 +79,12 @@ class AjaxEnemyPatrolController extends AjaxMappingModelBaseController
                 if (Auth::check()) {
                     /** @var User $user */
                     $user = Auth::getUser();
-                    broadcast(new EnemyPatrolDeletedEvent($enemyPatrol->floor->dungeon, $user, $enemyPatrol));
+
+                    try {
+                        broadcast(new EnemyPatrolDeletedEvent($enemyPatrol->floor->dungeon, $user, $enemyPatrol));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 // Trigger mapping changed event so the mapping gets saved across all environments

--- a/app/Http/Controllers/Ajax/AjaxKillZoneController.php
+++ b/app/Http/Controllers/Ajax/AjaxKillZoneController.php
@@ -25,6 +25,7 @@ use App\Service\Coordinates\CoordinatesServiceInterface;
 use App\Service\KillZonePath\KillZonePathServiceInterface;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Database\UniqueConstraintViolationException;
@@ -330,7 +331,12 @@ class AjaxKillZoneController extends Controller
                 // Something's updated; broadcast it
                 /** @var User $user */
                 $user = Auth::user();
-                broadcast(new KillZoneChangedEvent($coordinatesService, $dungeonroute, $user, $killZone));
+
+                try {
+                    broadcast(new KillZoneChangedEvent($coordinatesService, $dungeonroute, $user, $killZone));
+                } catch (BroadcastException) {
+                    // Ignore broadcast failures
+                }
             }
         } else {
             throw new Exception('Unable to save kill zone!');
@@ -513,7 +519,12 @@ class AjaxKillZoneController extends Controller
                 if (Auth::check()) {
                     /** @var User $user */
                     $user = Auth::user();
-                    broadcast(new KillZoneDeletedEvent($dungeonRoute, $user, $killZone));
+
+                    try {
+                        broadcast(new KillZoneDeletedEvent($dungeonRoute, $user, $killZone));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 $dungeonRoute->load('killZones');
@@ -571,11 +582,19 @@ class AjaxKillZoneController extends Controller
                     foreach ($killZones as $killZone) {
                         $this->dungeonRouteChanged($dungeonRoute, $killZone, null);
 
-                        broadcast(new KillZoneDeletedEvent($dungeonRoute, $user, $killZone));
+                        try {
+                            broadcast(new KillZoneDeletedEvent($dungeonRoute, $user, $killZone));
+                        } catch (BroadcastException) {
+                            // Ignore broadcast failures
+                        }
                     }
 
                     foreach ($pridefulEnemies as $pridefulEnemy) {
-                        broadcast(new PridefulEnemyDeletedEvent($dungeonRoute, $user, $pridefulEnemy));
+                        try {
+                            broadcast(new PridefulEnemyDeletedEvent($dungeonRoute, $user, $pridefulEnemy));
+                        } catch (BroadcastException) {
+                            // Ignore broadcast failures
+                        }
                     }
                 }
 

--- a/app/Http/Controllers/Ajax/AjaxLiveSessionController.php
+++ b/app/Http/Controllers/Ajax/AjaxLiveSessionController.php
@@ -9,6 +9,7 @@ use App\Models\LiveSession;
 use App\Models\User;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -43,7 +44,12 @@ class AjaxLiveSessionController extends Controller
                 if (Auth::check()) {
                     /** @var User $user */
                     $user = Auth::user();
-                    broadcast(new StopEvent($liveSession, $user));
+
+                    try {
+                        broadcast(new StopEvent($liveSession, $user));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 // Convert to seconds

--- a/app/Http/Controllers/Ajax/AjaxMapIconController.php
+++ b/app/Http/Controllers/Ajax/AjaxMapIconController.php
@@ -18,6 +18,7 @@ use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -172,7 +173,11 @@ class AjaxMapIconController extends AjaxMappingModelBaseController
         try {
             if ($mapIcon->delete()) {
                 if (Auth::check()) {
-                    broadcast(new MapIconDeletedEvent($dungeonRoute ?? $mapIcon->floor->dungeon, Auth::user(), $mapIcon));
+                    try {
+                        broadcast(new MapIconDeletedEvent($dungeonRoute ?? $mapIcon->floor->dungeon, Auth::user(), $mapIcon));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 // Only when icons that are sticky to the map are saved

--- a/app/Http/Controllers/Ajax/AjaxMappingModelBaseController.php
+++ b/app/Http/Controllers/Ajax/AjaxMappingModelBaseController.php
@@ -13,6 +13,7 @@ use App\Service\Coordinates\CoordinatesServiceInterface;
 use Closure;
 use DB;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Throwable;
@@ -93,7 +94,12 @@ abstract class AjaxMappingModelBaseController extends Controller
                     /** @var Floor|null $floor */
                     $floor = $model->getAttribute('floor');
                     $echoContext ??= $floor?->dungeon;
-                    broadcast($this->getModelChangedEvent($coordinatesService, $echoContext, Auth::user(), $model));
+
+                    try {
+                        broadcast($this->getModelChangedEvent($coordinatesService, $echoContext, Auth::user(), $model));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 return $model;

--- a/app/Http/Controllers/Ajax/AjaxMountableAreaController.php
+++ b/app/Http/Controllers/Ajax/AjaxMountableAreaController.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use DB;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -59,7 +60,12 @@ class AjaxMountableAreaController extends AjaxMappingModelBaseController
                     if (Auth::check()) {
                         /** @var User $user */
                         $user = Auth::user();
-                        broadcast(new MountableAreaDeletedEvent($mountableArea->floor->dungeon, $user, $mountableArea));
+
+                        try {
+                            broadcast(new MountableAreaDeletedEvent($mountableArea->floor->dungeon, $user, $mountableArea));
+                        } catch (BroadcastException) {
+                            // Ignore broadcast failures
+                        }
                     }
                 }
 

--- a/app/Http/Controllers/Ajax/AjaxNpcController.php
+++ b/app/Http/Controllers/Ajax/AjaxNpcController.php
@@ -12,6 +12,7 @@ use App\Logic\Datatables\NpcsDatatablesHandler;
 use App\Models\Npc\Npc;
 use App\Models\User;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -34,7 +35,11 @@ class AjaxNpcController extends Controller
                 /** @var User $user */
                 $user = Auth::user();
                 foreach ($npc->dungeons as $dungeon) {
-                    broadcast(new NpcDeletedEvent($dungeon, $user, $npc));
+                    try {
+                        broadcast(new NpcDeletedEvent($dungeon, $user, $npc));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
             }
 

--- a/app/Http/Controllers/Ajax/AjaxOverpulledEnemyController.php
+++ b/app/Http/Controllers/Ajax/AjaxOverpulledEnemyController.php
@@ -14,6 +14,7 @@ use App\Models\User;
 use App\Service\LiveSession\OverpulledEnemyServiceInterface;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
@@ -61,7 +62,12 @@ class AjaxOverpulledEnemyController extends Controller
             if (Auth::check()) {
                 /** @var User $user */
                 $user = Auth::getUser();
-                broadcast(new OverpulledEnemyChangedEvent($liveSession, $user, $overpulledEnemy, $enemy));
+
+                try {
+                    broadcast(new OverpulledEnemyChangedEvent($liveSession, $user, $overpulledEnemy, $enemy));
+                } catch (BroadcastException) {
+                    // Ignore broadcast failures
+                }
             }
         }
 
@@ -100,7 +106,12 @@ class AjaxOverpulledEnemyController extends Controller
                 if ($overpulledEnemy && $overpulledEnemy->delete() && Auth::check()) { // @phpstan-ignore booleanAnd.leftAlwaysTrue
                     /** @var User $user */
                     $user = Auth::getUser();
-                    broadcast(new OverpulledEnemyDeletedEvent($livesession, $user, $enemy));
+
+                    try {
+                        broadcast(new OverpulledEnemyDeletedEvent($livesession, $user, $enemy));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 // Optionally, don't calculate the return value

--- a/app/Http/Controllers/Ajax/AjaxPathController.php
+++ b/app/Http/Controllers/Ajax/AjaxPathController.php
@@ -17,6 +17,7 @@ use App\Models\Polyline;
 use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -95,7 +96,12 @@ class AjaxPathController extends Controller
                 if (Auth::check()) {
                     /** @var User $user */
                     $user = Auth::getUser();
-                    broadcast(new PathChangedEvent($coordinatesService, $dungeonRoute, $user, $path));
+
+                    try {
+                        broadcast(new PathChangedEvent($coordinatesService, $dungeonRoute, $user, $path));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 // Touch the route so that the thumbnail gets updated
@@ -127,7 +133,12 @@ class AjaxPathController extends Controller
                 if (Auth::check()) {
                     /** @var User $user */
                     $user = Auth::getUser();
-                    broadcast(new PathDeletedEvent($dungeonRoute, $user, $path));
+
+                    try {
+                        broadcast(new PathDeletedEvent($dungeonRoute, $user, $path));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
 
                 $this->dungeonRouteChanged($dungeonRoute, $path, null);

--- a/app/Http/Controllers/Ajax/AjaxPridefulEnemyController.php
+++ b/app/Http/Controllers/Ajax/AjaxPridefulEnemyController.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -53,7 +54,12 @@ class AjaxPridefulEnemyController extends Controller
         if (Auth::check()) {
             /** @var User $user */
             $user = Auth::getUser();
-            broadcast(new PridefulEnemyChangedEvent($coordinatesService, $dungeonRoute, $user, $pridefulEnemy));
+
+            try {
+                broadcast(new PridefulEnemyChangedEvent($coordinatesService, $dungeonRoute, $user, $pridefulEnemy));
+            } catch (BroadcastException) {
+                // Ignore broadcast failures
+            }
         }
 
         $dungeonRoute->touch();
@@ -76,7 +82,12 @@ class AjaxPridefulEnemyController extends Controller
             if ($pridefulEnemy && $pridefulEnemy->delete() && Auth::check()) {
                 /** @var User $user */
                 $user = Auth::getUser();
-                broadcast(new PridefulEnemyDeletedEvent($dungeonRoute, $user, $pridefulEnemy));
+
+                try {
+                    broadcast(new PridefulEnemyDeletedEvent($dungeonRoute, $user, $pridefulEnemy));
+                } catch (BroadcastException) {
+                    // Ignore broadcast failures
+                }
             }
 
             $dungeonRoute->touch();

--- a/app/Http/Controllers/Ajax/Floor/AjaxFloorUnionAreaController.php
+++ b/app/Http/Controllers/Ajax/Floor/AjaxFloorUnionAreaController.php
@@ -13,6 +13,7 @@ use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use DB;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -56,7 +57,12 @@ class AjaxFloorUnionAreaController extends AjaxMappingModelBaseController
                     if (Auth::check()) {
                         /** @var User $user */
                         $user = Auth::getUser();
-                        broadcast(new FloorUnionAreaDeletedEvent($floorUnionArea->floor->dungeon, $user, $floorUnionArea));
+
+                        try {
+                            broadcast(new FloorUnionAreaDeletedEvent($floorUnionArea->floor->dungeon, $user, $floorUnionArea));
+                        } catch (BroadcastException) {
+                            // Ignore broadcast failures
+                        }
                     }
                 }
 

--- a/app/Http/Controllers/Ajax/Floor/AjaxFloorUnionController.php
+++ b/app/Http/Controllers/Ajax/Floor/AjaxFloorUnionController.php
@@ -14,6 +14,7 @@ use App\Models\User;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use DB;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -60,7 +61,12 @@ class AjaxFloorUnionController extends AjaxMappingModelBaseController
                     if (Auth::check()) {
                         /** @var User $user */
                         $user = Auth::getUser();
-                        broadcast(new FloorUnionDeletedEvent($floorUnion->floor->dungeon, $user, $floorUnion));
+
+                        try {
+                            broadcast(new FloorUnionDeletedEvent($floorUnion->floor->dungeon, $user, $floorUnion));
+                        } catch (BroadcastException) {
+                            // Ignore broadcast failures
+                        }
                     }
                 }
 

--- a/app/Http/Controllers/LiveSessionController.php
+++ b/app/Http/Controllers/LiveSessionController.php
@@ -14,6 +14,7 @@ use App\Service\Reverb\ReverbHttpApiServiceInterface;
 use Auth;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
@@ -65,8 +66,12 @@ class LiveSessionController extends Controller
                 }
 
                 if ($invitees->isNotEmpty()) {
-                    // Broadcast that channel that a team member has started a live session and that we're invited!
-                    broadcast(new InviteEvent($liveSession, $user, $invitees));
+                    try {
+                        // Broadcast that channel that a team member has started a live session and that we're invited!
+                        broadcast(new InviteEvent($liveSession, $user, $invitees));
+                    } catch (BroadcastException) {
+                        // Ignore broadcast failures
+                    }
                 }
             } catch (Exception $exception) {
                 report($exception);

--- a/app/Http/Controllers/LiveSessionController.php
+++ b/app/Http/Controllers/LiveSessionController.php
@@ -69,8 +69,9 @@ class LiveSessionController extends Controller
                     try {
                         // Broadcast that channel that a team member has started a live session and that we're invited!
                         broadcast(new InviteEvent($liveSession, $user, $invitees));
-                    } catch (BroadcastException) {
-                        // Ignore broadcast failures
+                    } catch (BroadcastException $exception) {
+                        // Ignore broadcast failures, but keep the visibility the outer catch below used to give this
+                        report($exception);
                     }
                 }
             } catch (Exception $exception) {

--- a/app/Http/Controllers/NpcController.php
+++ b/app/Http/Controllers/NpcController.php
@@ -17,6 +17,7 @@ use App\Models\Spell\Spell;
 use App\Models\User;
 use App\Service\Npc\NpcServiceInterface;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Http\RedirectResponse;
@@ -162,11 +163,19 @@ class NpcController extends Controller
             /** @var User $user */
             $user = Auth::user();
             foreach ($npc->dungeons as $dungeon) {
-                broadcast(new NpcChangedEvent($dungeon, $user, $npc));
+                try {
+                    broadcast(new NpcChangedEvent($dungeon, $user, $npc));
+                } catch (BroadcastException) {
+                    // Ignore broadcast failures
+                }
             }
 
             foreach ($npcBefore->dungeons as $dungeon) {
-                broadcast(new NpcChangedEvent($dungeon, $user, $npcBefore));
+                try {
+                    broadcast(new NpcChangedEvent($dungeon, $user, $npcBefore));
+                } catch (BroadcastException) {
+                    // Ignore broadcast failures
+                }
             }
 
             // Trigger mapping changed event so the mapping gets saved across all environments

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -22,6 +22,7 @@ use App\Service\DungeonRoute\CoverageServiceInterface;
 use App\Service\Reverb\ReverbHttpApiServiceInterface;
 use App\Service\Season\SeasonServiceInterface;
 use Exception;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -205,7 +206,11 @@ class ProfileController extends Controller
                             foreach ($reverbHttpApiService->getChannelUsers($name) as $reverbChannelUser) {
                                 if ((int)$reverbChannelUser['id'] === $user->id) {
                                     // Broadcast that channel that our user's color has changed
-                                    broadcast(new UserColorChangedEvent($context, $user));
+                                    try {
+                                        broadcast(new UserColorChangedEvent($context, $user));
+                                    } catch (BroadcastException) {
+                                        // Ignore broadcast failures
+                                    }
 
                                     break;
                                 }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -208,8 +208,9 @@ class ProfileController extends Controller
                                     // Broadcast that channel that our user's color has changed
                                     try {
                                         broadcast(new UserColorChangedEvent($context, $user));
-                                    } catch (BroadcastException) {
-                                        // Ignore broadcast failures
+                                    } catch (BroadcastException $exception) {
+                                        // Ignore broadcast failures, but keep the visibility the outer catch below used to give this
+                                        report($exception);
                                     }
 
                                     break;

--- a/tests/Feature/Controller/Ajax/AjaxEnemyForcesCheckpointControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxEnemyForcesCheckpointControllerTest.php
@@ -312,8 +312,8 @@ final class AjaxEnemyForcesCheckpointControllerTest extends AjaxPublicTestCase
             }
 
             /**
-             * @param  array<int, mixed>    $channels
-             * @param  array<string, mixed> $payload
+             * @param array<int, mixed>    $channels
+             * @param array<string, mixed> $payload
              */
             public function broadcast(array $channels, $event, array $payload = []): void
             {

--- a/tests/Feature/Controller/Ajax/AjaxEnemyForcesCheckpointControllerTest.php
+++ b/tests/Feature/Controller/Ajax/AjaxEnemyForcesCheckpointControllerTest.php
@@ -7,6 +7,9 @@ use App\Models\EnemyForcesCheckpoint;
 use App\Models\Floor\Floor;
 use App\Models\Mapping\MappingVersion;
 use App\Models\User;
+use Illuminate\Broadcasting\BroadcastException;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Validation\ValidationException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -110,6 +113,48 @@ final class AjaxEnemyForcesCheckpointControllerTest extends AjaxPublicTestCase
     }
 
     #[Test]
+    public function store_givenBroadcastFails_stillCreatesCheckpoint(): void
+    {
+        // Arrange - a broadcast failure (e.g. Reverb briefly unreachable) must not turn a
+        // successfully saved model into an error response (#3941)
+        $this->forceBroadcastFailure();
+
+        $floor          = $this->getFloorWithEnemies();
+        $mappingVersion = $this->getMappingVersionForFloor($floor);
+
+        $enemyForcesCheckpointId = null;
+
+        try {
+            // Act
+            $response = $this->post(sprintf('/ajax/admin/mappingVersion/%d/enemyforcescheckpoint', $mappingVersion->id), [
+                'id'                 => -1,
+                'mapping_version_id' => $mappingVersion->id,
+                'floor_id'           => $floor->id,
+                'name'               => 'Test corridor',
+                'lat'                => -128.5,
+                'lng'                => 192.5,
+            ]);
+
+            // Assert
+            $response->assertSuccessful();
+
+            $enemyForcesCheckpointId = $response->json('id');
+            $this->assertNotNull($enemyForcesCheckpointId);
+
+            $this->assertDatabaseHas('enemy_forces_checkpoints', [
+                'id'                 => $enemyForcesCheckpointId,
+                'mapping_version_id' => $mappingVersion->id,
+                'floor_id'           => $floor->id,
+                'name'               => 'Test corridor',
+            ]);
+        } finally {
+            if ($enemyForcesCheckpointId !== null) {
+                EnemyForcesCheckpoint::where('id', $enemyForcesCheckpointId)->delete();
+            }
+        }
+    }
+
+    #[Test]
     public function delete_givenCheckpointWithEnemies_deletesItAndReleasesItsEnemies(): void
     {
         // Arrange
@@ -147,6 +192,41 @@ final class AjaxEnemyForcesCheckpointControllerTest extends AjaxPublicTestCase
         } finally {
             Enemy::where('enemy_forces_checkpoint_id', $enemyForcesCheckpoint->id)
                 ->update(['enemy_forces_checkpoint_id' => null]);
+            EnemyForcesCheckpoint::where('id', $enemyForcesCheckpoint->id)->delete();
+        }
+    }
+
+    #[Test]
+    public function delete_givenBroadcastFails_stillDeletesCheckpoint(): void
+    {
+        // Arrange - a broadcast failure must not turn an already-succeeded delete into an error
+        // response describing a state that isn't true (#3941)
+        $this->forceBroadcastFailure();
+
+        $floor          = $this->getFloorWithEnemies();
+        $mappingVersion = $this->getMappingVersionForFloor($floor);
+
+        $enemyForcesCheckpoint = EnemyForcesCheckpoint::create([
+            'mapping_version_id' => $mappingVersion->id,
+            'floor_id'           => $floor->id,
+            'name'               => 'Test corridor',
+            'lat'                => -128.5,
+            'lng'                => 192.5,
+        ]);
+
+        try {
+            // Act
+            $response = $this->delete(sprintf(
+                '/ajax/admin/mappingVersion/%d/enemyforcescheckpoint/%d',
+                $mappingVersion->id,
+                $enemyForcesCheckpoint->id,
+            ));
+
+            // Assert
+            $response->assertSuccessful();
+
+            $this->assertDatabaseMissing('enemy_forces_checkpoints', ['id' => $enemyForcesCheckpoint->id]);
+        } finally {
             EnemyForcesCheckpoint::where('id', $enemyForcesCheckpoint->id)->delete();
         }
     }
@@ -214,6 +294,37 @@ final class AjaxEnemyForcesCheckpointControllerTest extends AjaxPublicTestCase
         // Assert
         $this->assertContains($response->getStatusCode(), [401, 403]);
         $this->assertDatabaseMissing('enemy_forces_checkpoints', ['name' => 'Test corridor']);
+    }
+
+    /**
+     * Swaps the default broadcast connection for one that always throws a BroadcastException,
+     * simulating a Reverb outage without making a real network call.
+     */
+    private function forceBroadcastFailure(): void
+    {
+        Broadcast::extend('failing', static fn() => new class implements Broadcaster {
+            public function auth($request)
+            {
+            }
+
+            public function validAuthenticationResponse($request, $result)
+            {
+            }
+
+            /**
+             * @param  array<int, mixed>    $channels
+             * @param  array<string, mixed> $payload
+             */
+            public function broadcast(array $channels, $event, array $payload = []): void
+            {
+                throw new BroadcastException('Simulated broadcast failure');
+            }
+        });
+
+        config([
+            'broadcasting.connections.failing' => ['driver' => 'failing'],
+            'broadcasting.default'             => 'failing',
+        ]);
     }
 
     private function getFloorWithEnemies(): Floor


### PR DESCRIPTION
:robot: Closes #3941

## Summary

Follow-up to #3940/#3942, which surfaced that `broadcast(new ...Event(...))` failure handling was
inconsistent across ~20 controllers:

1. **Broad-catch (bug)** — `broadcast()` called inside a `try` whose `catch (\Exception)` also
   covers the surrounding mutation. A transient Reverb blip turned an already-successful
   delete/update into a misleading 404 (or, for `store()` inside a `DB::transaction()`, actually
   rolled back the just-saved row).
2. **No catch at all (bug)** — `broadcast()` had no surrounding catch, so a `BroadcastException`
   propagated as an unhandled 500.

Every site is now narrowed to wrap only the `broadcast()` call itself in
`catch (\Illuminate\Broadcasting\BroadcastException)`, matching the one controller
(`AjaxArrowController::store()`) that already did this correctly — including the shared
`AjaxMappingModelBaseController::storeModel()` used by 6 of the `store()` methods.

Note on production impact (raised in cold review): `BroadcastManager::queue()` only calls the
broadcaster inline for `ShouldBroadcastNow` events; every event here is a plain `ShouldBroadcast`,
so in production (`QUEUE_CONNECTION=redis`) `broadcast()` just pushes a job and the actual Reverb
call/`BroadcastException` happens in the Horizon worker, not in the web request. The bug patterns
above are real and this fix is what #3941 asked for, but they can only bite a live request under
`QUEUE_CONNECTION=sync` — today that's `phpunit.xml`. The immediate payoff is correctness in tests
(and #3940's flakiness) plus future-proofing; it doesn't currently prevent a misleading 404/500 in
a production request.

## Files touched

- `app/Http/Controllers/Ajax/AjaxMappingModelBaseController.php` (shared `storeModel()`)
- `app/Http/Controllers/Ajax/AjaxArrowController.php`, `AjaxBrushlineController.php`,
  `AjaxDungeonFloorSwitchMarkerController.php`, `AjaxEnemyController.php`,
  `AjaxEnemyForcesCheckpointController.php`, `AjaxEnemyPackController.php`,
  `AjaxEnemyPatrolController.php`, `AjaxKillZoneController.php` (4 sites),
  `AjaxLiveSessionController.php`, `AjaxMapIconController.php`, `AjaxMountableAreaController.php`,
  `AjaxNpcController.php`, `AjaxOverpulledEnemyController.php` (2 sites),
  `AjaxPathController.php`, `AjaxPridefulEnemyController.php` (2 sites),
  `Ajax/Floor/AjaxFloorUnionAreaController.php`, `Ajax/Floor/AjaxFloorUnionController.php`
- `app/Http/Controllers/LiveSessionController.php`, `NpcController.php`, `ProfileController.php`

## Tests

Added `store_givenBroadcastFails_stillCreatesCheckpoint` and
`delete_givenBroadcastFails_stillDeletesCheckpoint` to `AjaxEnemyForcesCheckpointControllerTest`
(representative of the no-catch `store()` and broad-catch `delete()` patterns respectively). Both
register a fake `failing` broadcast connection whose `broadcast()` always throws
`BroadcastException`, so the test forces a real synchronous broadcast failure without a network
call, and assert the mutation still succeeds.

## Test plan

- [x] `php artisan test --compact tests/Feature/Controller/Ajax` — 110 passed
- [x] `php artisan test --compact` (full suite) — 1969 passed, 1 pre-existing unrelated
      `MapTilesExistenceTest` worktree-env failure (excluded per issue), 1 skipped
- [x] `composer run fix` — clean
- [x] `composer run analyse` — no errors
