### PR TITLE
#3968 Scope the Compendium by dungeon: /compendium/dungeon/{dungeon}/{section}

### DIFF
--- a/app/Http/Controllers/Compendium/ClassCompendiumController.php
+++ b/app/Http/Controllers/Compendium/ClassCompendiumController.php
@@ -50,7 +50,11 @@ class ClassCompendiumController extends Controller
         ]);
     }
 
-    public function showDungeon(CharacterClass $characterClass, Dungeon $dungeon, DungeonServiceInterface $dungeonService): View
+    /**
+     * Parameters follow the URL's order (/compendium/dungeon/{dungeon}/class/{characterClass}) - a
+     * route registered with first-class callable syntax binds them positionally, not by name.
+     */
+    public function showDungeon(Dungeon $dungeon, CharacterClass $characterClass, DungeonServiceInterface $dungeonService): View
     {
         // The URL is the source of truth for which dungeon is being viewed - make it the context
         // dungeon as well, so the header's dungeon selection follows along (as on explore/heatmap)

--- a/app/Http/Controllers/Compendium/ClassCompendiumController.php
+++ b/app/Http/Controllers/Compendium/ClassCompendiumController.php
@@ -10,7 +10,10 @@ use App\Models\Npc\Npc;
 use App\Models\Spell\Spell;
 use App\Service\CombatLog\DataExtractors\SpellCounters\SpellCounterDefinitionInterface;
 use App\Service\CombatLog\DataExtractors\SpellCounters\SpellCounterDefinitions;
+use App\Service\Dungeon\DungeonServiceInterface;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 
 class ClassCompendiumController extends Controller
@@ -32,9 +35,27 @@ class ClassCompendiumController extends Controller
         ]);
     }
 
-    public function show(CharacterClass $characterClass): View
+    /**
+     * The class page without a dungeon in the URL - bounces to the canonical URL of the visitor's
+     * context dungeon.
+     *
+     * Deliberately a 302: the target depends on the visitor's own context dungeon, so a permanent
+     * redirect would get cached and pin one dungeon into every later visit.
+     */
+    public function show(CharacterClass $characterClass): RedirectResponse
     {
-        $dungeon        = Dungeon::getUserOrDefaultDungeon();
+        return redirect()->route('compendium.class.show.dungeon', [
+            'characterClass' => $characterClass,
+            'dungeon'        => Dungeon::getUserOrDefaultDungeon(),
+        ]);
+    }
+
+    public function showDungeon(CharacterClass $characterClass, Dungeon $dungeon, DungeonServiceInterface $dungeonService): View
+    {
+        // The URL is the source of truth for which dungeon is being viewed - make it the context
+        // dungeon as well, so the header's dungeon selection follows along (as on explore/heatmap)
+        $dungeonService->setDungeonContext($dungeon, Auth::user());
+
         $mappingVersion = $dungeon->getCurrentMappingVersion();
 
         $spells = Spell::query()
@@ -71,6 +92,9 @@ class ClassCompendiumController extends Controller
             'npcsByCharacteristicId' => $npcsByCharacteristicId,
             'counterSections'        => $this->getCounterSections($characterClass, $dungeon, $mappingVersion),
             'reflectSection'         => $this->getReflectSection($characterClass, $dungeon, $mappingVersion),
+            // HeaderComposer only injects this into the header view itself - the dungeon context
+            // links this page overrides are built in the view, so it needs its own copy
+            'gameVersionDungeons' => $dungeonService->getDungeonsForGameVersion(),
         ]);
     }
 

--- a/app/Http/Controllers/Compendium/NpcCompendiumController.php
+++ b/app/Http/Controllers/Compendium/NpcCompendiumController.php
@@ -89,21 +89,6 @@ class NpcCompendiumController extends Controller
         return redirect()->route('compendium.activity', ['dungeon' => $dungeon]);
     }
 
-    /**
-     * The activity pages used to hang off /compendium/activity/{dungeon}, before the dungeon moved to
-     * the front of the path. A 301 is right here where it is wrong for the context-dungeon
-     * redirects: this target is derived purely from the URL, so it is the same for every visitor.
-     */
-    public function activityLegacy(Dungeon $dungeon): RedirectResponse
-    {
-        return redirect(route('compendium.activity', ['dungeon' => $dungeon]), 301);
-    }
-
-    public function activityDayLegacy(Dungeon $dungeon, string $date): RedirectResponse
-    {
-        return redirect(route('compendium.activity.day', ['dungeon' => $dungeon, 'date' => $date]), 301);
-    }
-
     public function activity(
         Dungeon                       $dungeon,
         SeasonServiceInterface        $seasonService,

--- a/app/Http/Controllers/Compendium/NpcCompendiumController.php
+++ b/app/Http/Controllers/Compendium/NpcCompendiumController.php
@@ -137,9 +137,10 @@ class NpcCompendiumController extends Controller
             abort(404);
         }
 
