### PR TITLE
#3978 Apply DESIGN.md theme conventions to dungeon-route cards, leaderboard, and discover pagination

### DIFF
--- a/lang/en_US/view_common.php
+++ b/lang/en_US/view_common.php
@@ -60,6 +60,9 @@ return [
         'cardlist' => [
             'no_dungeonroutes' => 'No routes found',
         ],
+        'leaderboard' => [
+            'create_first_route' => 'Create the first route',
+        ],
         'rating' => [
             'nr_of_votes' => '%s vote(s)',
         ],

--- a/resources/assets/css/sections/discover.css
+++ b/resources/assets/css/sections/discover.css
@@ -31,11 +31,39 @@
     height: 16rem;
     border-radius: 6px;
     overflow: hidden;
+    /* Scrim-family fallback, not a theme color: the card is a dark-imagery object in every theme,
+       and its white scrimmed text needs a dark ground even when the thumbnail is missing or the
+       dungeon fallback image is transparent (which would otherwise expose lux's light page). */
+    background-color: #222;
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
     transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+/* Long titles otherwise wrap unbounded (4+ lines on narrow columns) and crowd the fixed-height
+   card; the full title stays available via the link's title attribute. */
+.card_dungeonroute.poster .title {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+/* The footer band stays part of the dark-imagery object in every theme; lux's near-transparent
+   --theme-bg-card-footer would leave its text floating on the image. */
+.card_dungeonroute.poster .poster_footer {
+    background-color: rgba(0, 0, 0, 0.55);
+}
+
+.card_dungeonroute.poster .poster_footer a {
+    color: #fff;
+}
+
+.card_dungeonroute.poster .poster_social {
+    color: rgba(255, 255, 255, 0.75);
 }
 
 .card_dungeonroute.poster:hover {
@@ -78,6 +106,8 @@
     min-height: 15rem;
     border-radius: 8px;
     overflow: hidden;
+    /* Same scrim-family fallback as the poster card: dark ground under white text in every theme */
+    background-color: #222;
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
@@ -105,6 +135,15 @@
     font-weight: 700;
     letter-spacing: 0.08em;
     text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.9);
+}
+
+/* Long titles clamp to two lines so cards in the hero band keep a uniform height */
+.card_dungeonroute.hero .hero_title {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .card_dungeonroute.hero .hero_title a {
@@ -180,10 +219,19 @@
 
 /* Darkly fills every page-link with the same success teal and marks the active page with a
    box-shadow, but $enable-shadows is off so the current page is indistinguishable. Give the
-   pagination a conventional look instead: subdued links with an accent-filled current page. */
+   pagination a conventional look instead: subdued links with an accent-filled current page.
+   Neutral gray-based borders/washes stay visible on darkly, lux, and vapor alike (the same family
+   as DESIGN.md's standard control border). */
+.discover_pagination .pagination {
+    /* On phones the link row otherwise overflows the viewport and clips the first pages */
+    flex-wrap: wrap;
+    justify-content: center;
+    row-gap: 0.25rem;
+}
+
 .discover_pagination .page-link {
     background-color: transparent;
-    border-color: rgba(255, 255, 255, 0.15);
+    border-color: rgba(128, 128, 128, 0.35);
     color: var(--bs-body-color);
     border-radius: var(--bs-border-radius);
 }
@@ -194,32 +242,34 @@
 }
 
 .discover_pagination .page-link:hover {
-    background-color: rgba(255, 255, 255, 0.08);
-    border-color: rgba(255, 255, 255, 0.25);
-    color: #fff;
+    background-color: rgba(128, 128, 128, 0.15);
+    border-color: rgba(128, 128, 128, 0.5);
+    color: var(--theme-text-contrast);
 }
 
 .discover_pagination .page-item.active .page-link {
-    background-color: var(--bs-success);
-    border-color: var(--bs-success);
+    background-color: var(--theme-btn-accent);
+    border-color: var(--theme-btn-accent);
     color: #fff;
     font-weight: 700;
 }
 
 .discover_pagination .page-item.disabled .page-link {
     background-color: transparent;
-    border-color: rgba(255, 255, 255, 0.1);
-    color: rgba(255, 255, 255, 0.35);
+    border-color: rgba(128, 128, 128, 0.2);
+    color: rgba(128, 128, 128, 0.6);
 }
 
+/* Rows sit on the page background, which is dark in darkly/vapor but light in lux - every color
+   here must come from a theme variable or the neutral gray family, never a hardcoded white. */
 .card_dungeonroute.leaderboard_row {
     padding: 0.5rem 0.25rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    border-bottom: 1px solid rgba(128, 128, 128, 0.18);
     transition: background-color 0.12s ease;
 }
 
 .card_dungeonroute.leaderboard_row:hover {
-    background-color: rgba(255, 255, 255, 0.04);
+    background-color: rgba(128, 128, 128, 0.1);
 }
 
 .card_dungeonroute.leaderboard_row .leaderboard_rank {
@@ -238,7 +288,7 @@
     margin-right: 0.75rem;
     border-radius: 6px;
     /* Subtle always-on backdrop so a transparent fallback image still reads as an intentional slot */
-    background-color: rgba(255, 255, 255, 0.05);
+    background-color: rgba(128, 128, 128, 0.15);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
@@ -250,7 +300,7 @@
 }
 
 .card_dungeonroute.leaderboard_row .leaderboard_title a {
-    color: #fff;
+    color: var(--theme-text-contrast);
     font-weight: 600;
     text-decoration: none;
 }
@@ -260,7 +310,7 @@
 }
 
 .card_dungeonroute.leaderboard_row .leaderboard_author a {
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--bs-secondary-color);
 }
 
 /* Fixed-ish column widths so the stats scan as vertical columns across rows */
@@ -268,9 +318,9 @@
     display: inline-block;
     min-width: 5rem;
     padding: 0.1rem 0.5rem;
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(128, 128, 128, 0.5);
     border-radius: 999px;
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--bs-secondary-color);
     text-align: end;
     white-space: nowrap;
 }
