### PR TITLE
#3958 Enable combatlog:pollruns scheduled command on production

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -21,6 +21,7 @@ $commands = [];
 $commands[] = Schedule::command('combatlog:detectstaledata')->hourly();
 if (in_array($appType, [
     'staging',
+    'production',
 ])) {
     $commands[] = Schedule::command('combatlog:pollruns')->hourly();
 }


### PR DESCRIPTION
:robot: Closes #3958

## Summary
- Adds `production` to the `appType` allow-list in `routes/console.php` so the hourly `combatlog:pollruns` schedule also runs there, not just on `staging`.

## Test plan
- [x] `composer run fix` clean, no changes
- [x] Green CI

Cold review skipped under the trivial-change rule (1-line config change, no schema/auth/security impact).