-        // The URL is the source of truth for which dungeon is being viewed - make it the context
-        // dungeon as well, so the header's dungeon selection follows along (as on explore/heatmap)
-        $dungeonService->setDungeonContext($dungeon, Auth::user());
+        // Deliberately no setDungeonContext() here, unlike every other dungeon-in-the-URL page: only
+        // pages that validate their dungeon write the site-wide context, and this one does not.
+        // activity() one route up rejects any dungeon outside the current season, so persisting one
+        // from here would leave the visitor with a context its own overview refuses to show.
 
         return view('compendium.activity.day', [
             'contextDungeon'      => $dungeon,

--- a/app/Http/Controllers/Compendium/NpcCompendiumController.php
+++ b/app/Http/Controllers/Compendium/NpcCompendiumController.php
@@ -13,20 +13,46 @@ use App\Models\GameVersion\GameVersion;
 use App\Models\Npc\Npc;
 use App\Models\Npc\NpcHealth;
 use App\Service\Compendium\NpcCompendiumServiceInterface;
+use App\Service\Dungeon\DungeonServiceInterface;
 use App\Service\Season\SeasonServiceInterface;
 use Exception;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 
 class NpcCompendiumController extends Controller
 {
-    public function index(): View
+    /**
+     * The NPC index without a dungeon in the URL - bounces to the canonical URL of the visitor's
+     * context dungeon.
+     *
+     * Deliberately a 302: the target depends on the visitor's own context dungeon, so a permanent
+     * redirect would get cached and pin one dungeon into every later visit.
+     */
+    public function index(): RedirectResponse
     {
+        return redirect()->route('npc.compendium.index.dungeon', [
+            'dungeon' => Dungeon::getUserOrDefaultDungeon(),
+        ]);
+    }
+
+    public function indexDungeon(Dungeon $dungeon, DungeonServiceInterface $dungeonService): View
+    {
+        // The URL is the source of truth for which dungeon is being viewed - make it the context
+        // dungeon as well, so the header's dungeon selection follows along (as on explore/heatmap)
+        $dungeonService->setDungeonContext($dungeon, Auth::user());
+
         return view('compendium.npc.index', [
-            'contextDungeon' => Dungeon::getUserOrDefaultDungeon(),
+            'contextDungeon' => $dungeon,
+            // HeaderComposer only injects this into the header view itself - the dungeon context
+            // links this page overrides are built in the view, so it needs its own copy
+            'gameVersionDungeons' => $dungeonService->getDungeonsForGameVersion(),
+            // The dungeon filter's options are dungeon ids; navigating to another dungeon's page
+            // needs their slugs
+            'dungeonSlugsById' => Dungeon::query()->pluck('slug', 'id'),
         ]);
     }
 
@@ -67,6 +93,7 @@ class NpcCompendiumController extends Controller
         Dungeon                       $dungeon,
         SeasonServiceInterface        $seasonService,
         NpcCompendiumServiceInterface $npcCompendiumService,
+        DungeonServiceInterface       $dungeonService,
     ): View|RedirectResponse {
         $contextDungeon = $this->getContextDungeonOrDefault($seasonService, $dungeon);
         if ($contextDungeon === null) {
@@ -74,6 +101,10 @@ class NpcCompendiumController extends Controller
         } elseif ($contextDungeon->id !== $dungeon->id) {
             return redirect()->route('compendium.activity', ['dungeon' => $contextDungeon]);
         }
+
+        // The URL is the source of truth for which dungeon is being viewed - make it the context
+        // dungeon as well, so the header's dungeon selection follows along (as on explore/heatmap)
+        $dungeonService->setDungeonContext($dungeon, Auth::user());
 
         $dates       = $npcCompendiumService->getActivityDates(10, $dungeon);
         $eventsByDay = [];
@@ -83,14 +114,19 @@ class NpcCompendiumController extends Controller
         }
 
         return view('compendium.activity.index', [
-            'contextDungeon' => $dungeon,
-            'dates'          => $dates,
-            'eventsByDay'    => $eventsByDay,
+            'contextDungeon'      => $dungeon,
+            'dates'               => $dates,
+            'eventsByDay'         => $eventsByDay,
+            'gameVersionDungeons' => $dungeonService->getDungeonsForGameVersion(),
         ]);
     }
 
-    public function activityDay(Dungeon $dungeon, string $date, NpcCompendiumServiceInterface $npcCompendiumService): View
-    {
+    public function activityDay(
+        Dungeon                       $dungeon,
+        string                        $date,
+        NpcCompendiumServiceInterface $npcCompendiumService,
+        DungeonServiceInterface       $dungeonService,
+    ): View {
         try {
             $carbon = Carbon::createFromFormat('Y-m-d', $date);
         } catch (Exception) {
@@ -101,10 +137,15 @@ class NpcCompendiumController extends Controller
             abort(404);
         }
 
+        // The URL is the source of truth for which dungeon is being viewed - make it the context
+        // dungeon as well, so the header's dungeon selection follows along (as on explore/heatmap)
+        $dungeonService->setDungeonContext($dungeon, Auth::user());
+
         return view('compendium.activity.day', [
-            'contextDungeon' => $dungeon,
-            'date'           => $carbon,
-            'events'         => $npcCompendiumService->getEventsForDate($carbon, $dungeon),
+            'contextDungeon'      => $dungeon,
+            'date'                => $carbon,
+            'events'              => $npcCompendiumService->getEventsForDate($carbon, $dungeon),
+            'gameVersionDungeons' => $dungeonService->getDungeonsForGameVersion(),
         ]);
     }
 

--- a/app/Http/Controllers/Compendium/NpcCompendiumController.php
+++ b/app/Http/Controllers/Compendium/NpcCompendiumController.php
@@ -89,6 +89,21 @@ class NpcCompendiumController extends Controller
         return redirect()->route('compendium.activity', ['dungeon' => $dungeon]);
     }
 
+    /**
+     * The activity pages used to hang off /compendium/activity/{dungeon}, before the dungeon moved to
+     * the front of the path. A 301 is right here where it is wrong for the context-dungeon
+     * redirects: this target is derived purely from the URL, so it is the same for every visitor.
+     */
+    public function activityLegacy(Dungeon $dungeon): RedirectResponse
+    {
+        return redirect(route('compendium.activity', ['dungeon' => $dungeon]), 301);
+    }
+
+    public function activityDayLegacy(Dungeon $dungeon, string $date): RedirectResponse
+    {
+        return redirect(route('compendium.activity.day', ['dungeon' => $dungeon, 'date' => $date]), 301);
+    }
+
     public function activity(
         Dungeon                       $dungeon,
         SeasonServiceInterface        $seasonService,

--- a/app/Http/Controllers/Compendium/SpellCompendiumController.php
+++ b/app/Http/Controllers/Compendium/SpellCompendiumController.php
@@ -10,17 +10,43 @@ use App\Logic\Datatables\SpellsDatatablesHandler;
 use App\Models\Dungeon;
 use App\Models\Spell\Spell;
 use App\Service\Compendium\SpellCompendiumServiceInterface;
+use App\Service\Dungeon\DungeonServiceInterface;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 
 class SpellCompendiumController extends Controller
 {
-    public function index(): View
+    /**
+     * The spell index without a dungeon in the URL - bounces to the canonical URL of the visitor's
+     * context dungeon.
+     *
+     * Deliberately a 302: the target depends on the visitor's own context dungeon, so a permanent
+     * redirect would get cached and pin one dungeon into every later visit.
+     */
+    public function index(): RedirectResponse
     {
+        return redirect()->route('spell.compendium.index.dungeon', [
+            'dungeon' => Dungeon::getUserOrDefaultDungeon(),
+        ]);
+    }
+
+    public function indexDungeon(Dungeon $dungeon, DungeonServiceInterface $dungeonService): View
+    {
+        // The URL is the source of truth for which dungeon is being viewed - make it the context
+        // dungeon as well, so the header's dungeon selection follows along (as on explore/heatmap)
+        $dungeonService->setDungeonContext($dungeon, Auth::user());
+
         return view('compendium.spell.index', [
-            'contextDungeon' => Dungeon::getUserOrDefaultDungeon(),
+            'contextDungeon' => $dungeon,
+            // HeaderComposer only injects this into the header view itself - the dungeon context
+            // links this page overrides are built in the view, so it needs its own copy
+            'gameVersionDungeons' => $dungeonService->getDungeonsForGameVersion(),
+            // The dungeon filter's options are dungeon ids; navigating to another dungeon's page
+            // needs their slugs
+            'dungeonSlugsById' => Dungeon::query()->pluck('slug', 'id'),
         ]);
     }
 

--- a/resources/views/common/layout/header.blade.php
+++ b/resources/views/common/layout/header.blade.php
@@ -198,12 +198,16 @@ $isActiveRoute = function (string $route, bool $strict = false) {
 
                 @if(Feature::active(NpcCompendium::class))
                         <?php
-                        $compendiumRoutes       = [
-                            route('compendium.index')          => sprintf('%s %s', '<i class="fas fa-book-open"></i>', __('view_common.layout.header.compendium_overview')),
-                            route('npc.compendium.index')      => sprintf('%s %s', '<i class="fas fa-dragon"></i>', __('view_common.layout.header.npc_compendium')),
-                            route('spell.compendium.index')    => sprintf('%s %s', '<i class="fas fa-magic"></i>', __('view_common.layout.header.spell_compendium')),
-                            route('compendium.activity.index') => sprintf('%s %s', '<i class="fas fa-stream"></i>', __('view_common.layout.header.compendium_activity')),
-                            route('compendium.class.index')    => sprintf('%s %s', '<i class="fas fa-hat-wizard"></i>', __('view_common.layout.header.class_compendium')),
+                        // Link straight to the dungeon-scoped canonical routes rather than the bare
+                        // (no dungeon) endpoints - those still exist for backward-compatible bookmarks,
+                        // but internal navigation shouldn't pay for their extra 302 redirect hop.
+                        $compendiumContextDungeon = Dungeon::getUserOrDefaultDungeon();
+                        $compendiumRoutes         = [
+                            route('compendium.index')                                                      => sprintf('%s %s', '<i class="fas fa-book-open"></i>', __('view_common.layout.header.compendium_overview')),
+                            route('npc.compendium.index.dungeon', ['dungeon' => $compendiumContextDungeon])   => sprintf('%s %s', '<i class="fas fa-dragon"></i>', __('view_common.layout.header.npc_compendium')),
+                            route('spell.compendium.index.dungeon', ['dungeon' => $compendiumContextDungeon]) => sprintf('%s %s', '<i class="fas fa-magic"></i>', __('view_common.layout.header.spell_compendium')),
+                            route('compendium.activity.index')                                               => sprintf('%s %s', '<i class="fas fa-stream"></i>', __('view_common.layout.header.compendium_activity')),
+                            route('compendium.class.index')                                                  => sprintf('%s %s', '<i class="fas fa-hat-wizard"></i>', __('view_common.layout.header.class_compendium')),
                         ];
                         $hasCompendiumSubActive = null;
                         $compendiumHeaderText   = __('view_common.layout.header.compendium');

--- a/resources/views/common/layout/header.blade.php
+++ b/resources/views/common/layout/header.blade.php
@@ -198,9 +198,6 @@ $isActiveRoute = function (string $route, bool $strict = false) {
 
                 @if(Feature::active(NpcCompendium::class))
                         <?php
-                        // Link straight to the dungeon-scoped canonical routes rather than the bare
-                        // (no dungeon) endpoints - those still exist for backward-compatible bookmarks,
-                        // but internal navigation shouldn't pay for their extra 302 redirect hop.
                         $compendiumContextDungeon = Dungeon::getUserOrDefaultDungeon();
                         $compendiumRoutes         = [
                             route('compendium.index')                                                      => sprintf('%s %s', '<i class="fas fa-book-open"></i>', __('view_common.layout.header.compendium_overview')),

--- a/resources/views/compendium/activity/day.blade.php
+++ b/resources/views/compendium/activity/day.blade.php
@@ -10,11 +10,16 @@ use Illuminate\Support\Collection;
  * @var Dungeon                                                $contextDungeon
  * @var Carbon                                                 $date
  * @var Collection<int, CombatLogNpcEvent|CombatLogSpellEvent> $events
+ * @var Collection<int, Dungeon>                               $gameVersionDungeons
  */
 ?>
 @extends('layouts.sitepage', [
     'breadcrumbsParams' => [$contextDungeon, $date],
     'title'             => __('view_compendium.activity.day.title', ['date' => $date->format('F j, Y')]),
+    // To that dungeon's activity overview - the same day does not necessarily exist for it
+    'dungeonContextLinks' => $gameVersionDungeons->mapWithKeys(fn (Dungeon $dungeon) => [
+        $dungeon->key => route('compendium.activity', ['dungeon' => $dungeon])
+    ]),
 ])
 
 @section('header-title')

--- a/resources/views/compendium/activity/index.blade.php
+++ b/resources/views/compendium/activity/index.blade.php
@@ -11,11 +11,15 @@ use Illuminate\Support\Collection;
  * @var Dungeon                                                               $contextDungeon
  * @var LengthAwarePaginator<int, string>                                     $dates
  * @var array<string, Collection<int, CombatLogNpcEvent|CombatLogSpellEvent>> $eventsByDay
+ * @var Collection<int, Dungeon>                                              $gameVersionDungeons
  */
 ?>
 @extends('layouts.sitepage', [
     'breadcrumbsParams' => [$contextDungeon],
     'title'             => __('view_compendium.activity.index.title'),
+    'dungeonContextLinks' => $gameVersionDungeons->mapWithKeys(fn (Dungeon $dungeon) => [
+        $dungeon->key => route('compendium.activity', ['dungeon' => $dungeon])
+    ]),
 ])
 
 @section('header-title')

--- a/resources/views/compendium/class/index.blade.php
+++ b/resources/views/compendium/class/index.blade.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Collection;
  * @var Collection<int, CharacterClass> $characterClasses
  */
 
-// Link straight to the dungeon-scoped canonical route rather than the bare (no dungeon) endpoint -
-// that still exists for backward-compatible bookmarks, but internal navigation shouldn't pay for
-// its extra 302 redirect hop.
 $contextDungeon = Dungeon::getUserOrDefaultDungeon();
 ?>
 @extends('layouts.sitepage', ['title' => __('view_compendium.class.index.title')])

--- a/resources/views/compendium/class/index.blade.php
+++ b/resources/views/compendium/class/index.blade.php
@@ -1,11 +1,17 @@
 <?php
 
 use App\Models\CharacterClass;
+use App\Models\Dungeon;
 use Illuminate\Support\Collection;
 
 /**
  * @var Collection<int, CharacterClass> $characterClasses
  */
+
+// Link straight to the dungeon-scoped canonical route rather than the bare (no dungeon) endpoint -
+// that still exists for backward-compatible bookmarks, but internal navigation shouldn't pay for
+// its extra 302 redirect hop.
+$contextDungeon = Dungeon::getUserOrDefaultDungeon();
 ?>
 @extends('layouts.sitepage', ['title' => __('view_compendium.class.index.title')])
 
@@ -18,7 +24,7 @@ use Illuminate\Support\Collection;
         @foreach($characterClasses as $characterClass)
             <?php /** @var CharacterClass $characterClass */ ?>
             <div class="col-6 col-sm-4 col-md-3 col-lg-2 mb-3">
-                <a href="{{ route('compendium.class.show', $characterClass) }}" class="compendium_class_tile">
+                <a href="{{ route('compendium.class.show.dungeon', ['dungeon' => $contextDungeon, 'characterClass' => $characterClass]) }}" class="compendium_class_tile">
                     <img src="{{ $characterClass->icon_url }}"
                          width="48" height="48"
                          alt="{{ __($characterClass->name) }}"

--- a/resources/views/compendium/class/show.blade.php
+++ b/resources/views/compendium/class/show.blade.php
@@ -23,12 +23,19 @@ use Illuminate\Support\Collection;
  *     spells: Collection<int, Spell>,
  *     npcsBySpellId: Collection<int, Collection<int, Npc>>,
  * }|null $reflectSection
+ * @var Collection<int, Dungeon> $gameVersionDungeons
  */
 ?>
 @extends('layouts.sitepage', [
     'breadcrumbs'       => 'compendium.class.show',
     'breadcrumbsParams' => [$characterClass, $contextDungeon],
     'title'             => __('view_compendium.class.show.title', ['name' => __($characterClass->name)]),
+    'dungeonContextLinks' => $gameVersionDungeons->mapWithKeys(fn (Dungeon $dungeon) => [
+        $dungeon->key => route('compendium.class.show.dungeon', [
+            'characterClass' => $characterClass,
+            'dungeon' => $dungeon,
+        ])
+    ]),
 ])
 
 @section('content')

--- a/resources/views/compendium/index.blade.php
+++ b/resources/views/compendium/index.blade.php
@@ -6,9 +6,6 @@ use App\Models\Dungeon;
  * @var array{npc: int, spell: int, class: int} $stats
  */
 
-// Link straight to the dungeon-scoped canonical routes rather than the bare (no dungeon) endpoints -
-// those still exist for backward-compatible bookmarks, but internal navigation shouldn't pay for
-// their extra 302 redirect hop.
 $contextDungeon = Dungeon::getUserOrDefaultDungeon();
 
 $sections = [

--- a/resources/views/compendium/index.blade.php
+++ b/resources/views/compendium/index.blade.php
@@ -1,8 +1,15 @@
 <?php
 
+use App\Models\Dungeon;
+
 /**
  * @var array{npc: int, spell: int, class: int} $stats
  */
+
+// Link straight to the dungeon-scoped canonical routes rather than the bare (no dungeon) endpoints -
+// those still exist for backward-compatible bookmarks, but internal navigation shouldn't pay for
+// their extra 302 redirect hop.
+$contextDungeon = Dungeon::getUserOrDefaultDungeon();
 
 $sections = [
     [
@@ -10,7 +17,7 @@ $sections = [
         'title'    => __('view_compendium.index.cards.npc.title'),
         'text'     => __('view_compendium.index.cards.npc.description'),
         'cta'      => __('view_compendium.index.cards.npc.cta'),
-        'route'    => route('npc.compendium.index'),
+        'route'    => route('npc.compendium.index.dungeon', ['dungeon' => $contextDungeon]),
         'subtitle' => sprintf('%s %s', number_format($stats['npc']), __('view_compendium.index.cards.npc.count_suffix')),
     ],
     [
@@ -18,7 +25,7 @@ $sections = [
         'title'    => __('view_compendium.index.cards.spell.title'),
         'text'     => __('view_compendium.index.cards.spell.description'),
         'cta'      => __('view_compendium.index.cards.spell.cta'),
-        'route'    => route('spell.compendium.index'),
+        'route'    => route('spell.compendium.index.dungeon', ['dungeon' => $contextDungeon]),
         'subtitle' => sprintf('%s %s', number_format($stats['spell']), __('view_compendium.index.cards.spell.count_suffix')),
     ],
     [

--- a/resources/views/compendium/npc/index.blade.php
+++ b/resources/views/compendium/npc/index.blade.php
@@ -122,13 +122,13 @@ use Illuminate\Support\Collection;
             // hold something that is not a dungeon id (the select can emit season/expansion
             // options), fall back to just reloading the table.
             const dungeonSlugsById = @json($dungeonSlugsById);
-            const dungeonIndexBaseUrl = '{{ url('/compendium/npc/dungeon') }}';
+            const dungeonBaseUrl = '{{ url('/compendium/dungeon') }}';
 
             $('#compendium_filter_dungeon').on('change', function () {
                 const dungeonSlug = dungeonSlugsById[$(this).val()];
 
                 if (dungeonSlug) {
-                    window.location.href = `${dungeonIndexBaseUrl}/${dungeonSlug}`;
+                    window.location.href = `${dungeonBaseUrl}/${dungeonSlug}/npc`;
                 } else {
                     table.ajax.reload();
                 }

--- a/resources/views/compendium/npc/index.blade.php
+++ b/resources/views/compendium/npc/index.blade.php
@@ -2,12 +2,20 @@
 
 use App\Models\Dungeon;
 use App\Models\Npc\NpcClassification;
+use Illuminate\Support\Collection;
 
 /**
- * @var Dungeon $contextDungeon
+ * @var Dungeon                  $contextDungeon
+ * @var Collection<int, Dungeon> $gameVersionDungeons
+ * @var Collection<int, string>  $dungeonSlugsById
  */
 ?>
-@extends('layouts.sitepage', ['title' => __('view_compendium.npc.index.title')])
+@extends('layouts.sitepage', [
+    'title' => __('view_compendium.npc.index.title'),
+    'dungeonContextLinks' => $gameVersionDungeons->mapWithKeys(fn (Dungeon $dungeon) => [
+        $dungeon->key => route('npc.compendium.index.dungeon', ['dungeon' => $dungeon])
+    ]),
+])
 
 @section('header-title')
     {{ __('view_compendium.npc.index.header') }}
@@ -104,8 +112,21 @@ use App\Models\Npc\NpcClassification;
                 }),
             });
 
+            // The dungeon is part of the URL, so picking another one navigates to that dungeon's
+            // page - that keeps the URL, the header's dungeon selection and the dungeon context in
+            // sync. Should the selection ever hold something that is not a dungeon id (the select
+            // can emit season/expansion options), fall back to just reloading the table.
+            const dungeonSlugsById = @json($dungeonSlugsById);
+            const dungeonIndexBaseUrl = '{{ url('/compendium/npc/dungeon') }}';
+
             $('#compendium_filter_dungeon').on('change', function () {
-                table.ajax.reload();
+                const dungeonSlug = dungeonSlugsById[$(this).val()];
+
+                if (dungeonSlug) {
+                    window.location.href = `${dungeonIndexBaseUrl}/${dungeonSlug}`;
+                } else {
+                    table.ajax.reload();
+                }
             });
         });
     </script>

--- a/resources/views/compendium/npc/index.blade.php
+++ b/resources/views/compendium/npc/index.blade.php
@@ -37,6 +37,11 @@ use Illuminate\Support\Collection;
             const spellShowBaseUrl = '{{ url('/compendium/spell') }}';
             const npcTemplate = Handlebars.templates['npc'];
             const spellTemplate = Handlebars.templates['spell_template'];
+            // The dungeon in the URL is what this page is about; the filter below is only a way to
+            // navigate to another dungeon's page. Reading the table's dungeon off the select instead
+            // would list a different dungeon whenever the select does not offer this one - it only
+            // lists dungeons mapped for the visitor's game version, which the URL is not bound by.
+            const contextDungeonId = {{ $contextDungeon->id }};
 
             const table = $('#compendium_npc_table').DataTable({
                 'processing': true,
@@ -46,7 +51,7 @@ use Illuminate\Support\Collection;
                 'ajax': {
                     'url': '{{ route('ajax.npc.compendium.search') }}',
                     'data': function (d) {
-                        d.dungeon_id = $('#compendium_filter_dungeon').val();
+                        d.dungeon_id = contextDungeonId;
                     },
                 },
                 'lengthMenu': [25],
@@ -112,10 +117,10 @@ use Illuminate\Support\Collection;
                 }),
             });
 
-            // The dungeon is part of the URL, so picking another one navigates to that dungeon's
-            // page - that keeps the URL, the header's dungeon selection and the dungeon context in
-            // sync. Should the selection ever hold something that is not a dungeon id (the select
-            // can emit season/expansion options), fall back to just reloading the table.
+            // Picking another dungeon navigates to that dungeon's page - that keeps the URL, the
+            // header's dungeon selection and the dungeon context in sync. Should the selection ever
+            // hold something that is not a dungeon id (the select can emit season/expansion
+            // options), fall back to just reloading the table.
             const dungeonSlugsById = @json($dungeonSlugsById);
             const dungeonIndexBaseUrl = '{{ url('/compendium/npc/dungeon') }}';
 

--- a/resources/views/compendium/spell/index.blade.php
+++ b/resources/views/compendium/spell/index.blade.php
@@ -2,12 +2,20 @@
 
 use App\Models\Dungeon;
 use App\Models\Npc\NpcClassification;
+use Illuminate\Support\Collection;
 
 /**
- * @var Dungeon $contextDungeon
+ * @var Dungeon                  $contextDungeon
+ * @var Collection<int, Dungeon> $gameVersionDungeons
+ * @var Collection<int, string>  $dungeonSlugsById
  */
 ?>
-@extends('layouts.sitepage', ['title' => __('view_compendium.spell.index.title')])
+@extends('layouts.sitepage', [
+    'title' => __('view_compendium.spell.index.title'),
+    'dungeonContextLinks' => $gameVersionDungeons->mapWithKeys(fn (Dungeon $dungeon) => [
+        $dungeon->key => route('spell.compendium.index.dungeon', ['dungeon' => $dungeon])
+    ]),
+])
 
 @section('header-title')
     {{ __('view_compendium.spell.index.header') }}
@@ -107,8 +115,21 @@ use App\Models\Npc\NpcClassification;
                 }),
             });
 
+            // The dungeon is part of the URL, so picking another one navigates to that dungeon's
+            // page - that keeps the URL, the header's dungeon selection and the dungeon context in
+            // sync. Should the selection ever hold something that is not a dungeon id (the select
+            // can emit season/expansion options), fall back to just reloading the table.
+            const dungeonSlugsById = @json($dungeonSlugsById);
+            const dungeonIndexBaseUrl = '{{ url('/compendium/spell/dungeon') }}';
+
             $('#compendium_filter_dungeon').on('change', function () {
-                table.ajax.reload();
+                const dungeonSlug = dungeonSlugsById[$(this).val()];
+
+                if (dungeonSlug) {
+                    window.location.href = `${dungeonIndexBaseUrl}/${dungeonSlug}`;
+                } else {
+                    table.ajax.reload();
+                }
             });
         });
     </script>

