### PR TITLE
#3963 Run the combat_log_parse_failures drop migration on combatlog_migrate

### DIFF
--- a/database/migrations_combatlog/2026_08_06_000001_drop_combat_log_parse_failures_table.php
+++ b/database/migrations_combatlog/2026_08_06_000001_drop_combat_log_parse_failures_table.php
@@ -5,7 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
-    protected $connection = 'combatlog';
+    protected $connection = 'combatlog_migrate';
 
     public function up(): void
     {

--- a/tests/Feature/Database/Migrations/DropCombatLogParseFailuresTableTest.php
+++ b/tests/Feature/Database/Migrations/DropCombatLogParseFailuresTableTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Database\Migrations;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+/**
+ * The runtime `combatlog` connection is least-privilege and lacks DROP - only the elevated
+ * `combatlog_migrate` connection may run this migration, see #3963.
+ */
+#[Group('CombatLog')]
+final class DropCombatLogParseFailuresTableTest extends PublicTestCase
+{
+    private const MIGRATION = 'migrations_combatlog/2026_08_06_000001_drop_combat_log_parse_failures_table.php';
+
+    #[Test]
+    public function migration_usesTheElevatedCombatlogMigrateConnection(): void
+    {
+        // Arrange
+        // Act
+        $migration = require database_path(self::MIGRATION);
+
+        // Assert
+        $this->assertSame('combatlog_migrate', $migration->getConnection());
+    }
+}

--- a/tests/Feature/Database/Migrations/DropCombatLogParseFailuresTableTest.php
+++ b/tests/Feature/Database/Migrations/DropCombatLogParseFailuresTableTest.php
@@ -16,7 +16,7 @@ final class DropCombatLogParseFailuresTableTest extends PublicTestCase
     private const MIGRATION = 'migrations_combatlog/2026_08_06_000001_drop_combat_log_parse_failures_table.php';
 
     #[Test]
-    public function migration_usesTheElevatedCombatlogMigrateConnection(): void
+    public function getConnection_givenTheMigration_returnsAConfiguredElevatedConnection(): void
     {
         // Arrange
         // Act
@@ -24,5 +24,10 @@ final class DropCombatLogParseFailuresTableTest extends PublicTestCase
 
         // Assert
         $this->assertSame('combatlog_migrate', $migration->getConnection());
+        $this->assertArrayHasKey(
+            $migration->getConnection(),
+            config('database.connections'),
+            'The migration points at a connection that no longer exists in config/database.php.',
+        );
     }
 }


### PR DESCRIPTION
:robot: Closes #3963

## Summary
- The `combat_log_parse_failures` drop migration hardcoded `protected $connection = 'combatlog'` — the least-privilege runtime connection — instead of the elevated `combatlog_migrate` connection that `config/database.php` defines specifically for privileged schema changes.
- The runtime combatlog DB user lacks DROP grant, so this migration has been failing on every staging migrate attempt since #3822 merged it (present since v15.10.0). Sentry: PHP-LARAVEL-SJ.
- Already hotfixed onto the deployed v15.10.2 tag (S3 hotfix overlay + staging redeploy); this PR lands the same one-line fix on master so the next real release contains it.

## Test plan
- [x] Added `DropCombatLogParseFailuresTableTest` asserting the migration's connection, proved RED before the fix / GREEN after
- [x] `composer run fix` / `composer run analyse` clean
- [x] CI green