### PR TITLE
#3966 Restore adding vertices to lines during route edit

### DIFF
--- a/resources/assets/js/custom/mapcontrols/drawcontrols.js
+++ b/resources/assets/js/custom/mapcontrols/drawcontrols.js
@@ -69,10 +69,12 @@ L.DrawToolbar.prototype.getModeHandlers = function (map) {
     ];
 };
 
-// Prevent the editing of
+// Prevent the creation of new vertices during edit for layers that opted out (arrows, which are
+// always exactly two vertices). Every other polyline keeps Leaflet.draw's middle markers - dragging
+// one is the only way to insert a vertex into an existing line (#3966).
 const _originalCreateMiddleMarker = L.Edit.PolyVerticesEdit.prototype._createMiddleMarker;
 L.Edit.PolyVerticesEdit.prototype._createMiddleMarker = function (marker1, marker2) {
-    if (!this._poly.options.allowVertexCreationDuringEdit) {
+    if (this._poly.options.allowVertexCreationDuringEdit === false) {
         return;
     }
     _originalCreateMiddleMarker.call(this, marker1, marker2);

--- a/resources/assets/js/custom/mapcontrols/drawcontrols.test.js
+++ b/resources/assets/js/custom/mapcontrols/drawcontrols.test.js
@@ -1,0 +1,124 @@
+// ---------------------------------------------------------------------------
+// Covers #3966: adding a new vertex to an existing line during edit.
+//
+// Leaflet.draw inserts a vertex when you drag the translucent "middle marker"
+// it renders halfway between two vertices. drawcontrols.js monkeypatches
+// L.Edit.PolyVerticesEdit#_createMiddleMarker so arrows - which are always
+// exactly two vertices - do not get them. That guard has to be opt-OUT: every
+// other polyline (path, brushline, killzone path, enemy patrol, floor union
+// area) must keep its middle markers.
+//
+// These tests drive the REAL leaflet + leaflet-draw packages so the patch is
+// exercised through Leaflet.draw's own editing handler, not a stand-in.
+// ---------------------------------------------------------------------------
+
+// leaflet-draw binds to the global `L` at require time, so real Leaflet has to
+// replace the setup.js stub before it is pulled in.
+global.L = require('leaflet');
+global.window.L = global.L;
+require('leaflet-draw');
+
+// drawcontrols.js is a global-script file: `$.extend` and these two base
+// classes are all it touches at load time.
+global.$ = require('jquery');
+global.MapControl = class MapControl {
+};
+global.DungeonMap = class DungeonMap {
+};
+
+require('./drawcontrols');
+
+// Arrow extends Polyline, which it only needs as a base class here; the flag
+// under test is set in its own onLayerInit().
+global.Polyline = class Polyline {
+    constructor(map, layer) {
+        this.layer = layer;
+    }
+
+    onLayerInit() {
+    }
+};
+
+const Arrow = require('../models/arrow');
+
+/**
+ * Builds a real Leaflet map on a sized jsdom container. jsdom reports every
+ * element as 0x0, so the container's dimensions are stubbed - Leaflet refuses
+ * to lay out markers in a zero-sized viewport.
+ *
+ * @returns {L.Map}
+ */
+function createMap() {
+    const container = document.createElement('div');
+    Object.defineProperty(container, 'clientWidth', {value: 800});
+    Object.defineProperty(container, 'clientHeight', {value: 600});
+    document.body.appendChild(container);
+
+    return L.map(container, {center: [0, 0], zoom: 2});
+}
+
+/**
+ * Enables Leaflet.draw's vertex editing on a 3-point polyline and counts the
+ * markers it put on the map. 3 vertices yield 3 vertex markers, plus one middle
+ * marker per segment when vertex creation is allowed.
+ *
+ * @param options {object} Layer options, e.g. {allowVertexCreationDuringEdit: false}
+ * @returns {{total: Number, middle: Number}}
+ */
+function countEditMarkers(options) {
+    const map = createMap();
+    const polyline = L.polyline([[0, 0], [1, 1], [2, 0]], options).addTo(map);
+
+    polyline.editing.enable();
+
+    // L.Edit.Poly delegates to one L.Edit.PolyVerticesEdit per ring; a plain
+    // polyline has exactly one. Its _markerGroup holds the vertex markers and
+    // whatever middle markers _createMiddleMarker produced.
+    const verticesHandler = polyline.editing._verticesHandlers[0];
+    const markers = [];
+    verticesHandler._markerGroup.eachLayer((marker) => markers.push(marker));
+
+    return {
+        total: markers.length,
+        middle: markers.length - verticesHandler._markers.length,
+    };
+}
+
+describe('DrawControls middle marker patch (#3966)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('createMiddleMarker_givenPolylineWithoutFlag_createsMiddleMarker', () => {
+        // A path/brushline/killzone path never sets the flag; it must still be
+        // able to gain vertices. This is the assertion that fails on master,
+        // where the guard was `!options.allowVertexCreationDuringEdit`.
+        const {total, middle} = countEditMarkers({});
+
+        expect(middle).toBe(2);
+        expect(total).toBe(5);
+    });
+
+    test('createMiddleMarker_givenArrowWithFlagFalse_skipsMiddleMarker', () => {
+        // Arrows opt out - they are start + tip and nothing in between.
+        const {total, middle} = countEditMarkers({allowVertexCreationDuringEdit: false});
+
+        expect(middle).toBe(0);
+        expect(total).toBe(3);
+    });
+});
+
+describe('Arrow vertex creation opt-out (#3966)', () => {
+    test('onLayerInit_givenRebuiltLayer_reappliesVertexCreationFlag', () => {
+        // MapObjectGroup#setLayerToMapObject() replaces mapObject.layer wholesale
+        // on every rebuild (floor switch, live session update), so a flag set once
+        // in the constructor would be lost and the arrow would regain its middle
+        // markers.
+        const arrow = Object.create(Arrow.prototype);
+        arrow.layer = L.polyline([[0, 0], [1, 1]]);
+
+        arrow.onLayerInit();
+
+        expect(arrow.layer.options.allowVertexCreationDuringEdit).toBe(false);
+    });
+});