--- a/resources/views/compendium/spell/index.blade.php
+++ b/resources/views/compendium/spell/index.blade.php
@@ -122,13 +122,13 @@ use Illuminate\Support\Collection;
             // hold something that is not a dungeon id (the select can emit season/expansion
             // options), fall back to just reloading the table.
             const dungeonSlugsById = @json($dungeonSlugsById);
-            const dungeonIndexBaseUrl = '{{ url('/compendium/spell/dungeon') }}';
+            const dungeonBaseUrl = '{{ url('/compendium/dungeon') }}';
 
             $('#compendium_filter_dungeon').on('change', function () {
                 const dungeonSlug = dungeonSlugsById[$(this).val()];
 
                 if (dungeonSlug) {
-                    window.location.href = `${dungeonIndexBaseUrl}/${dungeonSlug}`;
+                    window.location.href = `${dungeonBaseUrl}/${dungeonSlug}/spell`;
                 } else {
                     table.ajax.reload();
                 }

--- a/resources/views/compendium/spell/index.blade.php
+++ b/resources/views/compendium/spell/index.blade.php
@@ -37,6 +37,11 @@ use Illuminate\Support\Collection;
             const npcShowBaseUrl = '{{ url('/compendium/npc') }}';
             const spellTemplate = Handlebars.templates['spell_template'];
             const npcTemplate = Handlebars.templates['npc'];
+            // The dungeon in the URL is what this page is about; the filter below is only a way to
+            // navigate to another dungeon's page. Reading the table's dungeon off the select instead
+            // would list a different dungeon whenever the select does not offer this one - it only
+            // lists dungeons mapped for the visitor's game version, which the URL is not bound by.
+            const contextDungeonId = {{ $contextDungeon->id }};
 
             const table = $('#compendium_spell_table').DataTable({
                 'processing': true,
@@ -46,10 +51,7 @@ use Illuminate\Support\Collection;
                 'ajax': {
                     'url': '{{ route('ajax.spell.compendium.search') }}',
                     'data': function (d) {
-                        const dungeonId = $('#compendium_filter_dungeon').val();
-                        if (dungeonId) {
-                            d.dungeon_id = dungeonId;
-                        }
+                        d.dungeon_id = contextDungeonId;
                     },
                 },
                 'lengthMenu': [25],
@@ -115,10 +117,10 @@ use Illuminate\Support\Collection;
                 }),
             });
 
