### PR TITLE
#3967 Kill area button visibly reflects add vs remove state

### DIFF
--- a/resources/assets/js/custom/inline/common/maps/editsidebar/pullworkbench.js
+++ b/resources/assets/js/custom/inline/common/maps/editsidebar/pullworkbench.js
@@ -179,15 +179,21 @@ class PullWorkBench extends Signalable {
          * Code to prevent calling refreshTooltips too often
          */
         let $killAreaLabel = $(`#map_killzonessidebar_killzone_kill_area_label`);
+        let $killAreaButton = $(`#map_killzonessidebar_killzone_has_killzone`);
+        let $killAreaIcon = $(`#map_killzonessidebar_killzone_has_killzone_icon`);
 
         let resultMessage;
         // Set and is currently 0
         if (this.killZone.hasKillArea()) {
             // It was not, update it
             resultMessage = lang.get('js.pull_workbench_remove_kill_area_label');
+            $killAreaButton.removeClass('btn-primary').addClass('btn-danger');
+            $killAreaIcon.removeClass('fa-bullseye').addClass('fa-ban');
         } else {
             // Default
             resultMessage = lang.get('js.pull_workbench_add_kill_area_label');
+            $killAreaButton.removeClass('btn-danger').addClass('btn-primary');
+            $killAreaIcon.removeClass('fa-ban').addClass('fa-bullseye');
         }
 
         $killAreaLabel.attr('title', resultMessage).refreshTooltips();

--- a/resources/views/common/maps/controls/pullsworkbench.blade.php
+++ b/resources/views/common/maps/controls/pullsworkbench.blade.php
@@ -56,7 +56,7 @@ $spellsSelect = $spellsSelect->mapWithKeys(static fn(Collection $spells, string 
                  data-bs-toggle="tooltip" title="">
                 <button id="map_killzonessidebar_killzone_has_killzone"
                         class="btn btn-primary" data-bs-toggle="button" aria-pressed="false">
-                    <i class="fas fa-bullseye"></i>
+                    <i id="map_killzonessidebar_killzone_has_killzone_icon" class="fas fa-bullseye"></i>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
:robot: Closes #3967

The "kill area" button in the pull workbench only updated its tooltip text
between "Add kill area" / "Remove kill area" - the visible button never
changed, so there was no at-a-glance way to tell which action clicking it
would perform.

## What changed
- The button now also toggles color: `btn-primary` (add) vs `btn-danger`
  (remove).
- The icon swaps between `fa-bullseye` (add) and `fa-ban` (remove).
- Tooltip behavior is unchanged.

## Test plan
- [x] Verified in headless Chrome against a real pull: with no kill area set
  the button is blue with a bullseye icon; once a kill area exists it turns
  red with a ban icon.
- Cold review skipped under the trivial-change rule (≤20 changed lines, no
  schema/auth/security change, purely visual JS/blade tweak, no UI logic
  branch beyond existing hasKillArea() check).