### PR TITLE
#3974 Add a View on Wowhead link to the NPC compendium page

### DIFF
--- a/app/Models/Npc/Npc.php
+++ b/app/Models/Npc/Npc.php
@@ -104,6 +104,7 @@ class Npc extends CacheModel implements MappingModelInterface
 
     protected $appends = [
         'enemy_portrait_url',
+        'wowhead_url',
     ];
 
     protected function casts(): array
@@ -138,6 +139,17 @@ class Npc extends CacheModel implements MappingModelInterface
     public function getEnemyPortraitUrlAttribute(): string
     {
         return sprintf('images/enemyportraits/%d.png', $this->id);
+    }
+
+    public function getWowheadUrlAttribute(): string
+    {
+        $result = sprintf('https://www.wowhead.com/npc=%d', $this->id);
+
+        if (!empty(__($this->name))) {
+            $result .= '/' . Str::slug(__($this->name));
+        }
+
+        return $result;
     }
 
     /**

--- a/lang/en_US/view_compendium.php
+++ b/lang/en_US/view_compendium.php
@@ -89,7 +89,8 @@ return [
             'table_header_spells'   => 'Spells',
         ],
         'show' => [
-            'title' => ':name - NPC Compendium',
+            'title'   => ':name - NPC Compendium',
+            'wowhead' => 'View on Wowhead',
         ],
         'sections' => [
             'header' => [

--- a/resources/views/compendium/npc/sections/header.blade.php
+++ b/resources/views/compendium/npc/sections/header.blade.php
@@ -66,4 +66,10 @@ foreach (['dangerous', 'truesight', /*'bursting', 'bolstering', 'sanguine',*/ 'r
 {{--            @endif--}}
         </div>
     </div>
+    <div class="compendium_identity_actions">
+        <a href="{{ $npc->wowhead_url }}" target="_blank" rel="noopener" class="btn btn-sm btn-secondary" data-wh-icon-size="small">
+            {{ __('view_compendium.npc.show.wowhead') }}
+            <i class="fas fa-external-link-alt ms-1"></i>
+        </a>
+    </div>
 </div>

--- a/tests/Feature/Controller/Compendium/NpcCompendiumControllerTest.php
+++ b/tests/Feature/Controller/Compendium/NpcCompendiumControllerTest.php
@@ -183,6 +183,21 @@ final class NpcCompendiumControllerTest extends PublicTestCase
     }
 
     #[Test]
+    public function show_givenValidNpc_seesWowheadLink(): void
+    {
+        // Arrange
+        $npc = Npc::with('classification')->first();
+        $this->assertNotNull($npc);
+
+        // Act
+        $response = $this->get(route('npc.compendium.show', $npc));
+
+        // Assert
+        $response->assertOk();
+        $response->assertSee($npc->wowhead_url, false);
+    }
+
+    #[Test]
     public function show_givenCorrectSlug_returnsOk(): void
     {
         // Arrange


### PR DESCRIPTION
:robot: Closes #3974

The spell compendium page has a "View on Wowhead" button in its identity band; the NPC compendium
page did not. This adds the same affordance, mirroring `Spell::getWowheadUrlAttribute` /
`Spell::getWowheadLink` — `Npc` has no `game_version_id` column, so the link is simply
`wowhead.com/npc={id}/{slug}` with no version-domain switching.

## Test plan
- [x] `NpcCompendiumControllerTest::show_givenValidNpc_seesWowheadLink` (new)
- [x] `php artisan test --compact --filter=NpcCompendiumControllerTest` — 15 passed
- [x] `composer run fix` / `composer run analyse` — clean
- [x] Verified in headless Chrome: button renders in the identity band, links to
      `https://www.wowhead.com/npc=68/stormwind-city-guard`