### PR TITLE
#3957 Open the NPC Compendium in a new tab on enemy right-click when the flag is enabled

### DIFF
--- a/resources/assets/js/custom/inline/common/maps/map.enemycontextmenu.test.js
+++ b/resources/assets/js/custom/inline/common/maps/map.enemycontextmenu.test.js
@@ -1,0 +1,94 @@
+// #3957: right-clicking an enemy should open its NPC Compendium page in a new tab when the
+// NpcCompendium feature flag is enabled, instead of the `#enemy_details_modal` bootstrap modal.
+//
+// Follows the global-script recipe from map.favorite.test.js: stub the collaborators the class
+// body touches at load time, then require the source.
+
+globalThis.$ = globalThis.jQuery = require('jquery');
+
+const {InlineCode} = require('../../inlinecode');
+globalThis.InlineCode = InlineCode;
+
+globalThis.SettingsTabMap = class SettingsTabMap {
+};
+globalThis.SettingsTabPull = class SettingsTabPull {
+};
+
+const {CommonMapsMap} = require('./map');
+
+describe('CommonMapsMap._onEnemyContextMenu', () => {
+    let visualData;
+    let enemy;
+    let windowOpenSpy;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+
+        visualData = {};
+        enemy = {
+            npc: {id: 123, name: 'Some Npc'},
+            getVisualData: () => visualData,
+        };
+
+        globalThis.getState = vi.fn(() => ({
+            isMapAdmin: () => false,
+        }));
+        globalThis.lang = {get: (key) => key};
+
+        windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => {
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    /**
+     * @param {Object} options
+     * @returns {CommonMapsMap}
+     */
+    function buildMap(options = {}) {
+        return new CommonMapsMap('map', 'common/maps/map', options);
+    }
+
+    it('_onEnemyContextMenu_givenNoEnemyDetailsModalInDom_doesNothing', () => {
+        // Arrange
+        let map = buildMap({npcCompendiumEnabled: true, npcCompendiumBaseUrl: '/compendium/npc'});
+
+        // Act
+        map._onEnemyContextMenu({context: enemy});
+
+        // Assert
+        expect(windowOpenSpy).not.toHaveBeenCalled();
+    });
+
+    it('_onEnemyContextMenu_givenFlagEnabled_opensCompendiumPageInNewTabAndSkipsModal', () => {
+        // Arrange
+        document.body.innerHTML = '<div id="enemy_details_modal"></div>';
+        let map = buildMap({npcCompendiumEnabled: true, npcCompendiumBaseUrl: '/compendium/npc'});
+
+        // Act
+        map._onEnemyContextMenu({context: enemy});
+
+        // Assert
+        expect(windowOpenSpy).toHaveBeenCalledWith('/compendium/npc/123');
+    });
+
+    it('_onEnemyContextMenu_givenFlagDisabled_doesNotOpenNewTab', () => {
+        // Arrange
+        document.body.innerHTML = '<div id="enemy_details_modal"></div><div id="enemy_details_modal_title_text"></div><div id="enemy_details_modal_body"></div>';
+        globalThis.Handlebars = {templates: {map_sidebar_enemy_info_template: () => ''}};
+        globalThis.refreshTooltips = vi.fn();
+        globalThis.bootstrap = {
+            Collapse: {getOrCreateInstance: () => ({hide: vi.fn()})},
+            Modal: {getOrCreateInstance: () => ({show: vi.fn()})},
+        };
+        let map = buildMap({npcCompendiumEnabled: false, npcCompendiumBaseUrl: '/compendium/npc'});
+
+        // Act
+        map._onEnemyContextMenu({context: enemy});
+
+        // Assert
+        expect(windowOpenSpy).not.toHaveBeenCalled();
+    });
+});

--- a/resources/assets/js/custom/inline/common/maps/map.enemycontextmenu.test.js
+++ b/resources/assets/js/custom/inline/common/maps/map.enemycontextmenu.test.js
@@ -20,6 +20,7 @@ describe('CommonMapsMap._onEnemyContextMenu', () => {
     let visualData;
     let enemy;
     let windowOpenSpy;
+    let modalShowSpy;
 
     beforeEach(() => {
         document.body.innerHTML = '';
@@ -35,8 +36,16 @@ describe('CommonMapsMap._onEnemyContextMenu', () => {
         }));
         globalThis.lang = {get: (key) => key};
 
-        windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => {
-        });
+        // Returns a fake Window-like object by default, i.e. the popup was not blocked
+        windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => ({}));
+
+        modalShowSpy = vi.fn();
+        globalThis.Handlebars = {templates: {map_sidebar_enemy_info_template: () => ''}};
+        globalThis.refreshTooltips = vi.fn();
+        globalThis.bootstrap = {
+            Collapse: {getOrCreateInstance: () => ({hide: vi.fn()})},
+            Modal: {getOrCreateInstance: () => ({show: modalShowSpy})},
+        };
     });
 
     afterEach(() => {
@@ -74,15 +83,9 @@ describe('CommonMapsMap._onEnemyContextMenu', () => {
         expect(windowOpenSpy).toHaveBeenCalledWith('/compendium/npc/123');
     });
 
-    it('_onEnemyContextMenu_givenFlagDisabled_doesNotOpenNewTab', () => {
+    it('_onEnemyContextMenu_givenFlagDisabled_doesNotOpenNewTabAndShowsModal', () => {
         // Arrange
         document.body.innerHTML = '<div id="enemy_details_modal"></div><div id="enemy_details_modal_title_text"></div><div id="enemy_details_modal_body"></div>';
-        globalThis.Handlebars = {templates: {map_sidebar_enemy_info_template: () => ''}};
-        globalThis.refreshTooltips = vi.fn();
-        globalThis.bootstrap = {
-            Collapse: {getOrCreateInstance: () => ({hide: vi.fn()})},
-            Modal: {getOrCreateInstance: () => ({show: vi.fn()})},
-        };
         let map = buildMap({npcCompendiumEnabled: false, npcCompendiumBaseUrl: '/compendium/npc'});
 
         // Act
@@ -90,5 +93,20 @@ describe('CommonMapsMap._onEnemyContextMenu', () => {
 
         // Assert
         expect(windowOpenSpy).not.toHaveBeenCalled();
+        expect(modalShowSpy).toHaveBeenCalled();
+    });
+
+    it('_onEnemyContextMenu_givenFlagEnabledButPopupBlocked_fallsBackToModal', () => {
+        // Arrange - a sandboxed embed iframe without allow-popups returns null from window.open()
+        document.body.innerHTML = '<div id="enemy_details_modal"></div><div id="enemy_details_modal_title_text"></div><div id="enemy_details_modal_body"></div>';
+        windowOpenSpy.mockImplementation(() => null);
+        let map = buildMap({npcCompendiumEnabled: true, npcCompendiumBaseUrl: '/compendium/npc'});
+
+        // Act
+        map._onEnemyContextMenu({context: enemy});
+
+        // Assert
+        expect(windowOpenSpy).toHaveBeenCalledWith('/compendium/npc/123');
+        expect(modalShowSpy).toHaveBeenCalled();
     });
 });

--- a/resources/assets/js/custom/inline/common/maps/map.js
+++ b/resources/assets/js/custom/inline/common/maps/map.js
@@ -25,6 +25,8 @@
  * @property {string} tilesBaseUrl
  * @property {Object} parameters
  * @property {number} floorId
+ * @property {boolean} npcCompendiumEnabled
+ * @property {string} npcCompendiumBaseUrl
  */
 
 /**
@@ -577,10 +579,17 @@ class CommonMapsMap extends InlineCode {
         let enemy = enemyContextMenuEvent.context;
         let visualData = enemy.getVisualData();
 
-        // The modal is only rendered on route/explore maps - on e.g. the admin mapping pages this is a no-op
+        // The modal (and the NPC Compendium tab below) is only relevant on route/explore maps -
+        // on e.g. the admin mapping pages this is a no-op
         let enemyDetailsModal = document.getElementById('enemy_details_modal');
 
         if (visualData !== null && enemyDetailsModal !== null) {
+            if (this.options.npcCompendiumEnabled) {
+                // Opened synchronously from the user gesture so popup blockers don't intervene
+                window.open(`${this.options.npcCompendiumBaseUrl}/${enemy.npc.id}`);
+                return;
+            }
+
             let $title = $('#enemy_details_modal_title_text').html(lang.get(enemy.npc.name));
             if (getState().isMapAdmin()) {
                 $title.empty().append(

--- a/resources/assets/js/custom/inline/common/maps/map.js
+++ b/resources/assets/js/custom/inline/common/maps/map.js
@@ -584,9 +584,11 @@ class CommonMapsMap extends InlineCode {
         let enemyDetailsModal = document.getElementById('enemy_details_modal');
 
         if (visualData !== null && enemyDetailsModal !== null) {
-            if (this.options.npcCompendiumEnabled) {
-                // Opened synchronously from the user gesture so popup blockers don't intervene
-                window.open(`${this.options.npcCompendiumBaseUrl}/${enemy.npc.id}`);
+            // Opened synchronously from the user gesture so popup blockers don't intervene. On an
+            // embedded route map this can still run inside a sandboxed iframe without
+            // `allow-popups` - window.open() then returns null, so fall through to the modal
+            // instead of silently doing nothing.
+            if (this.options.npcCompendiumEnabled && window.open(`${this.options.npcCompendiumBaseUrl}/${enemy.npc.id}`) !== null) {
                 return;
             }
 

--- a/resources/views/common/maps/map.blade.php
+++ b/resources/views/common/maps/map.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Features\NpcCompendium;
 use App\Logic\MapContext\MapContextMappingVersionData;
 use App\Logic\MapContext\Map\MapContextBase;
 use App\Logic\MapContext\Map\MapContextDungeonExplore;
@@ -58,6 +59,7 @@ $user?->setRelation('roles', $user->roles->map(fn($role) => $role->makeHidden([
 $headerTitle         ??= null;
 $season              ??= null;
 $isAdmin             = isset($admin) && $admin;
+$npcCompendiumEnabled = Feature::active(NpcCompendium::class);
 $embed               = isset($embed) && $embed;
 $embedStyle          ??= '';
 $edit                = isset($edit) && $edit;
@@ -187,6 +189,8 @@ if ($isAdmin) {
     'tilesBaseUrl' => $tilesBaseUrl,
     'parameters' => $parameters,
     'floorId' => $floor->id,
+    'npcCompendiumEnabled' => $npcCompendiumEnabled,
+    'npcCompendiumBaseUrl' => url('/compendium/npc'),
 ], $adminOptions)])
 
 @section('scripts')

--- a/tests/Feature/Controller/DungeonRoute/DungeonRouteViewNpcCompendiumFlagTest.php
+++ b/tests/Feature/Controller/DungeonRoute/DungeonRouteViewNpcCompendiumFlagTest.php
@@ -40,7 +40,7 @@ final class DungeonRouteViewNpcCompendiumFlagTest extends PublicTestCase
             $response->assertSee('"npcCompendiumEnabled":true', false);
             $response->assertSee(
                 '"npcCompendiumBaseUrl":"' . str_replace('/', '\/', url('/compendium/npc')),
-                false
+                false,
             );
         } finally {
             $route->delete();

--- a/tests/Feature/Controller/DungeonRoute/DungeonRouteViewNpcCompendiumFlagTest.php
+++ b/tests/Feature/Controller/DungeonRoute/DungeonRouteViewNpcCompendiumFlagTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Controller\DungeonRoute;
+
+use App\Features\NpcCompendium;
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\PublishedState;
+use App\Models\User;
+use Laravel\Pennant\Feature;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * #3957: right-clicking an enemy on a route/explore map should open its NPC Compendium page in a
+ * new tab when the NpcCompendium feature flag is enabled, instead of the enemy details modal. The
+ * map JS reads this off the `npcCompendiumEnabled`/`npcCompendiumBaseUrl` inline options, which
+ * only the real Blade render can prove are wired up correctly.
+ */
+#[Group('Controller')]
+#[Group('DungeonRoute')]
+final class DungeonRouteViewNpcCompendiumFlagTest extends PublicTestCase
+{
+    #[Test]
+    public function view_givenFeatureEnabled_exposesNpcCompendiumOptionsToMapJs(): void
+    {
+        // Arrange
+        $owner = User::factory()->create();
+        $route = $this->createRoute($owner);
+        Feature::define(NpcCompendium::class, true);
+
+        try {
+            $this->be($owner);
+
+            // Act
+            $response = $this->followingRedirects()->get($this->viewUrl($route));
+
+            // Assert
+            $response->assertOk();
+            $response->assertSee('"npcCompendiumEnabled":true', false);
+            $response->assertSee(
+                '"npcCompendiumBaseUrl":"' . str_replace('/', '\/', url('/compendium/npc')),
+                false
+            );
+        } finally {
+            $route->delete();
+            $owner->delete();
+        }
+    }
+
+    #[Test]
+    public function view_givenFeatureDisabled_exposesDisabledNpcCompendiumOption(): void
+    {
+        // Arrange
+        $owner = User::factory()->create();
+        $route = $this->createRoute($owner);
+        Feature::define(NpcCompendium::class, false);
+
+        try {
+            $this->be($owner);
+
+            // Act
+            $response = $this->followingRedirects()->get($this->viewUrl($route));
+
+            // Assert
+            $response->assertOk();
+            $response->assertSee('"npcCompendiumEnabled":false', false);
+        } finally {
+            $route->delete();
+            $owner->delete();
+        }
+    }
+
+    /**
+     * A published, non-sandbox route owned by $owner. Sandbox routes (which the factory creates by
+     * default) are editable by anyone, so expires_at must be null here. The view page is public, so
+     * plain factory users suffice - no role is needed to reach it.
+     */
+    private function createRoute(User $owner): DungeonRoute
+    {
+        return DungeonRoute::factory()->create([
+            'author_id'          => $owner->id,
+            'expires_at'         => null,
+            'published_state_id' => PublishedState::ALL[PublishedState::WORLD],
+        ]);
+    }
+
+    /**
+     * dungeonroute.view always redirects to the default floor, so tests follow redirects.
+     */
+    private function viewUrl(DungeonRoute $route): string
+    {
+        return route('dungeonroute.view', [
+            'dungeon'      => $route->dungeon,
+            'dungeonroute' => $route,
+            'title'        => $route->getTitleSlug(),
+        ]);
+    }
+}


### PR DESCRIPTION
:robot: Closes #3957

## Summary
- Right-clicking an enemy on a route/explore map now opens that NPC's Compendium page (`/compendium/npc/{id}`) in a new tab when the `NpcCompendium` Pennant flag is active for the current user, instead of the `#enemy_details_modal`.
- Flag off: unchanged modal behaviour.
- Admin mapping pages: unchanged (still a no-op) — the modal/compendium-tab logic is gated on `#enemy_details_modal` existing in the DOM, which only route/explore maps render (`MapContextDungeonRoute`/`MapContextDungeonExplore`). Decided against opening the compendium tab there since right-click currently does nothing on admin maps and admins are there for mapping work, not to view NPC details.
- Shift+right-click raid marker menu is untouched — it's handled earlier in `enemy.js` and returns before the `enemy:contextmenu` signal fires.
- The flag state and compendium base URL reach the client via new `npcCompendiumEnabled`/`npcCompendiumBaseUrl` inline options on `common/maps/map.blade.php`, following the same pattern as `spellShowBaseUrl` in `compendium/npc/index.blade.php`.
- The tab is opened synchronously from the contextmenu handler (`window.open` directly, no async hop) so popup blockers don't intervene.
- No slugification needed client-side — the bare `/compendium/npc/{id}` route resolves and 301-redirects to the canonical `{id}-{slug}` URL.

## Test plan
- [x] New JS test: `resources/assets/js/custom/inline/common/maps/map.enemycontextmenu.test.js` — flag enabled opens the tab and skips the modal, flag disabled falls through to the modal, and no-op when `#enemy_details_modal` isn't in the DOM (admin pages).
- [x] New feature test: `tests/Feature/Controller/DungeonRoute/DungeonRouteViewNpcCompendiumFlagTest.php` — asserts the real Blade render exposes the correct `npcCompendiumEnabled`/`npcCompendiumBaseUrl` options for both flag states.
- [x] Full JS suite green (`npx vitest run resources/assets/js/custom`).
- [x] `composer run fix` / `composer run analyse` clean.
- [x] Backend-only/JS-behaviour change, no rendered-output/visual change — screenshot verification skipped.