-            // The dungeon is part of the URL, so picking another one navigates to that dungeon's
-            // page - that keeps the URL, the header's dungeon selection and the dungeon context in
-            // sync. Should the selection ever hold something that is not a dungeon id (the select
-            // can emit season/expansion options), fall back to just reloading the table.
+            // Picking another dungeon navigates to that dungeon's page - that keeps the URL, the
+            // header's dungeon selection and the dungeon context in sync. Should the selection ever
+            // hold something that is not a dungeon id (the select can emit season/expansion
+            // options), fall back to just reloading the table.
             const dungeonSlugsById = @json($dungeonSlugsById);
             const dungeonIndexBaseUrl = '{{ url('/compendium/spell/dungeon') }}';
 

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -507,9 +507,6 @@ Breadcrumbs::for('admin.userreport.list', static function (Generator $trail) {
  */
 Breadcrumbs::for('compendium.npc.index', static function (Generator $trail) {
     $trail->parent('home');
-    // Link straight to the dungeon-scoped canonical route rather than the bare (no dungeon) endpoint -
-    // that still exists for backward-compatible bookmarks, but internal navigation shouldn't pay for
-    // its extra 302 redirect hop.
     $trail->push(__('breadcrumbs.home.compendium.npc'), route('npc.compendium.index.dungeon', ['dungeon' => Dungeon::getUserOrDefaultDungeon()]));
 });
 
@@ -520,9 +517,6 @@ Breadcrumbs::for('compendium.npc.show', static function (Generator $trail, Npc $
 
 Breadcrumbs::for('compendium.spell.index', static function (Generator $trail) {
     $trail->parent('home');
-    // Link straight to the dungeon-scoped canonical route rather than the bare (no dungeon) endpoint -
-    // that still exists for backward-compatible bookmarks, but internal navigation shouldn't pay for
-    // its extra 302 redirect hop.
     $trail->push(__('breadcrumbs.home.compendium.spell'), route('spell.compendium.index.dungeon', ['dungeon' => Dungeon::getUserOrDefaultDungeon()]));
 });
 

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -543,6 +543,9 @@ Breadcrumbs::for('compendium.class.index', static function (Generator $trail) {
 
 Breadcrumbs::for('compendium.class.show', static function (Generator $trail, CharacterClass $characterClass, Dungeon $dungeon) {
     $trail->parent('compendium.class.index');
-    $trail->push(__($characterClass->name), route('compendium.class.show', $characterClass));
+    $trail->push(__($characterClass->name), route('compendium.class.show.dungeon', [
+        'characterClass' => $characterClass,
+        'dungeon'        => $dungeon,
+    ]));
     $trail->push(__($dungeon->name));
 });

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -507,7 +507,10 @@ Breadcrumbs::for('admin.userreport.list', static function (Generator $trail) {
  */
 Breadcrumbs::for('compendium.npc.index', static function (Generator $trail) {
     $trail->parent('home');
-    $trail->push(__('breadcrumbs.home.compendium.npc'), route('npc.compendium.index'));
+    // Link straight to the dungeon-scoped canonical route rather than the bare (no dungeon) endpoint -
+    // that still exists for backward-compatible bookmarks, but internal navigation shouldn't pay for
+    // its extra 302 redirect hop.
+    $trail->push(__('breadcrumbs.home.compendium.npc'), route('npc.compendium.index.dungeon', ['dungeon' => Dungeon::getUserOrDefaultDungeon()]));
 });
 
 Breadcrumbs::for('compendium.npc.show', static function (Generator $trail, Npc $npc) {
@@ -517,7 +520,10 @@ Breadcrumbs::for('compendium.npc.show', static function (Generator $trail, Npc $
 
 Breadcrumbs::for('compendium.spell.index', static function (Generator $trail) {
     $trail->parent('home');
-    $trail->push(__('breadcrumbs.home.compendium.spell'), route('spell.compendium.index'));
+    // Link straight to the dungeon-scoped canonical route rather than the bare (no dungeon) endpoint -
+    // that still exists for backward-compatible bookmarks, but internal navigation shouldn't pay for
+    // its extra 302 redirect hop.
+    $trail->push(__('breadcrumbs.home.compendium.spell'), route('spell.compendium.index.dungeon', ['dungeon' => Dungeon::getUserOrDefaultDungeon()]));
 });
 
 Breadcrumbs::for('compendium.spell.show', static function (Generator $trail, Spell $spell) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -179,29 +179,36 @@ Route::middleware(['viewcachebuster', 'language', 'debugbarmessagelogger', 'read
     Route::middleware(sprintf('feature_active:%s', NpcCompendium::class))
         ->prefix('compendium')->group(static function () {
             Route::get('/', new CompendiumController()->index(...))->name('compendium.index');
+            // Every page whose content is scoped to a dungeon lives under the dungeon it is about.
+            // The literal segment keeps the slug unambiguous, so no section here can ever be mistaken
+            // for a dungeon (or the other way around) no matter what a dungeon is called.
+            Route::prefix('dungeon/{dungeon}')->group(static function () {
+                Route::get('npc', new NpcCompendiumController()->indexDungeon(...))->name('npc.compendium.index.dungeon');
+                Route::get('spell', new SpellCompendiumController()->indexDungeon(...))->name('spell.compendium.index.dungeon');
+                Route::get('activity', new NpcCompendiumController()->activity(...))->name('compendium.activity');
+                Route::get('activity/{date}', new NpcCompendiumController()->activityDay(...))->name('compendium.activity.day');
+                // withoutScopedBindings: a child binding with a custom key is scoped to its parent by
+                // default, which would have Laravel resolve the class through $dungeon->characterClasses()
+                Route::get('class/{characterClass:key}', new ClassCompendiumController()->showDungeon(...))
+                    ->withoutScopedBindings()->name('compendium.class.show.dungeon');
+            });
             Route::prefix('npc')->group(static function () {
                 Route::get('/', new NpcCompendiumController()->index(...))->name('npc.compendium.index');
-                // Behind a literal segment - /{npc} owns the next path segment already
-                Route::get('/dungeon/{dungeon}', new NpcCompendiumController()->indexDungeon(...))->name('npc.compendium.index.dungeon');
                 Route::get('/{npc}', new NpcCompendiumController()->show(...))->name('npc.compendium.show');
             });
             Route::prefix('spell')->group(static function () {
                 Route::get('/', new SpellCompendiumController()->index(...))->name('spell.compendium.index');
-                // Behind a literal segment - /{spell} owns the next path segment already
-                Route::get('/dungeon/{dungeon}', new SpellCompendiumController()->indexDungeon(...))->name('spell.compendium.index.dungeon');
                 Route::get('/{spell}', new SpellCompendiumController()->show(...))->name('spell.compendium.show');
             });
             Route::prefix('activity')->group(static function () {
                 Route::get('/', new NpcCompendiumController()->activityIndex(...))->name('compendium.activity.index');
-                Route::prefix('{dungeon}')->group(static function () {
-                    Route::get('/', new NpcCompendiumController()->activity(...))->name('compendium.activity');
-                    Route::get('/{date}', new NpcCompendiumController()->activityDay(...))->name('compendium.activity.day');
-                });
+                // The activity pages lived here before the dungeon moved to the front of the path
+                Route::get('/{dungeon}', new NpcCompendiumController()->activityLegacy(...));
+                Route::get('/{dungeon}/{date}', new NpcCompendiumController()->activityDayLegacy(...));
             });
             Route::prefix('class')->group(static function () {
                 Route::get('/', new ClassCompendiumController()->index(...))->name('compendium.class.index');
                 Route::get('/{characterClass:key}', new ClassCompendiumController()->show(...))->name('compendium.class.show');
-                Route::get('/{characterClass:key}/{dungeon}', new ClassCompendiumController()->showDungeon(...))->name('compendium.class.show.dungeon');
             });
         });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -181,10 +181,14 @@ Route::middleware(['viewcachebuster', 'language', 'debugbarmessagelogger', 'read
             Route::get('/', new CompendiumController()->index(...))->name('compendium.index');
             Route::prefix('npc')->group(static function () {
                 Route::get('/', new NpcCompendiumController()->index(...))->name('npc.compendium.index');
+                // Behind a literal segment - /{npc} owns the next path segment already
+                Route::get('/dungeon/{dungeon}', new NpcCompendiumController()->indexDungeon(...))->name('npc.compendium.index.dungeon');
                 Route::get('/{npc}', new NpcCompendiumController()->show(...))->name('npc.compendium.show');
             });
             Route::prefix('spell')->group(static function () {
                 Route::get('/', new SpellCompendiumController()->index(...))->name('spell.compendium.index');
+                // Behind a literal segment - /{spell} owns the next path segment already
+                Route::get('/dungeon/{dungeon}', new SpellCompendiumController()->indexDungeon(...))->name('spell.compendium.index.dungeon');
                 Route::get('/{spell}', new SpellCompendiumController()->show(...))->name('spell.compendium.show');
             });
             Route::prefix('activity')->group(static function () {
@@ -197,6 +201,7 @@ Route::middleware(['viewcachebuster', 'language', 'debugbarmessagelogger', 'read
             Route::prefix('class')->group(static function () {
                 Route::get('/', new ClassCompendiumController()->index(...))->name('compendium.class.index');
                 Route::get('/{characterClass:key}', new ClassCompendiumController()->show(...))->name('compendium.class.show');
+                Route::get('/{characterClass:key}/{dungeon}', new ClassCompendiumController()->showDungeon(...))->name('compendium.class.show.dungeon');
             });
         });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -200,12 +200,7 @@ Route::middleware(['viewcachebuster', 'language', 'debugbarmessagelogger', 'read
                 Route::get('/', new SpellCompendiumController()->index(...))->name('spell.compendium.index');
                 Route::get('/{spell}', new SpellCompendiumController()->show(...))->name('spell.compendium.show');
             });
-            Route::prefix('activity')->group(static function () {
-                Route::get('/', new NpcCompendiumController()->activityIndex(...))->name('compendium.activity.index');
-                // The activity pages lived here before the dungeon moved to the front of the path
-                Route::get('/{dungeon}', new NpcCompendiumController()->activityLegacy(...));
-                Route::get('/{dungeon}/{date}', new NpcCompendiumController()->activityDayLegacy(...));
-            });
+            Route::get('activity', new NpcCompendiumController()->activityIndex(...))->name('compendium.activity.index');
             Route::prefix('class')->group(static function () {
                 Route::get('/', new ClassCompendiumController()->index(...))->name('compendium.class.index');
                 Route::get('/{characterClass:key}', new ClassCompendiumController()->show(...))->name('compendium.class.show');

--- a/tests/Feature/Controller/Compendium/ClassCompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/ClassCompendiumControllerTest.php
@@ -151,7 +151,7 @@ final class ClassCompendiumControllerTest extends PublicTestCase
         $characterClass = CharacterClass::where('key', CharacterClass::CHARACTER_CLASS_MAGE)->firstOrFail();
 
         // Act
-        $response = $this->get(sprintf('/compendium/class/%s/not-a-dungeon', $characterClass->key));
+        $response = $this->get(sprintf('/compendium/dungeon/not-a-dungeon/class/%s', $characterClass->key));
 
         // Assert
         $response->assertNotFound();

--- a/tests/Feature/Controller/Compendium/ClassCompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/ClassCompendiumControllerTest.php
@@ -77,10 +77,84 @@ final class ClassCompendiumControllerTest extends PublicTestCase
         $characterClass = CharacterClass::where('key', CharacterClass::CHARACTER_CLASS_MAGE)->firstOrFail();
 
         // Act
-        $response = $this->get(route('compendium.class.show', $characterClass));
+        $response = $this->get(route('compendium.class.show.dungeon', [
+            'characterClass' => $characterClass,
+            'dungeon'        => Dungeon::getUserOrDefaultDungeon(),
+        ]));
 
         // Assert
         $response->assertOk();
+    }
+
+    #[Test]
+    public function show_givenNoDungeonInUrl_redirectsToContextDungeon(): void
+    {
+        // Arrange
+        $characterClass = CharacterClass::where('key', CharacterClass::CHARACTER_CLASS_MAGE)->firstOrFail();
+        $dungeon        = Dungeon::active()->firstOrFail();
+
+        $user              = User::findOrFail(1);
+        $originalDungeonId = $user->dungeon_id;
+        $user->dungeon_id  = $dungeon->id;
+        $user->save();
+
+        try {
+            // Act
+            $response = $this->actingAs($user->fresh())->get(route('compendium.class.show', $characterClass));
+
+            // Assert - a 302, not a 301: the target depends on the visitor's own context dungeon
+            $response->assertRedirect(route('compendium.class.show.dungeon', [
+                'characterClass' => $characterClass,
+                'dungeon'        => $dungeon,
+            ]));
+            $response->assertStatus(302);
+        } finally {
+            $user->dungeon_id = $originalDungeonId;
+            $user->save();
+        }
+    }
+
+    #[Test]
+    public function showDungeon_givenDungeonOtherThanContextDungeon_rendersThatDungeonAndMakesItTheContext(): void
+    {
+        // Arrange - two different dungeons, so the URL is provably what decides what is rendered
+        $characterClass   = CharacterClass::where('key', CharacterClass::CHARACTER_CLASS_MAGE)->firstOrFail();
+        $contextDungeon   = Dungeon::active()->orderBy('id')->firstOrFail();
+        $requestedDungeon = Dungeon::active()->where('id', '!=', $contextDungeon->id)->orderBy('id')->firstOrFail();
+
+        $user              = User::findOrFail(1);
+        $originalDungeonId = $user->dungeon_id;
+        $user->dungeon_id  = $contextDungeon->id;
+        $user->save();
+
+        try {
+            // Act
+            $response = $this->actingAs($user->fresh())->get(route('compendium.class.show.dungeon', [
+                'characterClass' => $characterClass,
+                'dungeon'        => $requestedDungeon,
+            ]));
+
+            // Assert
+            $response->assertOk();
+            $response->assertSeeText(__($requestedDungeon->name));
+            $this->assertSame($requestedDungeon->id, User::findOrFail(1)->dungeon_id);
+        } finally {
+            $user->dungeon_id = $originalDungeonId;
+            $user->save();
+        }
+    }
+
+    #[Test]
+    public function showDungeon_givenUnknownDungeonSlug_returnsNotFound(): void
+    {
+        // Arrange
+        $characterClass = CharacterClass::where('key', CharacterClass::CHARACTER_CLASS_MAGE)->firstOrFail();
+
+        // Act
+        $response = $this->get(sprintf('/compendium/class/%s/not-a-dungeon', $characterClass->key));
+
+        // Assert
+        $response->assertNotFound();
     }
 
     #[Test]
@@ -101,7 +175,10 @@ final class ClassCompendiumControllerTest extends PublicTestCase
         $dungeon        = Dungeon::getUserOrDefaultDungeon();
 
         // Act
-        $response = $this->get(route('compendium.class.show', $characterClass));
+        $response = $this->get(route('compendium.class.show.dungeon', [
+            'characterClass' => $characterClass,
+            'dungeon'        => Dungeon::getUserOrDefaultDungeon(),
+        ]));
 
         // Assert
         $response->assertOk();
@@ -116,7 +193,10 @@ final class ClassCompendiumControllerTest extends PublicTestCase
         $characterClass = CharacterClass::where('key', CharacterClass::CHARACTER_CLASS_ROGUE)->firstOrFail();
 
         // Act
-        $response = $this->get(route('compendium.class.show', $characterClass));
+        $response = $this->get(route('compendium.class.show.dungeon', [
+            'characterClass' => $characterClass,
+            'dungeon'        => Dungeon::getUserOrDefaultDungeon(),
+        ]));
 
         // Assert
         $response->assertOk();
@@ -132,7 +212,10 @@ final class ClassCompendiumControllerTest extends PublicTestCase
         $characterClass = CharacterClass::where('key', CharacterClass::CHARACTER_CLASS_PALADIN)->firstOrFail();
 
         // Act
-        $response = $this->get(route('compendium.class.show', $characterClass));
+        $response = $this->get(route('compendium.class.show.dungeon', [
+            'characterClass' => $characterClass,
+            'dungeon'        => Dungeon::getUserOrDefaultDungeon(),
+        ]));
 
         // Assert
         $response->assertOk();
@@ -147,7 +230,10 @@ final class ClassCompendiumControllerTest extends PublicTestCase
         $characterClass = CharacterClass::where('key', CharacterClass::CHARACTER_CLASS_WARRIOR)->firstOrFail();
 
         // Act
-        $response = $this->get(route('compendium.class.show', $characterClass));
+        $response = $this->get(route('compendium.class.show.dungeon', [
+            'characterClass' => $characterClass,
+            'dungeon'        => Dungeon::getUserOrDefaultDungeon(),
+        ]));
 
         // Assert
         $response->assertOk();
@@ -161,7 +247,10 @@ final class ClassCompendiumControllerTest extends PublicTestCase
         $characterClass = CharacterClass::where('key', CharacterClass::CHARACTER_CLASS_PALADIN)->firstOrFail();
 
         // Act
-        $response = $this->get(route('compendium.class.show', $characterClass));
+        $response = $this->get(route('compendium.class.show.dungeon', [
+            'characterClass' => $characterClass,
+            'dungeon'        => Dungeon::getUserOrDefaultDungeon(),
+        ]));
 
         // Assert
         $response->assertOk();
@@ -231,7 +320,10 @@ final class ClassCompendiumControllerTest extends PublicTestCase
             ]);
 
             // Act
-            $response = $this->actingAs($user)->get(route('compendium.class.show', $characterClass));
+            $response = $this->actingAs($user)->get(route('compendium.class.show.dungeon', [
+                'characterClass' => $characterClass,
+                'dungeon'        => $dungeon,
+            ]));
 
             // Assert
             $response->assertOk();
@@ -295,7 +387,10 @@ final class ClassCompendiumControllerTest extends PublicTestCase
             ]);
 
             // Act
-            $response = $this->actingAs($user)->get(route('compendium.class.show', $characterClass));
+            $response = $this->actingAs($user)->get(route('compendium.class.show.dungeon', [
+                'characterClass' => $characterClass,
+                'dungeon'        => $dungeon,
+            ]));
 
             // Assert
             $response->assertOk();

--- a/tests/Feature/Controller/Compendium/CompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/CompendiumControllerTest.php
@@ -54,8 +54,6 @@ final class CompendiumControllerTest extends PublicTestCase
 
         // Assert
         $response->assertOk();
-        // The npc/spell cards link straight to the visitor's context-dungeon canonical URL - the bare
-        // (no dungeon) routes still exist, but only for backward-compatible bookmarks, not internal use.
         $contextDungeon = Dungeon::getUserOrDefaultDungeon();
         $response->assertSee(route('npc.compendium.index.dungeon', ['dungeon' => $contextDungeon]));
         $response->assertSee(route('spell.compendium.index.dungeon', ['dungeon' => $contextDungeon]));

--- a/tests/Feature/Controller/Compendium/CompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/CompendiumControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Controller\Compendium;
 
 use App\Features\NpcCompendium;
+use App\Models\Dungeon;
 use App\Models\User;
 use Laravel\Pennant\Feature;
 use PHPUnit\Framework\Attributes\Group;
@@ -53,8 +54,11 @@ final class CompendiumControllerTest extends PublicTestCase
 
         // Assert
         $response->assertOk();
-        $response->assertSee(route('npc.compendium.index'));
-        $response->assertSee(route('spell.compendium.index'));
+        // The npc/spell cards link straight to the visitor's context-dungeon canonical URL - the bare
+        // (no dungeon) routes still exist, but only for backward-compatible bookmarks, not internal use.
+        $contextDungeon = Dungeon::getUserOrDefaultDungeon();
+        $response->assertSee(route('npc.compendium.index.dungeon', ['dungeon' => $contextDungeon]));
+        $response->assertSee(route('spell.compendium.index.dungeon', ['dungeon' => $contextDungeon]));
         $response->assertSee(route('compendium.activity.index'));
         $response->assertSee(route('compendium.class.index'));
         $response->assertSee('https://raider.io/addon');

--- a/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
+++ b/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
@@ -83,6 +83,29 @@ final class NpcCompendiumControllerActivityTest extends PublicTestCase
     }
 
     #[Test]
+    public function activity_givenDungeonInUrl_makesItTheContextDungeon(): void
+    {
+        // Arrange - a context dungeon other than the one in the URL, so the URL is provably what wins
+        $otherDungeon      = Dungeon::active()->where('id', '!=', $this->dungeon->id)->orderBy('id')->firstOrFail();
+        $user              = User::findOrFail(1);
+        $originalDungeonId = $user->dungeon_id;
+        $user->dungeon_id  = $otherDungeon->id;
+        $user->save();
+
+        try {
+            // Act
+            $response = $this->actingAs($user->fresh())->get(route('compendium.activity', $this->dungeon));
+
+            // Assert
+            $response->assertOk();
+            $this->assertSame($this->dungeon->id, User::findOrFail(1)->dungeon_id);
+        } finally {
+            $user->dungeon_id = $originalDungeonId;
+            $user->save();
+        }
+    }
+
+    #[Test]
     public function activity_givenFeatureEnabledNoAuth_returnsOk(): void
     {
         // Arrange

--- a/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
+++ b/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
@@ -106,6 +106,32 @@ final class NpcCompendiumControllerActivityTest extends PublicTestCase
     }
 
     #[Test]
+    public function activityLegacy_givenOldUrl_redirectsToTheDungeonFirstUrl(): void
+    {
+        // Act
+        $response = $this->get(sprintf('/compendium/activity/%s', $this->dungeon->slug));
+
+        // Assert - a 301 is right here, unlike the context-dungeon redirects: this target comes
+        // purely from the URL, so it is the same for every visitor
+        $response->assertRedirect(route('compendium.activity', ['dungeon' => $this->dungeon]));
+        $response->assertStatus(301);
+    }
+
+    #[Test]
+    public function activityDayLegacy_givenOldUrl_redirectsToTheDungeonFirstUrl(): void
+    {
+        // Act
+        $response = $this->get(sprintf('/compendium/activity/%s/2025-01-15', $this->dungeon->slug));
+
+        // Assert
+        $response->assertRedirect(route('compendium.activity.day', [
+            'dungeon' => $this->dungeon,
+            'date'    => '2025-01-15',
+        ]));
+        $response->assertStatus(301);
+    }
+
+    #[Test]
     public function activityDay_givenDungeonInUrl_leavesTheContextDungeonAlone(): void
     {
         // Arrange - unlike activity(), the day page does not validate its dungeon against the current
@@ -338,7 +364,7 @@ final class NpcCompendiumControllerActivityTest extends PublicTestCase
     public function activityDay_givenInvalidDateFormat_returnsNotFound(): void
     {
         // Act
-        $response = $this->get(sprintf('/compendium/activity/%s/not-a-date', $this->dungeon->slug));
+        $response = $this->get(sprintf('/compendium/dungeon/%s/activity/not-a-date', $this->dungeon->slug));
 
         // Assert
         $response->assertNotFound();

--- a/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
+++ b/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
@@ -106,6 +106,33 @@ final class NpcCompendiumControllerActivityTest extends PublicTestCase
     }
 
     #[Test]
+    public function activityDay_givenDungeonInUrl_leavesTheContextDungeonAlone(): void
+    {
+        // Arrange - unlike activity(), the day page does not validate its dungeon against the current
+        // season, so it must not push one into the site-wide context either
+        $otherDungeon      = Dungeon::active()->where('id', '!=', $this->dungeon->id)->orderBy('id')->firstOrFail();
+        $user              = User::findOrFail(1);
+        $originalDungeonId = $user->dungeon_id;
+        $user->dungeon_id  = $otherDungeon->id;
+        $user->save();
+
+        try {
+            // Act
+            $response = $this->actingAs($user->fresh())->get(route('compendium.activity.day', [
+                'dungeon' => $this->dungeon,
+                'date'    => '2025-01-15',
+            ]));
+
+            // Assert
+            $response->assertOk();
+            $this->assertSame($otherDungeon->id, User::findOrFail(1)->dungeon_id);
+        } finally {
+            $user->dungeon_id = $originalDungeonId;
+            $user->save();
+        }
+    }
+
+    #[Test]
     public function activity_givenFeatureEnabledNoAuth_returnsOk(): void
     {
         // Arrange

--- a/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
+++ b/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
@@ -106,32 +106,6 @@ final class NpcCompendiumControllerActivityTest extends PublicTestCase
     }
 
     #[Test]
-    public function activityLegacy_givenOldUrl_redirectsToTheDungeonFirstUrl(): void
-    {
-        // Act
-        $response = $this->get(sprintf('/compendium/activity/%s', $this->dungeon->slug));
-
-        // Assert - a 301 is right here, unlike the context-dungeon redirects: this target comes
-        // purely from the URL, so it is the same for every visitor
-        $response->assertRedirect(route('compendium.activity', ['dungeon' => $this->dungeon]));
-        $response->assertStatus(301);
-    }
-
-    #[Test]
-    public function activityDayLegacy_givenOldUrl_redirectsToTheDungeonFirstUrl(): void
-    {
-        // Act
-        $response = $this->get(sprintf('/compendium/activity/%s/2025-01-15', $this->dungeon->slug));
-
-        // Assert
-        $response->assertRedirect(route('compendium.activity.day', [
-            'dungeon' => $this->dungeon,
-            'date'    => '2025-01-15',
-        ]));
-        $response->assertStatus(301);
-    }
-
-    #[Test]
     public function activityDay_givenDungeonInUrl_leavesTheContextDungeonAlone(): void
     {
         // Arrange - unlike activity(), the day page does not validate its dungeon against the current

--- a/tests/Feature/Controller/Compendium/NpcCompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/NpcCompendiumControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Controller\Compendium;
 use App\Features\NpcCompendium;
 use App\Models\Dungeon;
 use App\Models\Enemy;
+use App\Models\GameVersion\GameVersion;
 use App\Models\Npc\Npc;
 use App\Models\User;
 use Laravel\Pennant\Feature;
@@ -138,6 +139,25 @@ final class NpcCompendiumControllerTest extends PublicTestCase
             $user->dungeon_id = $originalDungeonId;
             $user->save();
         }
+    }
+
+    #[Test]
+    public function indexDungeon_givenDungeonNotOfferedByTheFilter_stillDrivesTheTableFromTheUrlDungeon(): void
+    {
+        // Arrange - the dungeon filter only lists dungeons mapped for the visitor's game version, so
+        // a dungeon outside it is not among its options. The table must still show the URL's dungeon
+        $gameVersion = GameVersion::getUserOrDefaultGameVersion();
+        $dungeon     = Dungeon::query()
+            ->whereDoesntHave('mappingVersions', static fn($query) => $query->where('game_version_id', $gameVersion->id))
+            ->firstOrFail();
+
+        // Act
+        $response = $this->get(route('npc.compendium.index.dungeon', ['dungeon' => $dungeon]));
+
+        // Assert
+        $response->assertOk();
+        $this->assertNotSame($dungeon->id, $this->getSelectedDungeonId($response->getContent()));
+        $response->assertSee(sprintf('const contextDungeonId = %d;', $dungeon->id), false);
     }
 
     #[Test]

--- a/tests/Feature/Controller/Compendium/NpcCompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/NpcCompendiumControllerTest.php
@@ -10,12 +10,15 @@ use App\Models\User;
 use Laravel\Pennant\Feature;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Traits\ReadsDungeonSelect;
 use Tests\TestCases\PublicTestCase;
 
 #[Group('Controller')]
 #[Group('Compendium')]
 final class NpcCompendiumControllerTest extends PublicTestCase
 {
+    use ReadsDungeonSelect;
+
     /** @var array<string, mixed> */
     private array $datatableParams = [
         'draw'    => 1,
@@ -72,7 +75,7 @@ final class NpcCompendiumControllerTest extends PublicTestCase
         $this->actingAsGuest();
 
         // Act
-        $response = $this->get(route('npc.compendium.index'));
+        $response = $this->get(route('npc.compendium.index.dungeon', ['dungeon' => Dungeon::active()->firstOrFail()]));
 
         // Assert
         $response->assertOk();
@@ -82,17 +85,76 @@ final class NpcCompendiumControllerTest extends PublicTestCase
     public function index_givenAdminFeatureEnabled_returnsOk(): void
     {
         // Act
-        $response = $this->get(route('npc.compendium.index'));
+        $response = $this->get(route('npc.compendium.index.dungeon', ['dungeon' => Dungeon::active()->firstOrFail()]));
 
         // Assert
         $response->assertOk();
     }
 
     #[Test]
+    public function index_givenNoDungeonInUrl_redirectsToContextDungeon(): void
+    {
+        // Arrange
+        $dungeon           = Dungeon::active()->firstOrFail();
+        $user              = User::findOrFail(1);
+        $originalDungeonId = $user->dungeon_id;
+        $user->dungeon_id  = $dungeon->id;
+        $user->save();
+
+        try {
+            // Act
+            $response = $this->actingAs($user->fresh())->get(route('npc.compendium.index'));
+
+            // Assert - a 302, not a 301: the target depends on the visitor's own context dungeon
+            $response->assertRedirect(route('npc.compendium.index.dungeon', ['dungeon' => $dungeon]));
+            $response->assertStatus(302);
+        } finally {
+            $user->dungeon_id = $originalDungeonId;
+            $user->save();
+        }
+    }
+
+    #[Test]
+    public function indexDungeon_givenDungeonOtherThanContextDungeon_rendersThatDungeonAndMakesItTheContext(): void
+    {
+        // Arrange - two different dungeons, so the URL is provably what decides what is rendered
+        $contextDungeon   = Dungeon::active()->orderBy('id')->firstOrFail();
+        $requestedDungeon = Dungeon::active()->where('id', '!=', $contextDungeon->id)->orderBy('id')->firstOrFail();
+
+        $user              = User::findOrFail(1);
+        $originalDungeonId = $user->dungeon_id;
+        $user->dungeon_id  = $contextDungeon->id;
+        $user->save();
+
+        try {
+            // Act
+            $response = $this->actingAs($user->fresh())->get(route('npc.compendium.index.dungeon', ['dungeon' => $requestedDungeon]));
+
+            // Assert
+            $response->assertOk();
+            $this->assertSame($requestedDungeon->id, $this->getSelectedDungeonId($response->getContent()));
+            $this->assertSame($requestedDungeon->id, User::findOrFail(1)->dungeon_id);
+        } finally {
+            $user->dungeon_id = $originalDungeonId;
+            $user->save();
+        }
+    }
+
+    #[Test]
+    public function indexDungeon_givenUnknownDungeonSlug_returnsNotFound(): void
+    {
+        // Act
+        $response = $this->get('/compendium/npc/dungeon/not-a-dungeon');
+
+        // Assert
+        $response->assertNotFound();
+    }
+
+    #[Test]
     public function index_givenShowSeasons_returnsNoDuplicateDungeonsInSelect(): void
     {
         // Act
-        $response = $this->get(route('npc.compendium.index'));
+        $response = $this->get(route('npc.compendium.index.dungeon', ['dungeon' => Dungeon::active()->firstOrFail()]));
 
         // Assert
         $response->assertOk();

--- a/tests/Feature/Controller/Compendium/NpcCompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/NpcCompendiumControllerTest.php
@@ -164,7 +164,7 @@ final class NpcCompendiumControllerTest extends PublicTestCase
     public function indexDungeon_givenUnknownDungeonSlug_returnsNotFound(): void
     {
         // Act
-        $response = $this->get('/compendium/npc/dungeon/not-a-dungeon');
+        $response = $this->get('/compendium/dungeon/not-a-dungeon/npc');
 
         // Assert
         $response->assertNotFound();

--- a/tests/Feature/Controller/Compendium/SpellCompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/SpellCompendiumControllerTest.php
@@ -164,7 +164,7 @@ final class SpellCompendiumControllerTest extends PublicTestCase
     public function indexDungeon_givenUnknownDungeonSlug_returnsNotFound(): void
     {
         // Act
-        $response = $this->get('/compendium/spell/dungeon/not-a-dungeon');
+        $response = $this->get('/compendium/dungeon/not-a-dungeon/spell');
 
         // Assert
         $response->assertNotFound();

--- a/tests/Feature/Controller/Compendium/SpellCompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/SpellCompendiumControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Controller\Compendium;
 
 use App\Features\NpcCompendium;
 use App\Models\Dungeon;
+use App\Models\GameVersion\GameVersion;
 use App\Models\Spell\Spell;
 use App\Models\Spell\SpellDungeon;
 use App\Models\User;
@@ -138,6 +139,25 @@ final class SpellCompendiumControllerTest extends PublicTestCase
             $user->dungeon_id = $originalDungeonId;
             $user->save();
         }
+    }
+
+    #[Test]
+    public function indexDungeon_givenDungeonNotOfferedByTheFilter_stillDrivesTheTableFromTheUrlDungeon(): void
+    {
+        // Arrange - the dungeon filter only lists dungeons mapped for the visitor's game version, so
+        // a dungeon outside it is not among its options. The table must still show the URL's dungeon
+        $gameVersion = GameVersion::getUserOrDefaultGameVersion();
+        $dungeon     = Dungeon::query()
+            ->whereDoesntHave('mappingVersions', static fn($query) => $query->where('game_version_id', $gameVersion->id))
+            ->firstOrFail();
+
+        // Act
+        $response = $this->get(route('spell.compendium.index.dungeon', ['dungeon' => $dungeon]));
+
+        // Assert
+        $response->assertOk();
+        $this->assertNotSame($dungeon->id, $this->getSelectedDungeonId($response->getContent()));
+        $response->assertSee(sprintf('const contextDungeonId = %d;', $dungeon->id), false);
     }
 
     #[Test]

--- a/tests/Feature/Controller/Compendium/SpellCompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/SpellCompendiumControllerTest.php
@@ -10,12 +10,15 @@ use App\Models\User;
 use Laravel\Pennant\Feature;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Traits\ReadsDungeonSelect;
 use Tests\TestCases\PublicTestCase;
 
 #[Group('Controller')]
 #[Group('Compendium')]
 final class SpellCompendiumControllerTest extends PublicTestCase
 {
+    use ReadsDungeonSelect;
+
     /** @var array<string, mixed> */
     private array $datatableParams = [
         'draw'    => 1,
@@ -72,7 +75,7 @@ final class SpellCompendiumControllerTest extends PublicTestCase
         $this->actingAsGuest();
 
         // Act
-        $response = $this->get(route('spell.compendium.index'));
+        $response = $this->get(route('spell.compendium.index.dungeon', ['dungeon' => Dungeon::active()->firstOrFail()]));
 
         // Assert
         $response->assertOk();
@@ -82,10 +85,69 @@ final class SpellCompendiumControllerTest extends PublicTestCase
     public function index_givenAdminFeatureEnabled_returnsOk(): void
     {
         // Act
-        $response = $this->get(route('spell.compendium.index'));
+        $response = $this->get(route('spell.compendium.index.dungeon', ['dungeon' => Dungeon::active()->firstOrFail()]));
 
         // Assert
         $response->assertOk();
+    }
+
+    #[Test]
+    public function index_givenNoDungeonInUrl_redirectsToContextDungeon(): void
+    {
+        // Arrange
+        $dungeon           = Dungeon::active()->firstOrFail();
+        $user              = User::findOrFail(1);
+        $originalDungeonId = $user->dungeon_id;
+        $user->dungeon_id  = $dungeon->id;
+        $user->save();
+
+        try {
+            // Act
+            $response = $this->actingAs($user->fresh())->get(route('spell.compendium.index'));
+
+            // Assert - a 302, not a 301: the target depends on the visitor's own context dungeon
+            $response->assertRedirect(route('spell.compendium.index.dungeon', ['dungeon' => $dungeon]));
+            $response->assertStatus(302);
+        } finally {
+            $user->dungeon_id = $originalDungeonId;
+            $user->save();
+        }
+    }
+
+    #[Test]
+    public function indexDungeon_givenDungeonOtherThanContextDungeon_rendersThatDungeonAndMakesItTheContext(): void
+    {
+        // Arrange - two different dungeons, so the URL is provably what decides what is rendered
+        $contextDungeon   = Dungeon::active()->orderBy('id')->firstOrFail();
+        $requestedDungeon = Dungeon::active()->where('id', '!=', $contextDungeon->id)->orderBy('id')->firstOrFail();
+
+        $user              = User::findOrFail(1);
+        $originalDungeonId = $user->dungeon_id;
+        $user->dungeon_id  = $contextDungeon->id;
+        $user->save();
+
+        try {
+            // Act
+            $response = $this->actingAs($user->fresh())->get(route('spell.compendium.index.dungeon', ['dungeon' => $requestedDungeon]));
+
+            // Assert
+            $response->assertOk();
+            $this->assertSame($requestedDungeon->id, $this->getSelectedDungeonId($response->getContent()));
+            $this->assertSame($requestedDungeon->id, User::findOrFail(1)->dungeon_id);
+        } finally {
+            $user->dungeon_id = $originalDungeonId;
+            $user->save();
+        }
+    }
+
+    #[Test]
+    public function indexDungeon_givenUnknownDungeonSlug_returnsNotFound(): void
+    {
+        // Act
+        $response = $this->get('/compendium/spell/dungeon/not-a-dungeon');
+
+        // Assert
+        $response->assertNotFound();
     }
 
     #[Test]

--- a/tests/Feature/Traits/ReadsDungeonSelect.php
+++ b/tests/Feature/Traits/ReadsDungeonSelect.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Traits;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+
+trait ReadsDungeonSelect
+{
+    /**
+     * The dungeon id that a rendered page's dungeon filter is pre-selected with.
+     */
+    protected function getSelectedDungeonId(string $html, string $selectId = 'compendium_filter_dungeon'): ?int
+    {
+        $dom = new DOMDocument();
+        @$dom->loadHTML($html);
+
+        $options = new DOMXPath($dom)->query(sprintf('//select[@id="%s"]//option[@selected]', $selectId));
+
+        if ($options === false) {
+            return null;
+        }
+
+        $option = $options->item(0);
+
+        return $option instanceof DOMElement ? (int)$option->getAttribute('value') : null;
+    }
+}


### PR DESCRIPTION
:robot: Closes #3968

`/compendium/class/{class}`, `/compendium/npc` and `/compendium/spell` all rendered content scoped to the visitor's *context dungeon* (`users.dungeon_id` for members, the `dungeon_context` cookie for guests). The dungeon appeared nowhere in the URL, so the same URL showed different content per visitor, a link could not be shared for a specific dungeon, and the per-dungeon variants could not be indexed separately.

## URL shape

| Page | Bare (302 →) | Canonical |
|---|---|---|
| Class | `/compendium/class/rogue` | `/compendium/dungeon/the-dawnbreaker/class/rogue` |
| NPC index | `/compendium/npc` | `/compendium/dungeon/the-dawnbreaker/npc` |
| Spell index | `/compendium/spell` | `/compendium/dungeon/the-dawnbreaker/spell` |
| Activity | `/compendium/activity` | `/compendium/dungeon/the-dawnbreaker/activity` |
| Activity day | — | `/compendium/dungeon/the-dawnbreaker/activity/{date}` |

Every dungeon-scoped page hangs off the dungeon it is about, so all four share one shape. The literal `dungeon/` segment keeps the slug unambiguous, so no section can ever be mistaken for a dungeon (or vice versa) whatever a dungeon is called — and it removes the need for any route-ordering trick. Pages that are not dungeon-scoped stay where they are: `/compendium`, `/compendium/npc/{npc}`, `/compendium/spell/{spell}`, `/compendium/class`.

The pre-move `/compendium/activity/{dungeon}[/{date}]` URLs are **removed rather than redirected**: the Compendium is gated to admins/internal team and has never been enabled on production, so there is no audience to keep them working for.

Otherwise this follows the `{gameVersion}/{dungeon}` pattern the rest of the site already uses (explore / heatmap / discover): the bare URL redirects to the canonical dungeon-ful one, the page writes the URL dungeon back into the dungeon context, and the header dungeon picker gets a `dungeonContextLinks` override so its cards link straight to the same page for another dungeon.

Decisions worth calling out:

- **302, not 301**, for the bare → canonical redirect: the target is derived from the visitor's own cookie / `users.dungeon_id`, so a permanent redirect would get browser- and proxy-cached and pin one dungeon into every later session. (The neighbouring slug guards in `NpcCompendiumController::show()` *are* 301, correctly — those targets are static.)
- **A separate bare route + redirect, not an optional `{dungeon?}` param** — an optional param would serve identical content at two URLs, which is the duplicate-content problem this issue is about.
- **Two Laravel details worth knowing**, both now commented in place: a route registered with first-class callable syntax binds its parameters **positionally**, so `showDungeon()` takes `(Dungeon, CharacterClass)` to match the URL; and a nested binding with a custom key (`{characterClass:key}` under `{dungeon}`) is **scoped to its parent** by default, which had Laravel resolving the class through `$dungeon->characterClasses()` — hence `->withoutScopedBindings()`.
- **No season forcing.** Unlike `activity()`, the class/index pages accept any dungeon; an out-of-season dungeon renders with no data rather than silently redirecting a shared link elsewhere. Consequence, intended: for such a dungeon the header picker (current season only) has no matching card.
- **The in-page dungeon filter on the NPC/spell index now navigates** instead of reloading the DataTable, which keeps URL, header selection and persisted context in one round-trip. If the select ever holds a non-dungeon-id value (it can emit season/expansion options when configured to), it falls back to the old `table.ajax.reload()`.
- **The index tables take their dungeon from the URL, not from that filter** (cold review). The filter only lists dungeons mapped for the visitor's game version, so reading the table's dungeon off it would list a different dungeon whenever the URL named one the select does not offer. A guard rejecting such URLs was deliberately not added: it would make the same URL 404/redirect for one visitor and render for another, which is the per-visitor variability this issue exists to remove. Residual, cosmetic: for such a dungeon the dropdown's visible label falls back to its first option while URL, breadcrumb, header identity and table all name the right dungeon.
- **Only pages that validate their dungeon write the site-wide context** (cold review). `activity()` validates against the current season and redirects, so it writes; `activityDay()` does not validate, so it does not write — a direct link to a day page therefore leaves the header dungeon highlight stale, by design.
- Also fixed: the activity pages never persisted their URL dungeon as the context, letting the header's dungeon selection drift away from the page being viewed.

## Not doing: canonical / meta tags (issue bullet 3)

Checked, deferred. There is no `<link rel="canonical">` anywhere in `resources/views` or `app` today, and no `<meta name="description">` either — only Open Graph via `common/general/linkpreview.blade.php`. Adding canonical tags would mean new shared-layout infrastructure, and it cannot pay off yet: `NpcCompendium::resolve()` gates on `ROLE_ADMIN`/`ROLE_INTERNAL_TEAM`, so `feature_active` 404s Googlebot on every Compendium URL — nothing is indexable until the flag goes public.

The issue's `pushState` bullet is answered by the design rather than implemented: with the dungeon in the path and `dungeonContextLinks` overridden, the picker is plain link navigation — real URLs, working back button, no history API.

## Verification

- `php artisan test --filter=Compendium` — 71 passed. New per page: bare URL redirects to the context dungeon (asserting 302), a cross-dungeon case that sets `users.dungeon_id` to A, requests B's URL and asserts B renders *and* becomes the context, and an unknown-slug 404. Activity gained context-persistence tests (that `activity()` writes and `activityDay()` does not), and each index page has a test that a dungeon outside the visitor's game version still drives the table from the URL.
- `composer run fix` / `composer run analyse` clean.
- Real headless Chrome, logged in as an admin with the flag active: all four bare URLs 302 to their canonical form; the class page renders the URL dungeon (The Dawnbreaker) while the stored context was Black Rook Hold; header cards link to `/compendium/class/rogue/<other-dungeon>`; picking another dungeon in the index filter navigates to `/compendium/dungeon/pit-of-saron/npc`; the back button returns to the previous dungeon's page; no page errors.

No visual change beyond the URLs, so no before/after screenshots.
