### PR TITLE
#3976 Compendium event feed glyphs follow meaning, not source table

### DIFF
--- a/resources/views/compendium/sections/event_list.blade.php
+++ b/resources/views/compendium/sections/event_list.blade.php
@@ -49,8 +49,8 @@ $eventGlyph = static function (CombatLogNpcEvent|CombatLogSpellEvent $event): ar
 
     return match ($event->event_type) {
         CombatLogSpellEventType::SpellCreated => ['icon' => 'fas fa-plus', 'color' => 'text-info'],
-        CombatLogSpellEventType::PropertyChanged => ['icon' => 'fas fa-arrow-up', 'color' => 'text-warning'],
-        CombatLogSpellEventType::PropertyRemoved => ['icon' => 'fas fa-times', 'color' => 'text-danger'],
+        CombatLogSpellEventType::PropertyChanged => ['icon' => 'fas fa-plus', 'color' => 'text-success'],
+        CombatLogSpellEventType::PropertyRemoved => ['icon' => 'fas fa-minus', 'color' => 'text-danger'],
         CombatLogSpellEventType::SchoolRecorded => ['icon' => 'fas fa-plus', 'color' => 'text-info'],
     };
 };

--- a/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
+++ b/tests/Feature/Controller/Compendium/NpcCompendiumControllerActivityTest.php
@@ -202,6 +202,89 @@ final class NpcCompendiumControllerActivityTest extends PublicTestCase
     }
 
     #[Test]
+    public function activityDay_givenAddedNpcAndSpellEvents_rendersSameGlyph(): void
+    {
+        // Arrange - a "something started applying" event from each of the NPC and spell tables,
+        // on the same unique day, must render with the same icon/color regardless of which table
+        // the event came from
+        $uniqueDate       = '2025-07-21';
+        $npcId            = DB::table('npc_dungeons')->where('dungeon_id', $this->dungeon->id)->value('npc_id');
+        $characteristicId = Characteristic::query()->orderBy('id')->value('id');
+
+        $npcEventId = CombatLogNpcEvent::query()->insertGetId([
+            'npc_id'      => $npcId,
+            'event_type'  => CombatLogNpcEventType::CharacteristicAdded->value,
+            'model_class' => Characteristic::class,
+            'model_id'    => $characteristicId,
+            'created_at'  => $uniqueDate . ' 12:00:00',
+        ]);
+        $spellEventId = CombatLogSpellEvent::query()->insertGetId([
+            'spell_id'   => self::TEST_SPELL_ID,
+            'event_type' => CombatLogSpellEventType::PropertyChanged->value,
+            'property'   => SpellProperty::Aura->value,
+            'created_at' => $uniqueDate . ' 12:01:00',
+        ]);
+
+        try {
+            // Act
+            $response = $this->get(route('compendium.activity.day', ['dungeon' => $this->dungeon, 'date' => $uniqueDate]));
+
+            // Assert - both rows use the "added" glyph (fa-plus, text-success) and none of them use
+            // the old spell-only fa-arrow-up/text-warning glyph
+            $response->assertOk();
+            $response->assertSeeInOrder([
+                '<span class="compendium_log_icon text-success">',
+                '<i class="fas fa-plus"></i>',
+            ], false);
+            $response->assertDontSee('fa-arrow-up');
+        } finally {
+            CombatLogNpcEvent::query()->where('id', $npcEventId)->delete();
+            CombatLogSpellEvent::query()->where('id', $spellEventId)->delete();
+        }
+    }
+
+    #[Test]
+    public function activityDay_givenRemovedNpcAndSpellEvents_rendersSameGlyph(): void
+    {
+        // Arrange - a "something stopped applying" event from each of the NPC and spell tables, on
+        // the same unique day, must render with the same icon/color regardless of which table the
+        // event came from
+        $uniqueDate       = '2025-07-22';
+        $npcId            = DB::table('npc_dungeons')->where('dungeon_id', $this->dungeon->id)->value('npc_id');
+        $characteristicId = Characteristic::query()->orderBy('id')->value('id');
+
+        $npcEventId = CombatLogNpcEvent::query()->insertGetId([
+            'npc_id'      => $npcId,
+            'event_type'  => CombatLogNpcEventType::CharacteristicRemoved->value,
+            'model_class' => Characteristic::class,
+            'model_id'    => $characteristicId,
+            'created_at'  => $uniqueDate . ' 12:00:00',
+        ]);
+        $spellEventId = CombatLogSpellEvent::query()->insertGetId([
+            'spell_id'   => self::TEST_SPELL_ID,
+            'event_type' => CombatLogSpellEventType::PropertyRemoved->value,
+            'property'   => SpellProperty::Aura->value,
+            'created_at' => $uniqueDate . ' 12:01:00',
+        ]);
+
+        try {
+            // Act
+            $response = $this->get(route('compendium.activity.day', ['dungeon' => $this->dungeon, 'date' => $uniqueDate]));
+
+            // Assert - both rows use the same "removed" glyph (fa-minus, text-danger)
+            $response->assertOk();
+            $response->assertSeeInOrder([
+                '<span class="compendium_log_icon text-danger">',
+                '<i class="fas fa-minus"></i>',
+            ], false);
+            $response->assertDontSee('fa-times');
+        } finally {
+            CombatLogNpcEvent::query()->where('id', $npcEventId)->delete();
+            CombatLogSpellEvent::query()->where('id', $spellEventId)->delete();
+        }
+    }
+
+    #[Test]
     public function activityDay_givenInvalidDateFormat_returnsNotFound(): void
     {
         // Act


### PR DESCRIPTION
:robot: Closes #3976

## Summary
- The compendium event feed picked its icon/color by which table (NPC characteristic vs spell property) an event came from, so the same wording ("Affected by X" / "Unaffected by X") rendered with different glyphs.
- `PropertyChanged` now uses the same glyph as `CharacteristicAdded` (`fa-plus`, `text-success`), and `PropertyRemoved` now uses the same glyph as `CharacteristicRemoved` (`fa-minus`, `text-danger`).

## Test plan
- [x] `php artisan test --compact --group=Compendium` — 58 passed
- [x] Added two feature tests asserting the NPC and spell events render the same icon markup for the added/removed cases
- [x] `composer run analyse` — no errors
- [x] `composer run fix` — no changes needed