--- a/resources/assets/js/custom/models/arrow.js
+++ b/resources/assets/js/custom/models/arrow.js
@@ -37,10 +37,23 @@ class Arrow extends Polyline {
         super(map, layer, {name: 'arrow', has_route_model_binding: true, ignore_mapping_version_suffix: true});
 
         this.label = 'Arrow';
-        this.layer.options.allowVertexCreationDuringEdit = false;
         this.decorator = null;
 
         this.setSynced(false);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    onLayerInit() {
+        console.assert(this instanceof Arrow, 'this is not an Arrow', this);
+        super.onLayerInit();
+
+        // An arrow is always exactly two vertices, so it opts out of the middle markers that
+        // Leaflet.draw uses to insert new ones. MapObjectGroup#setLayerToMapObject() hands the map
+        // object a brand new layer on every rebuild (floor switch, live session update), so this
+        // must be (re)applied per layer rather than once in the constructor (#3966).
+        this.layer.options.allowVertexCreationDuringEdit = false;
     }
 
     /**
@@ -74,4 +87,10 @@ class Arrow extends Polyline {
     toString() {
         return 'Arrow';
     }
+}
+
+// Guarded export for the test runner (Vitest). This is a no-op in the browser,
+// where `module` is undefined, so it does not affect the concatenated bundle.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Arrow;
 }


### PR DESCRIPTION
:robot: Closes #3966

## What was wrong

`8318433de` (#2473, shipped 2026-06-09) added a **global** monkeypatch of Leaflet.draw's
middle-marker factory so arrows could not gain extra vertices during edit. The guard was written
opt-**in**:

```js
if (!this._poly.options.allowVertexCreationDuringEdit) { return; }
```

but `allowVertexCreationDuringEdit` is only ever *written* in one place in the codebase —
`arrow.js`, where it is set to `false`. Nothing ever set it to `true`, so for every other polyline
the option was `undefined`, `!undefined === true`, and the patch returned early. Middle markers are
the only way to insert a vertex into an existing line, so every editable polyline silently lost that
ability for ~2 months:

- **route editor**: paths and brushlines
- **mapping-version editor**: admin enemy patrols, floor unions and floor union areas

(Killzone paths and non-admin enemy patrols both return `false` from `isEditable()`, so they never
reach `editableLayers` and were never affected either way.)

## The fix

1. Invert the guard to opt-**out** (`=== false`). Arrow's explicit `false` still wins; everything
   else behaves as Leaflet.draw ships it, i.e. exactly as it did before June.
2. Move Arrow's flag from the constructor into `onLayerInit()`. `MapObjectGroup#setLayerToMapObject()`
   replaces `mapObject.layer` wholesale on every rebuild (floor switch, live-session update), so a
   flag set once at construction is lost — and the inversion in (1) is what makes that loss
   *observable*: a rebuilt arrow would have regained its middle markers. Verified below.

## Tests

New `resources/assets/js/custom/mapcontrols/drawcontrols.test.js` drives the real `leaflet` +
`leaflet-draw` packages through Leaflet.draw's own editing handler:

- `createMiddleMarker_givenPolylineWithoutFlag_createsMiddleMarker` — 3-point polyline gets 2 middle markers
- `createMiddleMarker_givenArrowWithFlagFalse_skipsMiddleMarker` — the arrow restriction survives
- `onLayerInit_givenRebuiltLayer_reappliesVertexCreationFlag` — guards (2)

Both regression assertions are **red on master** (`expected +0 to be 2`) and green here. Full JS
suite: 634 passed.

## Browser verification

Real headless Chrome, route edit mode with a 3-point path and a 2-point arrow, edit handler active:

| | path middle markers | arrow middle markers | arrow flag after a real `setLayerToMapObject()` swap |
|---|---|---|---|
| before | **0** | 0 | **lost (`undefined`)** |
| after | **2** | 0 | `false` (kept) |

![before](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3966-before.png)
![after](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/3966-after.png)

The faint extra handles along the red dashed path in the "after" shot are the restored middle
markers; the blue dashed arrow correctly keeps only its two endpoints in both.

The one page error logged (`Cannot read properties of undefined (reading 'length')`) is present
identically on the baseline — pre-existing, unrelated.

Note: JS change, so it cannot be hotfixed onto the current release — it ships with the next one.