@@ -312,7 +362,7 @@
 }
 
 .card_dungeonroute.leaderboard_row .menu_actions_btn i {
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--bs-secondary-color);
 }
 
 @media (max-width: 767.98px) {

--- a/resources/views/common/dungeonroute/cardhero.blade.php
+++ b/resources/views/common/dungeonroute/cardhero.blade.php
@@ -114,7 +114,9 @@ use (
         <div class="row g-0 px-3 hero_title_row">
             <div class="col">
                 <h3 class="mb-1 hero_title">
-                    <a href="{{ route('dungeonroute.view', ['dungeon' => $dungeonroute->dungeon, 'dungeonroute' => $dungeonroute, 'title' => $dungeonroute->getTitleSlug()]) }}">
+                    {{-- The title clamps to two lines (see discover.css); the attribute keeps the full text reachable --}}
+                    <a href="{{ route('dungeonroute.view', ['dungeon' => $dungeonroute->dungeon, 'dungeonroute' => $dungeonroute, 'title' => $dungeonroute->getTitleSlug()]) }}"
+                       title="{{ $dungeonroute->title }}">
                         {{ $dungeonroute->title }}
                     </a>
                 </h3>

--- a/resources/views/common/dungeonroute/cardposter.blade.php
+++ b/resources/views/common/dungeonroute/cardposter.blade.php
@@ -82,7 +82,9 @@ use (
         <div class="row g-0 px-2 align-items-end poster_title_row">
             <div class="col">
                 <h4 class="mb-0 title">
-                    <a href="{{ route('dungeonroute.view', ['dungeon' => $dungeonroute->dungeon, 'dungeonroute' => $dungeonroute, 'title' => $dungeonroute->getTitleSlug()]) }}">
+                    {{-- The title clamps to two lines (see discover.css); the attribute keeps the full text reachable --}}
+                    <a href="{{ route('dungeonroute.view', ['dungeon' => $dungeonroute->dungeon, 'dungeonroute' => $dungeonroute, 'title' => $dungeonroute->getTitleSlug()]) }}"
+                       title="{{ $dungeonroute->title }}">
                         {{ $dungeonroute->title }}
                     </a>
                 </h4>
@@ -110,14 +112,15 @@ use (
             </div>
         @endif
 
-        <div class="row g-0 bg-card-footer px-2 py-1 poster_footer">
+        <?php // The footer is styled in discover.css as part of the dark-imagery object (bg-card-footer is near-transparent in lux) ?>
+        <div class="row g-0 px-2 py-1 poster_footer">
             <div class="col">
                 <div class="poster_author d-flex align-items-center">
                     @include('common.user.name', ['user' => $dungeonroute->author, 'link' => true, 'showAnonIcon' => false])
                     {{-- Reserved slot for the future Raider.IO author trust badge (see #3349) --}}
                     <span class="poster_trust_badge ms-1"></span>
                 </div>
-                <div class="poster_social small text-muted">
+                <div class="poster_social small">
                     @if( $ratingCount > 0 )
                         <span class="poster_rating">
                             @include('common.dungeonroute.rating', ['count' => $ratingCount, 'rating' => (int) round($dungeonroute->rating)])

--- a/resources/views/common/dungeonroute/cardrow.blade.php
+++ b/resources/views/common/dungeonroute/cardrow.blade.php
@@ -102,7 +102,8 @@ $cacheFn = static function () use (
         @include('common.dungeonroute.pullgraph', [
             'pullForces'  => $pullForces,
             'chartHeight' => 22,
-            'fill'        => 'rgba(255, 255, 255, 0.45)',
+            // Inherits the stats cluster's muted text color, so the bars stay visible in every theme
+            'fill'        => 'currentColor',
             'bossFill'    => 'rgba(240, 180, 60, 0.9)',
             'graphClass'  => 'leaderboard_pull_graph me-3',
             'tooltipKey'  => 'view_common.dungeonroute.cardrow.pulls',

--- a/resources/views/common/dungeonroute/leaderboard.blade.php
+++ b/resources/views/common/dungeonroute/leaderboard.blade.php
@@ -25,7 +25,10 @@ $pullForcesResolver ??= new DungeonRouteEnemyForcesPageResolver(
 @if($dungeonroutes->isEmpty())
     <div class="row g-0">
         <div class="col-xl text-center">
-            {{ __('view_common.dungeonroute.cardlist.no_dungeonroutes') }}
+            <p>{{ __('view_common.dungeonroute.cardlist.no_dungeonroutes') }}</p>
+            <a class="btn btn-accent" href="{{ route('dungeonroute.new') }}">
+                <i class="fas fa-plus"></i> {{ __('view_common.dungeonroute.leaderboard.create_first_route') }}
+            </a>
         </div>
     </div>
 @else

--- a/resources/views/dungeonroute/discover/dungeon/overview.blade.php
+++ b/resources/views/dungeonroute/discover/dungeon/overview.blade.php
@@ -143,7 +143,8 @@ use Laravel\Pennant\Feature;
         @if($paginator->hasPages())
             <div class="row mt-4">
                 <div class="col d-flex justify-content-center discover_pagination">
-                    {{ $paginator->links() }}
+                    <?php // A compact window: the full page list otherwise overflows phone viewports ?>
+                    {{ $paginator->onEachSide(1)->links() }}
                 </div>
             </div>
         @endif

--- a/resources/views/dungeonroute/discover/dungeon/overview.blade.php
+++ b/resources/views/dungeonroute/discover/dungeon/overview.blade.php
@@ -122,23 +122,26 @@ use Laravel\Pennant\Feature;
             ->reject(fn(DungeonRoute $route) => $heroRouteIds->contains($route->id))
             ->values();
         ?>
-        <div class="row mt-5 align-items-center discover_section_header">
-            <div class="col">
-                <h5 class="mb-0 text-center">
-                    {{ __('view_dungeonroute.discover.dungeon.overview.community_routes') }}
-                </h5>
+        <?php // When every route already fills the hero band above, an empty "no routes" leaderboard here would be misleading ?>
+        @if($leaderboardRoutes->isNotEmpty() || $heroRouteIds->isEmpty())
+            <div class="row mt-5 align-items-center discover_section_header">
+                <div class="col">
+                    <h5 class="mb-0 text-center">
+                        {{ __('view_dungeonroute.discover.dungeon.overview.community_routes') }}
+                    </h5>
+                </div>
             </div>
-        </div>
-        <div class="row mt-2">
-            <div class="col">
-                @include('common.dungeonroute.leaderboard', [
-                    'dungeonroutes' => $leaderboardRoutes,
-                    'startRank' => $startRank,
-                    'cache' => true,
-                    'pullForcesResolver' => $pullForcesResolver,
-                ])
+            <div class="row mt-2">
+                <div class="col">
+                    @include('common.dungeonroute.leaderboard', [
+                        'dungeonroutes' => $leaderboardRoutes,
+                        'startRank' => $startRank,
+                        'cache' => true,
+                        'pullForcesResolver' => $pullForcesResolver,
+                    ])
+                </div>
             </div>
-        </div>
+        @endif
 
         @if($paginator->hasPages())
             <div class="row mt-4">

--- a/tests/Feature/Controller/DungeonRoute/DungeonRouteDiscoverCategoryTest.php
+++ b/tests/Feature/Controller/DungeonRoute/DungeonRouteDiscoverCategoryTest.php
@@ -223,6 +223,32 @@ final class DungeonRouteDiscoverCategoryTest extends PublicTestCase
         }
     }
 
+    #[Test]
+    public function discoverDungeon_givenReworkFlagActiveAndAllRoutesFitTheHeroBand_hidesEmptyCommunitySection(): void
+    {
+        // Arrange - exactly 3 routes are all promoted into the hero band, leaving none for the leaderboard
+        Feature::define(DungeonRouteListRework::class, true);
+        [$gameVersion, $dungeon, $routes] = $this->createQualifyingRoutes(3);
+
+        try {
+            // Act
+            $response = $this->get(route('dungeonroutes.discoverdungeon', [
+                'gameVersion' => $gameVersion,
+                'dungeon'     => $dungeon,
+            ]));
+
+            // Assert - the hero band shows all 3 routes; the "Community routes" section is skipped
+            // entirely rather than misleadingly claiming no routes exist directly below them
+            $response->assertOk();
+            $response->assertSee('discover_hero_band', false);
+            $response->assertDontSee(__('view_dungeonroute.discover.dungeon.overview.community_routes'));
+            $response->assertDontSee(__('view_common.dungeonroute.cardlist.no_dungeonroutes'));
+            $response->assertDontSee(__('view_common.dungeonroute.leaderboard.create_first_route'));
+        } finally {
+            $routes->each(fn(DungeonRoute $route) => $route->delete());
+        }
+    }
+
     /**
      * Resolves an active dungeon (with a current mapping version and floors) plus its game version.
      * @return array{0: GameVersion, 1: Dungeon}

--- a/tests/Feature/View/Common/DungeonRoute/CardHeroTest.php
+++ b/tests/Feature/View/Common/DungeonRoute/CardHeroTest.php
@@ -35,6 +35,29 @@ final class CardHeroTest extends PublicTestCase
     }
 
     #[Test]
+    public function render_givenRoute_returnsTitleAttributeOnTitleLink(): void
+    {
+        // Arrange
+        $dungeonroute = DungeonRoute::factory()->create([
+            'title' => 'A very long route title that the hero card clamps to two lines',
+        ]);
+
+        try {
+            // Act
+            $html = view('common.dungeonroute.cardhero', [
+                'dungeonroute' => $dungeonroute,
+                'archetype'    => null,
+                'cache'        => false,
+            ])->render();
+
+            // Assert - the visible title clamps to two lines, so the link carries the full text as a title attribute
+            $this->assertStringContainsString(sprintf('title="%s"', e($dungeonroute->title)), $html);
+        } finally {
+            $dungeonroute->delete();
+        }
+    }
+
+    #[Test]
     public function render_givenArchetype_returnsArchetypeLabel(): void
     {
         // Arrange

--- a/tests/Feature/View/Common/DungeonRoute/CardPosterTest.php
+++ b/tests/Feature/View/Common/DungeonRoute/CardPosterTest.php
@@ -38,6 +38,28 @@ final class CardPosterTest extends PublicTestCase
     }
 
     #[Test]
+    public function render_givenRoute_returnsTitleAttributeOnTitleLink(): void
+    {
+        // Arrange
+        $dungeonroute = DungeonRoute::factory()->create([
+            'title' => 'A very long route title that the poster card clamps to two lines',
+        ]);
+
+        try {
+            // Act
+            $html = view('common.dungeonroute.cardposter', [
+                'dungeonroute' => $dungeonroute,
+                'cache'        => false,
+            ])->render();
+
+            // Assert - the visible title clamps to two lines, so the link carries the full text as a title attribute
+            $this->assertStringContainsString(sprintf('title="%s"', e($dungeonroute->title)), $html);
+        } finally {
+            $dungeonroute->delete();
+        }
+    }
+
+    #[Test]
     public function render_givenRatedRoute_returnsRatingStars(): void
     {
         // Arrange

--- a/tests/Feature/View/Common/DungeonRoute/LeaderboardTest.php
+++ b/tests/Feature/View/Common/DungeonRoute/LeaderboardTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature\View\Common\DungeonRoute;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('View')]
+#[Group('Leaderboard')]
+final class LeaderboardTest extends PublicTestCase
+{
+    #[Test]
+    public function render_givenNoRoutes_returnsCreateFirstRouteCallToAction(): void
+    {
+        // Act
+        $html = view('common.dungeonroute.leaderboard', [
+            'dungeonroutes' => collect(),
+            'cache'         => false,
+        ])->render();
+
+        // Assert - the empty state invites the visitor to act instead of dead-ending
+        $this->assertStringContainsString(__('view_common.dungeonroute.cardlist.no_dungeonroutes'), $html);
+        $this->assertStringContainsString(__('view_common.dungeonroute.leaderboard.create_first_route'), $html);
+        $this->assertStringContainsString(route('dungeonroute.new'), $html);
+    }
+}


### PR DESCRIPTION
:robot: Closes #3978

## Summary
- Poster/hero cards, leaderboard rows, and discover pagination hardcoded `rgba(255, 255, 255, ...)` colors that only look right in the darkly theme; swap them for `var(--theme-*)`/`var(--bs-*)` tokens per DESIGN.md so lux (light background) and vapor render correctly too.
- Poster/hero card titles clamp to 2 lines so long titles don't blow out the fixed card height; full title stays reachable via the link's `title` attribute.
- Cardrow pull-graph fill switches from a hardcoded white rgba to `currentColor`.
- Discover pagination wraps on narrow viewports instead of overflowing/clipping on phones, and uses `onEachSide(1)` for a compact page-link window.
- Empty leaderboard state gets a "Create the first route" CTA.

## Test plan
- [x] `php artisan test --compact tests/Feature/View/Common/DungeonRoute` — 30 passed
- [x] `composer run fix` clean
- [x] `composer run analyse` clean
- [ ] Visual verification (darkly/lux/vapor) — pending