### PR TITLE
#3993 Import MDT genericItem POIs and report the ones we have no icon for

### DIFF
--- a/.claude/skills/update-mdt-package/SKILL.md
+++ b/.claude/skills/update-mdt-package/SKILL.md
@@ -426,10 +426,10 @@ formatting of the rewritten `npcs.php` files, per the project's finishing-up con
    change — screenshot the explore page of the dungeons whose mapping actually changed with the
    `headless-browser-verify` skill (A/B against the main stack as baseline) and post them on the
    MR. Also remind the user to browse the explore pages themselves.
-4. **Also check what the suite can't see:** `MapTilesExistenceTest` fails on its *first* dungeon
-   in a worktree (the assets dir isn't mounted), so it never reaches the newly imported ones and
-   cannot tell you a new floor is missing map tiles. Check the seeder export instead. **Floors are
-   not their own file** — there is no `floors.json`; each dungeon object in
+4. **Also check the seeder export for new floors.** `MapTilesExistenceTest` does run in a worktree
+   since #3993 mounted the assets repo into the worktree stack — it used to fail on its *first*
+   dungeon and never reach the newly imported ones — so it can now tell you a new floor is missing
+   map tiles. Check the export anyway, it is instant. **Floors are not their own file** — there is no `floors.json`; each dungeon object in
    `database/seeders/dungeondata/dungeons.json` carries a nested `floors` array, so that one file
    is the whole check:
    ```

--- a/.claude/skills/update-mdt-package/SKILL.md
+++ b/.claude/skills/update-mdt-package/SKILL.md
@@ -77,7 +77,7 @@ current retail season's dungeon mappings.
 - [ ] Bump composer package reference (version + commit SHA) and `composer update`
 - [ ] Bump `config/keystoneguru.php` MDT version (before the reimport - it stamps `mdt_addon_version`)
 - [ ] Reimport each retail-season dungeon mapping
-- [ ] Handle any new POI types/templates and missing map-icon translations
+- [ ] Handle any new POI types/templates, unhandled-POI tables, and missing map-icon translations
 - [ ] Run per-dungeon tests (rewrite stale CorrectEvents fixtures)
 - [ ] Refresh the MDT addonVersion => release-date map
 - [ ] Re-export NPC translations and re-seed
@@ -269,6 +269,21 @@ Read the output for each dungeon and handle:
   and report it upstream; `--force` is only for a genuine wholesale remap. Nothing was written when
   this fires: no mapping version is created and `mdt_mapping_hash` is untouched, so the dungeon keeps
   its previous mapping and the next run retries.
+- **The "N MDT map POI(s) … have no map icon type and were NOT imported" table** at the end of
+  the command: MDT draws these, we do not, and the map is missing them. This is the check that
+  catches a *known* POI type we simply have no icon for — the `Found new type` exception above
+  only fires on a type that is not in the enum at all, which is exactly why 19 `genericItem`
+  POIs went missing across six Midnight dungeons unnoticed (#3993). Handle it:
+  `docker compose exec -T app php artisan mapicon:downloadmdtitemicons <dungeonKey> retail`
+  downloads each item's icon into `keystone.guru.assets/images/mapicon_gen/` (MDT's
+  `info.texture` is a FileDataID → wago.tools' `ManifestInterfaceData` DB2 → Wowhead's CDN;
+  Wowhead's *pages* 403 the container, so do not try to scrape a name from there). Then add a
+  map icon type per item — constant + id in `MapIconType::ALL`, `MapIconTypesSeeder`,
+  `lang/en_US/mapicontypes.php`, `GenerateItemIcons`, and
+  `Conversion::MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING` — run
+  `mapicon:generateitemicons`, and **notify the user** with the table so they can sanity-check
+  the naming. The table is printed even on "No change detected", and does **not** affect the
+  exit code.
 - **Other errors:** try to fix them yourself first (the user prefers this). Only pause for the
   user if you get genuinely stuck.
 
@@ -322,9 +337,12 @@ Hand-authoring, when it comes to that (Den of Nalorakk, MDT 6.2.1, mv 841 — 60
 > lines. Redirect to a file and grep for the markers that matter rather than dumping it all,
 > e.g. `... > /tmp/mdt_<key>.log 2>&1; echo "exit=$?"` then
 > `grep -ciE 'Found new (template|type)' /tmp/mdt_<key>.log` and
-> `grep -iE 'No change detected|MappingChanged|MissingTranslation|NpcSetReplaced' /tmp/mdt_<key>.log`.
+> `grep -iE 'No change detected|MappingChanged|MissingTranslation|NpcSetReplaced|UnhandledMapPOI|were NOT imported' /tmp/mdt_<key>.log`.
 > A new POI type/template would make the command **exit non-zero**, so an `exit=0` with zero
-> `Found new` matches confirms no enum changes were needed.
+> `Found new` matches confirms no *enum* changes were needed — it does **not** mean every POI was
+> imported. A known type we have no icon for exits 0 and is only visible in the
+> `were NOT imported` table and the `importMapPOIsUnhandledMapPOI` lines, so grep for those too
+> (#3993).
 
 ## Step 5 — Run that dungeon's tests
 
@@ -399,7 +417,8 @@ formatting of the rewritten `npcs.php` files, per the project's finishing-up con
    don't spend time re-diagnosing it. A failure that's **new** (passed at baseline, fails now)
    is a real regression from the bump — root-cause and fix it before wrapping up, don't just
    report it (per this repo's "fix incidental issues" convention).
-2. Give the user a **summary**: dungeon mappings imported, any new POI types/templates added,
+2. Give the user a **summary**: dungeon mappings imported, any new POI types/templates added, any
+   unhandled-POI table rows (with the map icon types you created for them),
    and any tests still failing, split into **pre-existing** vs **newly broken by this update**
    (especially any unresolved CombatLogRoute failures). Include the **tracking issue number**
    from Step 1.

--- a/app/Console/Commands/MDT/ImportMapping.php
+++ b/app/Console/Commands/MDT/ImportMapping.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands\MDT;
 
+use App\Logic\MDT\Entity\MDTMapPOI;
 use App\Models\Dungeon;
 use App\Models\GameVersion\GameVersion;
 use App\Models\Season;
@@ -9,6 +10,7 @@ use App\Service\Mapping\MappingServiceInterface;
 use App\Service\MDT\MDTMappingImportServiceInterface;
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 
 class ImportMapping extends Command
 {
@@ -45,12 +47,17 @@ class ImportMapping extends Command
             throw new Exception(sprintf('Game version %s not found', $gameVersionKey));
         }
 
+        /** @var Collection<int, Dungeon> $dungeons */
+        $dungeons = new Collection();
+
         if (is_numeric($dungeonKey)) {
             // If it's an ID we should treat it as a season instead
             $season = Season::findOrFail($dungeonKey);
 
             // Cannot do ->with('npcs') here - it won't load the relationship properly due to orWhere(dungeon_id = -1)
             foreach ($season->dungeons as $dungeon) {
+                $dungeons->push($dungeon);
+
                 try {
                     $dungeon->setRelation('npcs', $dungeon->npcs()->get());
                     $mappingImportService->importMappingVersionFromMDT($mappingService, $dungeon, $gameVersion, $force);
@@ -62,10 +69,82 @@ class ImportMapping extends Command
             // Cannot do ->with('npcs') here - it won't load the relationship properly due to orWhere(dungeon_id = -1)
             /** @var Dungeon $dungeon */
             $dungeon = Dungeon::where('key', $dungeonKey)->firstOrFail();
+            $dungeons->push($dungeon);
 
             $dungeon->setRelation('npcs', $dungeon->npcs()->get());
 
             $mappingImportService->importMappingVersionFromMDT($mappingService, $dungeon, $gameVersion, $force);
         }
+
+        $this->renderUnhandledMapPOIs($mappingImportService, $dungeons);
+    }
+
+    /**
+     * Reports every POI MDT draws that we have no map icon type for. These are read straight from MDT rather
+     * than from the import, so they show up even when the import no-ops on an unchanged mapping hash - the
+     * gap exists either way, and used to be entirely invisible (#3993).
+     *
+     * @param Collection<int, Dungeon> $dungeons
+     */
+    private function renderUnhandledMapPOIs(
+        MDTMappingImportServiceInterface $mappingImportService,
+        Collection                       $dungeons,
+    ): void {
+        $rows                  = [];
+        $unhandledMapPOIsTotal = 0;
+
+        foreach ($dungeons as $dungeon) {
+            try {
+                $unhandledMapPOIs = $mappingImportService->getUnhandledMapPOIs($dungeon);
+            } catch (Exception $exception) {
+                $this->error($exception->getMessage());
+
+                continue;
+            }
+
+            $unhandledMapPOIsTotal += $unhandledMapPOIs->count();
+
+            // One row per distinct item rather than per POI - the same item is usually placed several times
+            $unhandledMapPOIsByItem = $unhandledMapPOIs->groupBy(
+                static fn(MDTMapPOI $mdtMapPOI): string => sprintf(
+                    '%s-%s-%s',
+                    $mdtMapPOI->getType()->value,
+                    $mdtMapPOI->getSpellId() ?? '',
+                    $mdtMapPOI->getTextureFileDataId() ?? '',
+                ),
+            );
+
+            foreach ($unhandledMapPOIsByItem as $unhandledMapPOIsForItem) {
+                /** @var MDTMapPOI $mdtMapPOI */
+                $mdtMapPOI = $unhandledMapPOIsForItem->first();
+
+                $rows[] = [
+                    $dungeon->key,
+                    $mdtMapPOI->getType()->value,
+                    $mdtMapPOI->getSpellId() ?? '-',
+                    $mdtMapPOI->getTextureFileDataId() ?? '-',
+                    $unhandledMapPOIsForItem->count(),
+                    $mdtMapPOI->getSpellId() === null
+                        ? '-'
+                        : sprintf('https://www.wowhead.com/spell=%d', $mdtMapPOI->getSpellId()),
+                ];
+            }
+        }
+
+        if ($rows === []) {
+            return;
+        }
+
+        $this->newLine();
+        $this->error(sprintf(
+            '%d MDT map POI(s) across %d distinct item(s) have no map icon type and were NOT imported:',
+            $unhandledMapPOIsTotal,
+            count($rows),
+        ));
+        $this->table(
+            ['Dungeon', 'MDT type', 'Spell ID', 'Texture ID', 'Count', 'Wowhead'],
+            $rows,
+        );
+        $this->line('Run <comment>mapicon:downloadmdtitemicons</comment> for these dungeons to fetch their icons, then add a map icon type for each.');
     }
 }

--- a/app/Console/Commands/MapIcon/DownloadMDTItemIcons.php
+++ b/app/Console/Commands/MapIcon/DownloadMDTItemIcons.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Console\Commands\MapIcon;
+
+use App\Logic\MDT\Entity\MDTMapPOI;
+use App\Models\Dungeon;
+use App\Models\Season;
+use App\Service\MDT\MDTMappingImportServiceInterface;
+use App\Service\Wago\WagoToolsServiceInterface;
+use App\Service\Wowhead\WowheadServiceInterface;
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class DownloadMDTItemIcons extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'mapicon:downloadmdtitemicons {dungeon}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Downloads the source icons of all MDT map POIs that have no map icon type yet';
+
+    /**
+     * Execute the console command.
+     *
+     * @throws Exception
+     */
+    public function handle(
+        MDTMappingImportServiceInterface $mappingImportService,
+        WagoToolsServiceInterface        $wagoToolsService,
+        WowheadServiceInterface          $wowheadService,
+    ): int {
+        $dungeonArgument = $this->argument('dungeon');
+
+        if (is_numeric($dungeonArgument)) {
+            $dungeons = Season::findOrFail($dungeonArgument)->dungeons;
+        } else {
+            $dungeons = new Collection([Dungeon::where('key', $dungeonArgument)->firstOrFail()]);
+        }
+
+        /** @var Collection<int, MDTMapPOI> $unhandledMapPOIs */
+        $unhandledMapPOIs = new Collection();
+        $dungeonKeyByPOI  = [];
+
+        foreach ($dungeons as $dungeon) {
+            foreach ($mappingImportService->getUnhandledMapPOIs($dungeon) as $mdtMapPOI) {
+                $dungeonKeyByPOI[spl_object_id($mdtMapPOI)] = $dungeon->key;
+                $unhandledMapPOIs->push($mdtMapPOI);
+            }
+        }
+
+        if ($unhandledMapPOIs->isEmpty()) {
+            $this->info('No unhandled MDT map POIs - nothing to download.');
+
+            return 0;
+        }
+
+        // One texture may be shared by several POIs, and resolving them costs a ~9MB DB2 download each time
+        $fileDataIds = $unhandledMapPOIs
+            ->map(static fn(MDTMapPOI $mdtMapPOI): ?int => $mdtMapPOI->getTextureFileDataId())
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        $iconFileNames = $wagoToolsService->getIconFileNamesByFileDataIds($fileDataIds);
+
+        $targetFolder = realpath(base_path('../keystone.guru.assets/images/mapicon_gen'));
+        if ($targetFolder === false) {
+            $this->error('Unable to find the keystone.guru.assets repository next to this checkout - is it cloned, and is it mounted into this container?');
+
+            return 1;
+        }
+
+        $rows        = [];
+        $downloaded  = [];
+        $hasFailures = false;
+
+        foreach ($unhandledMapPOIs as $mdtMapPOI) {
+            $fileDataId   = $mdtMapPOI->getTextureFileDataId();
+            $iconFileName = $fileDataId === null ? null : ($iconFileNames[$fileDataId] ?? null);
+
+            $status = 'no texture';
+            if ($iconFileName !== null) {
+                if (isset($downloaded[$iconFileName])) {
+                    $status = $downloaded[$iconFileName];
+                } elseif (file_exists(sprintf('%s/%s.jpg', $targetFolder, $iconFileName))) {
+                    $status = 'already present';
+                } elseif ($wowheadService->downloadIcon($iconFileName, $targetFolder)) {
+                    $status = 'downloaded';
+                } else {
+                    $status      = 'DOWNLOAD FAILED';
+                    $hasFailures = true;
+                }
+
+                $downloaded[$iconFileName] = $status;
+            } elseif ($fileDataId !== null) {
+                $status      = 'NOT AN ICON IN ManifestInterfaceData';
+                $hasFailures = true;
+            }
+
+            $rows[] = [
+                $dungeonKeyByPOI[spl_object_id($mdtMapPOI)],
+                $mdtMapPOI->getType()->value,
+                $mdtMapPOI->getSpellId() ?? '-',
+                $fileDataId ?? '-',
+                $iconFileName ?? '-',
+                $status,
+                $mdtMapPOI->getSpellId() === null
+                    ? '-'
+                    : sprintf('https://www.wowhead.com/spell=%d', $mdtMapPOI->getSpellId()),
+            ];
+        }
+
+        $this->table(
+            ['Dungeon', 'MDT type', 'Spell ID', 'Texture ID', 'Icon', 'Status', 'Wowhead'],
+            $rows,
+        );
+
+        $this->newLine();
+        $this->line('Next: add a MapIconType for each item (constant + id in MapIconType::ALL, MapIconTypesSeeder,');
+        $this->line('lang/en_US/mapicontypes.php, GenerateItemIcons and Conversion::MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING),');
+        $this->line('then run <comment>mapicon:generateitemicons</comment>.');
+
+        return $hasFailures ? 1 : 0;
+    }
+}

--- a/app/Console/Commands/MapIcon/DownloadMDTItemIcons.php
+++ b/app/Console/Commands/MapIcon/DownloadMDTItemIcons.php
@@ -94,6 +94,9 @@ class DownloadMDTItemIcons extends Command
                     $status = $downloaded[$iconFileName];
                 } elseif (file_exists(sprintf('%s/%s.jpg', $targetFolder, $iconFileName))) {
                     $status = 'already present';
+                    // Despite the service name this fetches from `wow.zamimg.com`, Wowhead's asset CDN, which
+                    // serves us fine. It is wowhead.com's *pages* that answer 403 - so the file name has to
+                    // come from wago.tools above rather than by scraping the icon page (#3993).
                 } elseif ($wowheadService->downloadIcon($iconFileName, $targetFolder)) {
                     $status = 'downloaded';
                 } else {

--- a/app/Console/Commands/MapIcon/DownloadMDTItemIcons.php
+++ b/app/Console/Commands/MapIcon/DownloadMDTItemIcons.php
@@ -94,9 +94,6 @@ class DownloadMDTItemIcons extends Command
                     $status = $downloaded[$iconFileName];
                 } elseif (file_exists(sprintf('%s/%s.jpg', $targetFolder, $iconFileName))) {
                     $status = 'already present';
-                    // Despite the service name this fetches from `wow.zamimg.com`, Wowhead's asset CDN, which
-                    // serves us fine. It is wowhead.com's *pages* that answer 403 - so the file name has to
-                    // come from wago.tools above rather than by scraping the icon page (#3993).
                 } elseif ($wowheadService->downloadIcon($iconFileName, $targetFolder)) {
                     $status = 'downloaded';
                 } else {

--- a/app/Console/Commands/MapIcon/GenerateItemIcons.php
+++ b/app/Console/Commands/MapIcon/GenerateItemIcons.php
@@ -14,10 +14,16 @@ use Illuminate\Console\Command;
  * {@see \App\Logic\MDT\Conversion::MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING}. Note that adding an
  * MDT mapping for an icon that was already placed by hand duplicates it on the next reimport (#3993).
  *
- * To get the raw icon: do **not** scrape Wowhead, its pages 403 the app container. Resolve the icon file name
- * from a texture FileDataID through wago.tools' ManifestInterfaceData DB2 and download it off Wowhead's CDN -
- * `mapicon:downloadmdtitemicons` does exactly that for every MDT POI we have no icon for. This command only
- * runs from the main checkout: the assets repo is not mounted into a worktree's container.
+ * To get the raw icon: do **not** scrape wowhead.com, its pages 403 the app container - not because of the
+ * container, but because {@see \App\Service\Traits\Curl} sends a spoofed Chrome user agent that Cloudflare
+ * rejects (plain curl from the same container gets a 200). Resolve the icon file name from a texture
+ * FileDataID through wago.tools' ManifestInterfaceData DB2 and download it off Wowhead's CDN at
+ * `wow.zamimg.com`, which serves us fine - `mapicon:downloadmdtitemicons` does exactly that for every MDT
+ * POI we have no icon for.
+ *
+ * Both this command and that one write into the `keystone.guru.assets` checkout, which is bind-mounted into
+ * the app container by both the main stack and (since #3993) every worktree stack. That repo is shared, not
+ * worktree-isolated, so `git status` it after a run.
  *
  * The full runbook lives in the `update-mdt-package` skill, which is where this is needed almost every time.
  */

--- a/app/Console/Commands/MapIcon/GenerateItemIcons.php
+++ b/app/Console/Commands/MapIcon/GenerateItemIcons.php
@@ -5,6 +5,22 @@ namespace App\Console\Commands\MapIcon;
 use App\Service\Image\ImageServiceInterface;
 use Illuminate\Console\Command;
 
+/**
+ * Renders the hexagonal item map icons from the raw WoW icons in `keystone.guru.assets/images/mapicon_gen`.
+ *
+ * Adding one is five registrations, all of which must agree on the same key: a constant + a new id in
+ * {@see \App\Models\MapIconType::ALL}, a `MapIconTypesSeeder` entry, a `lang/en_US/mapicontypes.php` string,
+ * a source => target pair below, and - if MDT draws it - an entry in
+ * {@see \App\Logic\MDT\Conversion::MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING}. Note that adding an
+ * MDT mapping for an icon that was already placed by hand duplicates it on the next reimport (#3993).
+ *
+ * To get the raw icon: do **not** scrape Wowhead, its pages 403 the app container. Resolve the icon file name
+ * from a texture FileDataID through wago.tools' ManifestInterfaceData DB2 and download it off Wowhead's CDN -
+ * `mapicon:downloadmdtitemicons` does exactly that for every MDT POI we have no icon for. This command only
+ * runs from the main checkout: the assets repo is not mounted into a worktree's container.
+ *
+ * The full runbook lives in the `update-mdt-package` skill, which is where this is needed almost every time.
+ */
 class GenerateItemIcons extends Command
 {
     /**
@@ -50,6 +66,19 @@ class GenerateItemIcons extends Command
             'inv_112_arcane_buff.jpg'               => 'eco_dome_al_dani_kareshi_surge.png',
             'inv_cooking_10_heartystew.jpg'         => 'maisara_caverns_hearty_vilebranch_stew.png',
             'inv_enchant_voidsphere.jpg'            => 'seat_of_the_triumvirate_void_infusion.png',
+            'inv_bijou_silver.jpg'                  => 'algethar_academy_black_dragonflight_pledge_pin.png',
+            'inv_bijou_blue.jpg'                    => 'algethar_academy_blue_dragonflight_pledge_pin.png',
+            'inv_bijou_orange.jpg'                  => 'algethar_academy_bronze_dragonflight_pledge_pin.png',
+            'inv_bijou_green.jpg'                   => 'algethar_academy_green_dragonflight_pledge_pin.png',
+            'inv_bijou_red.jpg'                     => 'algethar_academy_red_dragonflight_pledge_pin.png',
+            'spell_arcane_mindmastery.jpg'          => 'magisters_terrace_arcane_empowerment.png',
+            'inv_enchanting_wod_crystal.jpg'        => 'murder_row_fel_contraband.png',
+            'inv_infernalbrimstone.jpg'             => 'murder_row_felstone.png',
+            'inv_egg_08.jpg'                        => 'murder_row_felwyrm_egg.png',
+            'ability_boss_kilrogg_heartseeker.jpg'  => 'murder_row_heartstop_poison.png',
+            'inv_weapon_rifle_40.jpg'               => 'murder_row_loaded_pistol.png',
+            'ui_profession_engineering.jpg'         => 'murder_row_overload_golem.png',
+            'spell_lifegivingspeed.jpg'             => 'the_blinding_vale_flourishing_stride.png',
         ];
 
         foreach ($imagePaths as $sourceImage => $targetImage) {

--- a/app/Logic/MDT/Conversion.php
+++ b/app/Logic/MDT/Conversion.php
@@ -8,12 +8,15 @@
 
 namespace App\Logic\MDT;
 
+use App\Logic\MDT\Entity\MDTMapPOI;
+use App\Logic\MDT\Entity\MDTMapPOIType;
 use App\Logic\Structs\LatLng;
 use App\Models\AffixGroup\AffixGroup;
 use App\Models\Dungeon;
 use App\Models\DungeonKey;
 use App\Models\Expansion;
 use App\Models\Floor\Floor;
+use App\Models\MapIconType;
 use App\Models\RaidKey;
 use App\Models\Season;
 use App\Service\Season\SeasonServiceInterface;
@@ -288,6 +291,69 @@ class Conversion
     ];
 
     /**
+     * The map icon type each MDT POI type imports as. Types absent from this list are either handled
+     * separately ({@see MDTMapPOIType::MapLink} becomes a dungeon floor switch marker), deliberately not
+     * imported ({@see self::MAP_POI_TYPES_NOT_IMPORTED}), or not supported yet - the last of which is what
+     * {@see self::isMDTMapPOIUnhandled()} reports on.
+     *
+     * @var array<string, string>
+     */
+    public const array MAP_POI_TYPE_MAP_ICON_TYPE_MAPPING = [
+        MDTMapPOIType::Graveyard->value            => MapIconType::MAP_ICON_TYPE_GRAVEYARD,
+        MDTMapPOIType::DungeonEntrance->value      => MapIconType::MAP_ICON_TYPE_DUNGEON_START,
+        MDTMapPOIType::PrioryItem->value           => MapIconType::MAP_ICON_TYPE_PRIORY_BLESSING_OF_THE_SACRED_FLAME,
+        MDTMapPOIType::FloodgateItem->value        => MapIconType::MAP_ICON_TYPE_FLOODGATE_WEAPONS_STOCKPILE_EXPLOSION,
+        MDTMapPOIType::EcoDomeAlDaniItem1->value   => MapIconType::MAP_ICON_TYPE_ECO_DOME_AL_DANI_SHATTER_CONDUIT,
+        MDTMapPOIType::EcoDomeAlDaniItem2->value   => MapIconType::MAP_ICON_TYPE_ECO_DOME_AL_DANI_DISRUPTION_GRENADE,
+        MDTMapPOIType::EcoDomeAlDaniItem3->value   => MapIconType::MAP_ICON_TYPE_ECO_DOME_AL_DANI_KARESHI_SURGE,
+        MDTMapPOIType::GeneralNote->value          => MapIconType::MAP_ICON_TYPE_EXCLAMATION_YELLOW,
+        MDTMapPOIType::GenericAssignablePOI->value => MapIconType::MAP_ICON_TYPE_DOT_YELLOW,
+    ];
+
+    /**
+     * {@see MDTMapPOIType::GenericItem} is a single MDT type covering every item pickup MDT draws, so unlike
+     * every other type it cannot map to one map icon type. MDT tells the items apart by the spell it shows
+     * the tooltip of, and so do we.
+     *
+     * @var array<int, string>
+     */
+    public const array MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING = [
+        // Algeth'ar Academy
+        389501 => MapIconType::MAP_ICON_TYPE_ALGETHAR_ACADEMY_RED_DRAGONFLIGHT_PLEDGE_PIN,
+        389512 => MapIconType::MAP_ICON_TYPE_ALGETHAR_ACADEMY_BRONZE_DRAGONFLIGHT_PLEDGE_PIN,
+        389516 => MapIconType::MAP_ICON_TYPE_ALGETHAR_ACADEMY_BLACK_DRAGONFLIGHT_PLEDGE_PIN,
+        389521 => MapIconType::MAP_ICON_TYPE_ALGETHAR_ACADEMY_BLUE_DRAGONFLIGHT_PLEDGE_PIN,
+        389536 => MapIconType::MAP_ICON_TYPE_ALGETHAR_ACADEMY_GREEN_DRAGONFLIGHT_PLEDGE_PIN,
+        // Magisters' Terrace
+        1254550 => MapIconType::MAP_ICON_TYPE_MAGISTERS_TERRACE_ARCANE_EMPOWERMENT,
+        // Maisara Caverns
+        1269056 => MapIconType::MAP_ICON_TYPE_MAISARA_CAVERNS_HEARTY_VILEBRANCH_STEW,
+        // Murder Row
+        1217960 => MapIconType::MAP_ICON_TYPE_MURDER_ROW_LOADED_PISTOL,
+        1223133 => MapIconType::MAP_ICON_TYPE_MURDER_ROW_OVERLOAD_GOLEM,
+        1223537 => MapIconType::MAP_ICON_TYPE_MURDER_ROW_FELSTONE,
+        1223570 => MapIconType::MAP_ICON_TYPE_MURDER_ROW_FELWYRM_EGG,
+        1223607 => MapIconType::MAP_ICON_TYPE_MURDER_ROW_HEARTSTOP_POISON,
+        1270638 => MapIconType::MAP_ICON_TYPE_MURDER_ROW_FEL_CONTRABAND,
+        // Seat of the Triumvirate
+        244300 => MapIconType::MAP_ICON_TYPE_SEAT_OF_THE_TRIUMVIRATE_VOID_INFUSION,
+        // The Blinding Vale
+        1265942 => MapIconType::MAP_ICON_TYPE_THE_BLINDING_VALE_FLOURISHING_STRIDE,
+    ];
+
+    /**
+     * POI types that are part of MDT's own UI rather than of the dungeon mapping - a zoom affordance and the
+     * user's own text annotations. They have no keystone.guru equivalent by design, so they must not be
+     * reported as unhandled.
+     *
+     * @var array<MDTMapPOIType>
+     */
+    public const array MAP_POI_TYPES_NOT_IMPORTED = [
+        MDTMapPOIType::Zoom,
+        MDTMapPOIType::TextFrame,
+    ];
+
+    /**
      * Rounds a number to the nearest two decimals.
      */
     private static function round(float|int $nr): float
@@ -481,5 +547,37 @@ class Conversion
     public static function isDungeonInMainlineMDT(Dungeon $dungeon): bool
     {
         return in_array($dungeon->key, self::MAINLINE_MDT_DUNGEONS, true);
+    }
+
+    /**
+     * The {@see MapIconType} key an MDT POI imports as, or null when we have no map icon type for it.
+     */
+    public static function convertMDTMapPOIToMapIconTypeKey(MDTMapPOI $mdtMapPOI): ?string
+    {
+        if ($mdtMapPOI->getType() === MDTMapPOIType::GenericItem) {
+            return self::MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING[$mdtMapPOI->getSpellId()] ?? null;
+        }
+
+        return self::MAP_POI_TYPE_MAP_ICON_TYPE_MAPPING[$mdtMapPOI->getType()->value] ?? null;
+    }
+
+    /**
+     * Whether MDT draws this POI but keystone.guru has nothing to import it as - the map will be missing
+     * something MDT shows. This is deliberately not an exception: the rest of the mapping is still worth
+     * importing, so it is reported instead (see `MDTMappingImportService::importMapPOIs()` and
+     * `mdt:importmapping`'s summary table).
+     */
+    public static function isMDTMapPOIUnhandled(MDTMapPOI $mdtMapPOI): bool
+    {
+        // Floor switch markers rather than map icons, handled on their own terms
+        if ($mdtMapPOI->getType() === MDTMapPOIType::MapLink) {
+            return false;
+        }
+
+        if (in_array($mdtMapPOI->getType(), self::MAP_POI_TYPES_NOT_IMPORTED, true)) {
+            return false;
+        }
+
+        return self::convertMDTMapPOIToMapIconTypeKey($mdtMapPOI) === null;
     }
 }

--- a/app/Logic/MDT/Entity/MDTMapPOI.php
+++ b/app/Logic/MDT/Entity/MDTMapPOI.php
@@ -122,6 +122,25 @@ class MDTMapPOI implements Arrayable
         return $this->info['atlas'] ?? null;
     }
 
+    /**
+     * The spell MDT pulls this POI's tooltip from - set on {@see MDTMapPOIType::GenericItem} POIs, which MDT
+     * renders as `GameTooltip:SetSpellByID(info.spellId)`. It is the only thing distinguishing one generic
+     * item from another, so it is what a map icon type is keyed on.
+     */
+    public function getSpellId(): ?int
+    {
+        return $this->info['spellId'] ?? null;
+    }
+
+    /**
+     * The FileDataID of the texture MDT draws for this POI. Resolvable to an icon file name through
+     * wago.tools' ManifestInterfaceData DB2 - see {@see \App\Service\Wago\WagoToolsServiceInterface}.
+     */
+    public function getTextureFileDataId(): ?int
+    {
+        return $this->info['texture'] ?? null;
+    }
+
     public function getSizeMult(): ?float
     {
         return $this->sizeMult;

--- a/app/Models/MapIconType.php
+++ b/app/Models/MapIconType.php
@@ -148,6 +148,20 @@ class MapIconType extends CacheModel
     public const string MAP_ICON_TYPE_SEAT_OF_THE_TRIUMVIRATE_VOID_INFUSION  = 'seat_of_the_triumvirate_void_infusion';
     public const string MAP_ICON_TYPE_MAISARA_CAVERNS_HEARTY_VILEBRANCH_STEW = 'maisara_caverns_hearty_vilebranch_stew';
 
+    public const string MAP_ICON_TYPE_ALGETHAR_ACADEMY_BLACK_DRAGONFLIGHT_PLEDGE_PIN  = 'algethar_academy_black_dragonflight_pledge_pin';
+    public const string MAP_ICON_TYPE_ALGETHAR_ACADEMY_BLUE_DRAGONFLIGHT_PLEDGE_PIN   = 'algethar_academy_blue_dragonflight_pledge_pin';
+    public const string MAP_ICON_TYPE_ALGETHAR_ACADEMY_BRONZE_DRAGONFLIGHT_PLEDGE_PIN = 'algethar_academy_bronze_dragonflight_pledge_pin';
+    public const string MAP_ICON_TYPE_ALGETHAR_ACADEMY_GREEN_DRAGONFLIGHT_PLEDGE_PIN  = 'algethar_academy_green_dragonflight_pledge_pin';
+    public const string MAP_ICON_TYPE_ALGETHAR_ACADEMY_RED_DRAGONFLIGHT_PLEDGE_PIN    = 'algethar_academy_red_dragonflight_pledge_pin';
+    public const string MAP_ICON_TYPE_MAGISTERS_TERRACE_ARCANE_EMPOWERMENT            = 'magisters_terrace_arcane_empowerment';
+    public const string MAP_ICON_TYPE_MURDER_ROW_FEL_CONTRABAND                       = 'murder_row_fel_contraband';
+    public const string MAP_ICON_TYPE_MURDER_ROW_FELSTONE                             = 'murder_row_felstone';
+    public const string MAP_ICON_TYPE_MURDER_ROW_FELWYRM_EGG                          = 'murder_row_felwyrm_egg';
+    public const string MAP_ICON_TYPE_MURDER_ROW_HEARTSTOP_POISON                     = 'murder_row_heartstop_poison';
+    public const string MAP_ICON_TYPE_MURDER_ROW_LOADED_PISTOL                        = 'murder_row_loaded_pistol';
+    public const string MAP_ICON_TYPE_MURDER_ROW_OVERLOAD_GOLEM                       = 'murder_row_overload_golem';
+    public const string MAP_ICON_TYPE_THE_BLINDING_VALE_FLOURISHING_STRIDE            = 'the_blinding_vale_flourishing_stride';
+
     public const array ALL = [
         self::MAP_ICON_TYPE_UNKNOWN                   => 1,
         self::MAP_ICON_TYPE_COMMENT                   => 2,
@@ -284,6 +298,23 @@ class MapIconType extends CacheModel
 
         self::MAP_ICON_TYPE_SEAT_OF_THE_TRIUMVIRATE_VOID_INFUSION  => 108,
         self::MAP_ICON_TYPE_MAISARA_CAVERNS_HEARTY_VILEBRANCH_STEW => 109,
+
+        self::MAP_ICON_TYPE_ALGETHAR_ACADEMY_BLACK_DRAGONFLIGHT_PLEDGE_PIN  => 110,
+        self::MAP_ICON_TYPE_ALGETHAR_ACADEMY_BLUE_DRAGONFLIGHT_PLEDGE_PIN   => 111,
+        self::MAP_ICON_TYPE_ALGETHAR_ACADEMY_BRONZE_DRAGONFLIGHT_PLEDGE_PIN => 112,
+        self::MAP_ICON_TYPE_ALGETHAR_ACADEMY_GREEN_DRAGONFLIGHT_PLEDGE_PIN  => 113,
+        self::MAP_ICON_TYPE_ALGETHAR_ACADEMY_RED_DRAGONFLIGHT_PLEDGE_PIN    => 114,
+
+        self::MAP_ICON_TYPE_MAGISTERS_TERRACE_ARCANE_EMPOWERMENT => 115,
+
+        self::MAP_ICON_TYPE_MURDER_ROW_FEL_CONTRABAND   => 116,
+        self::MAP_ICON_TYPE_MURDER_ROW_FELSTONE         => 117,
+        self::MAP_ICON_TYPE_MURDER_ROW_FELWYRM_EGG      => 118,
+        self::MAP_ICON_TYPE_MURDER_ROW_HEARTSTOP_POISON => 119,
+        self::MAP_ICON_TYPE_MURDER_ROW_LOADED_PISTOL    => 120,
+        self::MAP_ICON_TYPE_MURDER_ROW_OVERLOAD_GOLEM   => 121,
+
+        self::MAP_ICON_TYPE_THE_BLINDING_VALE_FLOURISHING_STRIDE => 122,
     ];
 
     public function getIconUrlAttribute(): string

--- a/app/Providers/KeystoneGuruServiceProvider.php
+++ b/app/Providers/KeystoneGuruServiceProvider.php
@@ -166,6 +166,8 @@ use App\Service\View\RequestViewContext;
 use App\Service\View\RequestViewContextInterface;
 use App\Service\View\ViewService;
 use App\Service\View\ViewServiceInterface;
+use App\Service\Wago\WagoToolsService;
+use App\Service\Wago\WagoToolsServiceInterface;
 use App\Service\Wowhead\WowheadService;
 use App\Service\Wowhead\WowheadServiceInterface;
 use App\Service\Wowhead\WowheadTranslationService;
@@ -190,6 +192,7 @@ class KeystoneGuruServiceProvider extends ServiceProvider
         $this->app->bind(ArchonApiServiceInterface::class, ArchonApiService::class);
         $this->app->bind(PatreonApiServiceInterface::class, PatreonApiService::class);
         $this->app->bind(WowToolsServiceInterface::class, WowToolsService::class);
+        $this->app->bind(WagoToolsServiceInterface::class, WagoToolsService::class);
         $this->app->bind(AdProviderServiceInterface::class, AdProviderService::class);
         $this->app->bind(CreatorDirectoryServiceInterface::class, CreatorDirectoryService::class);
         $this->app->bind(WowheadServiceInterface::class, WowheadService::class);

--- a/app/Service/MDT/Logging/MDTMappingImportServiceLogging.php
+++ b/app/Service/MDT/Logging/MDTMappingImportServiceLogging.php
@@ -351,6 +351,20 @@ class MDTMappingImportServiceLogging extends StructuredLogging implements MDTMap
         $this->error(__METHOD__, get_defined_vars());
     }
 
+    public function importMapPOIsDeletedClonedGenericItemMapIcons(int $deletedCount): void
+    {
+        $this->info(__METHOD__, get_defined_vars());
+    }
+
+    public function importMapPOIsUnhandledMapPOI(
+        string $mdtMapPOIType,
+        ?int   $spellId,
+        ?int   $textureFileDataId,
+        int    $subLevel,
+    ): void {
+        $this->error(__METHOD__, get_defined_vars());
+    }
+
     public function importMapPOIsCreatedNewMapIcon(int $mapIconId, int $floorId, int $mapIconTypeId): void
     {
         $this->debug(__METHOD__, get_defined_vars());

--- a/app/Service/MDT/Logging/MDTMappingImportServiceLoggingInterface.php
+++ b/app/Service/MDT/Logging/MDTMappingImportServiceLoggingInterface.php
@@ -174,6 +174,16 @@ interface MDTMappingImportServiceLoggingInterface
     public function importMapPOIsMDTHasMapPOIs(): void;
 
     public function importMapPOIsMissingTranslation(string $translationKey): void;
+
+    public function importMapPOIsDeletedClonedGenericItemMapIcons(int $deletedCount): void;
+
+    public function importMapPOIsUnhandledMapPOI(
+        string $mdtMapPOIType,
+        ?int   $spellId,
+        ?int   $textureFileDataId,
+        int    $subLevel,
+    ): void;
+
     public function importMapPOIsCreatedNewMapIcon(int $mapIconId, int $floorId, int $mapIconTypeId): void;
 
     /**

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -1113,11 +1113,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                             );
                         }
                     } elseif (Conversion::isMDTMapPOIUnhandled($mdtMapPOI)) {
-                        // MDT draws something we have no map icon type for - our map will be missing it. This
-                        // used to disappear without a trace, which is how six Midnight dungeons ended up short
-                        // of 19 icons before anyone noticed (#3993). It is deliberately not an import failure:
-                        // $importFailures aborts and deletes the whole mapping version, and the rest of the
-                        // mapping is still worth having. `mdt:importmapping` summarises these in a table.
+                        // MDT draws something we have no map icon type for - our map will be missing it.
                         $this->log->importMapPOIsUnhandledMapPOI(
                             $mdtMapPOI->getType()->value,
                             $mdtMapPOI->getSpellId(),

--- a/app/Service/MDT/MDTMappingImportService.php
+++ b/app/Service/MDT/MDTMappingImportService.php
@@ -4,6 +4,7 @@ namespace App\Service\MDT;
 
 use App\Logic\MDT\Conversion;
 use App\Logic\MDT\Data\MDTDungeon;
+use App\Logic\MDT\Entity\MDTMapPOI;
 use App\Logic\MDT\Entity\MDTMapPOIType;
 use App\Logic\MDT\Entity\MDTNpc;
 use App\Logic\MDT\Entity\MDTPatrol;
@@ -190,6 +191,19 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                 'floorSwitchMarkers' => $mdtDungeon->getMDTMapPOIs()->toArray(),
             ]),
         );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws Exception
+     */
+    public function getUnhandledMapPOIs(Dungeon $dungeon): Collection
+    {
+        return new MDTDungeon($this->cacheService, $this->coordinatesService, $dungeon)
+            ->getMDTMapPOIs()
+            ->filter(static fn(MDTMapPOI $mdtMapPOI): bool => Conversion::isMDTMapPOIUnhandled($mdtMapPOI))
+            ->values();
     }
 
     public function importNpcsDataFromMDT(MDTDungeon $mdtDungeon, Dungeon $dungeon, GameVersion $gameVersion, array &$failures = []): void
@@ -1016,17 +1030,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
             if ($mdtMapPOIs->isNotEmpty()) {
                 $this->log->importMapPOIsMDTHasMapPOIs();
 
-                $mapIconTypeMapping = [
-                    MDTMapPOIType::Graveyard->value            => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_GRAVEYARD],
-                    MDTMapPOIType::DungeonEntrance->value      => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_DUNGEON_START],
-                    MDTMapPOIType::PrioryItem->value           => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_PRIORY_BLESSING_OF_THE_SACRED_FLAME],
-                    MDTMapPOIType::FloodgateItem->value        => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_FLOODGATE_WEAPONS_STOCKPILE_EXPLOSION],
-                    MDTMapPOIType::EcoDomeAlDaniItem1->value   => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_ECO_DOME_AL_DANI_SHATTER_CONDUIT],
-                    MDTMapPOIType::EcoDomeAlDaniItem2->value   => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_ECO_DOME_AL_DANI_DISRUPTION_GRENADE],
-                    MDTMapPOIType::EcoDomeAlDaniItem3->value   => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_ECO_DOME_AL_DANI_KARESHI_SURGE],
-                    MDTMapPOIType::GeneralNote->value          => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_EXCLAMATION_YELLOW],
-                    MDTMapPOIType::GenericAssignablePOI->value => MapIconType::ALL[MapIconType::MAP_ICON_TYPE_DOT_YELLOW],
-                ];
+                $this->deleteClonedGenericItemMapIcons($newMappingVersion);
 
                 foreach ($mdtMapPOIs as $mdtMapPOI) {
                     $floor = $this->findFloorByMdtSubLevel($dungeon, $newMappingVersion, $mdtMapPOI->getSubLevel());
@@ -1037,9 +1041,13 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                     ], $floor);
                     $latLng = $this->coordinatesService->convertFacadeMapLocationToMapLocation($newMappingVersion, $latLng);
 
-                    if (isset($mapIconTypeMapping[$mdtMapPOI->getType()->value])) {
+                    $mapIconTypeKey = Conversion::convertMDTMapPOIToMapIconTypeKey($mdtMapPOI);
+
+                    if ($mapIconTypeKey !== null) {
+                        $mapIconTypeId = MapIconType::ALL[$mapIconTypeKey];
+
                         // No predecessor to match against - always create a new icon (#3757).
-                        $existingMapIcon = $currentMappingVersion?->getMapIconNearLocation($latLng, $mapIconTypeMapping[$mdtMapPOI->getType()->value]);
+                        $existingMapIcon = $currentMappingVersion?->getMapIconNearLocation($latLng, $mapIconTypeId);
                         if ($existingMapIcon === null) {
                             $translationKey = null;
                             if ($mdtMapPOI->getType() === MDTMapPOIType::GenericAssignablePOI &&
@@ -1054,7 +1062,7 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
 
                             $mapIcon = MapIcon::create(array_merge(array_filter([
                                 'mapping_version_id' => $newMappingVersion->id,
-                                'map_icon_type_id'   => $mapIconTypeMapping[$mdtMapPOI->getType()->value],
+                                'map_icon_type_id'   => $mapIconTypeId,
                                 'comment'            => $translationKey,
                             ]), $latLng->toArrayWithFloor()));
 
@@ -1104,6 +1112,18 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                                 $newMappingVersion->dungeonFloorSwitchMarkers()->count(),
                             );
                         }
+                    } elseif (Conversion::isMDTMapPOIUnhandled($mdtMapPOI)) {
+                        // MDT draws something we have no map icon type for - our map will be missing it. This
+                        // used to disappear without a trace, which is how six Midnight dungeons ended up short
+                        // of 19 icons before anyone noticed (#3993). It is deliberately not an import failure:
+                        // $importFailures aborts and deletes the whole mapping version, and the rest of the
+                        // mapping is still worth having. `mdt:importmapping` summarises these in a table.
+                        $this->log->importMapPOIsUnhandledMapPOI(
+                            $mdtMapPOI->getType()->value,
+                            $mdtMapPOI->getSpellId(),
+                            $mdtMapPOI->getTextureFileDataId(),
+                            $mdtMapPOI->getSubLevel(),
+                        );
                     }
                 }
             }
@@ -1179,6 +1199,33 @@ class MDTMappingImportService implements MDTMappingImportServiceInterface
                 $keptPercentage,
                 $this->findDungeonKeyOwningNpcs($dungeon, $incomingNpcIds),
             );
+        }
+    }
+
+    /**
+     * MDT owns the item icons it draws - every map icon type in
+     * {@see Conversion::MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING} exists for one specific MDT
+     * `genericItem` POI and nothing else, so the import below re-creates the complete set from MDT.
+     *
+     * Until this import existed those items could only be placed by hand, and
+     * `copyMappingVersionContentsToDungeon()` clones such an icon into every subsequent mapping version -
+     * where it would now sit next to the imported copy as a duplicate. `getMapIconNearLocation()` does not
+     * catch it: its window is +/-5 lat/lng, while Maisara Caverns' hand-placed Hearty Vilebranch Stew is
+     * 5.3 off MDT's position and Seat of the Triumvirate's Void Infusion 13.9 (#3993).
+     */
+    private function deleteClonedGenericItemMapIcons(MappingVersion $newMappingVersion): void
+    {
+        $genericItemMapIconTypeIds = array_map(
+            static fn(string $mapIconTypeKey): int => MapIconType::ALL[$mapIconTypeKey],
+            array_values(Conversion::MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING),
+        );
+
+        $deletedCount = $newMappingVersion->mapIcons()
+            ->whereIn('map_icon_type_id', $genericItemMapIconTypeIds)
+            ->delete();
+
+        if ($deletedCount > 0) {
+            $this->log->importMapPOIsDeletedClonedGenericItemMapIcons($deletedCount);
         }
     }
 

--- a/app/Service/MDT/MDTMappingImportServiceInterface.php
+++ b/app/Service/MDT/MDTMappingImportServiceInterface.php
@@ -3,11 +3,13 @@
 namespace App\Service\MDT;
 
 use App\Logic\MDT\Data\MDTDungeon;
+use App\Logic\MDT\Entity\MDTMapPOI;
 use App\Models\Dungeon;
 use App\Models\GameVersion\GameVersion;
 use App\Models\Mapping\MappingVersion;
 use App\Service\Mapping\MappingServiceInterface;
 use Exception;
+use Illuminate\Support\Collection;
 
 interface MDTMappingImportServiceInterface
 {
@@ -19,6 +21,15 @@ interface MDTMappingImportServiceInterface
     ): MappingVersion;
 
     public function getMDTMappingHash(Dungeon $dungeon): string;
+
+    /**
+     * Every POI MDT draws for this dungeon that we have no map icon type for, and which the map is therefore
+     * missing - see {@see \App\Logic\MDT\Conversion::isMDTMapPOIUnhandled()}. Derived straight from MDT's own
+     * data, so it does not depend on an import having run.
+     *
+     * @return Collection<int, MDTMapPOI>
+     */
+    public function getUnhandledMapPOIs(Dungeon $dungeon): Collection;
 
     /**
      * @param array<int, Exception> $failures Appended with any exception a per-NPC save legitimately failed

--- a/app/Service/Wago/Logging/WagoToolsServiceLogging.php
+++ b/app/Service/Wago/Logging/WagoToolsServiceLogging.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Service\Wago\Logging;
+
+use App\Logging\StructuredLogging;
+
+class WagoToolsServiceLogging extends StructuredLogging implements WagoToolsServiceLoggingInterface
+{
+    public function getIconFileNamesByFileDataIdsStart(int $fileDataIdCount): void
+    {
+        $this->start(__METHOD__, get_defined_vars());
+    }
+
+    public function getIconFileNamesByFileDataIdsDownloadFailed(string $url): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
+    }
+
+    public function getIconFileNamesByFileDataIdsUnableToOpenFile(string $filePath): void
+    {
+        $this->error(__METHOD__, get_defined_vars());
+    }
+
+    public function getIconFileNamesByFileDataIdsNotFound(int $fileDataId): void
+    {
+        $this->warning(__METHOD__, get_defined_vars());
+    }
+
+    public function getIconFileNamesByFileDataIdsEnd(): void
+    {
+        $this->end(__METHOD__);
+    }
+}

--- a/app/Service/Wago/Logging/WagoToolsServiceLoggingInterface.php
+++ b/app/Service/Wago/Logging/WagoToolsServiceLoggingInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Service\Wago\Logging;
+
+interface WagoToolsServiceLoggingInterface
+{
+    public function getIconFileNamesByFileDataIdsStart(int $fileDataIdCount): void;
+
+    public function getIconFileNamesByFileDataIdsDownloadFailed(string $url): void;
+
+    public function getIconFileNamesByFileDataIdsUnableToOpenFile(string $filePath): void;
+
+    public function getIconFileNamesByFileDataIdsNotFound(int $fileDataId): void;
+
+    public function getIconFileNamesByFileDataIdsEnd(): void;
+}

--- a/app/Service/Wago/WagoToolsService.php
+++ b/app/Service/Wago/WagoToolsService.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Service\Wago;
+
+use App\Service\Traits\Curl;
+use App\Service\Wago\Logging\WagoToolsServiceLoggingInterface;
+
+class WagoToolsService implements WagoToolsServiceInterface
+{
+    use Curl;
+
+    /**
+     * The DB2 that maps every interface file's FileDataID to its path and file name. It is the only public
+     * source that turns MDT's `info.texture` into something downloadable - roughly 9MB of CSV, which is why
+     * it is fetched once per {@see WagoToolsService::getIconFileNamesByFileDataIds()} call and streamed
+     * rather than resolved per FileDataID.
+     */
+    private const string MANIFEST_INTERFACE_DATA_CSV_URL = 'https://wago.tools/db2/ManifestInterfaceData/csv';
+
+    /** Only `Interface\ICONS\` entries are addressable on Wowhead's icon CDN. */
+    private const string ICONS_FILE_PATH = 'interface\icons\\';
+
+    public function __construct(
+        private readonly WagoToolsServiceLoggingInterface $log,
+    ) {
+    }
+
+    public function getIconFileNamesByFileDataIds(array $fileDataIds): array
+    {
+        try {
+            $this->log->getIconFileNamesByFileDataIdsStart(count($fileDataIds));
+
+            if ($fileDataIds === []) {
+                return [];
+            }
+
+            $csvFilePath = tempnam(sys_get_temp_dir(), 'manifestinterfacedata');
+            if ($csvFilePath === false) {
+                return [];
+            }
+
+            try {
+                if (!$this->curlSaveToFile(self::MANIFEST_INTERFACE_DATA_CSV_URL, $csvFilePath)) {
+                    $this->log->getIconFileNamesByFileDataIdsDownloadFailed(self::MANIFEST_INTERFACE_DATA_CSV_URL);
+
+                    return [];
+                }
+
+                $result = $this->parseIconFileNames($csvFilePath, $fileDataIds);
+            } finally {
+                unlink($csvFilePath);
+            }
+
+            foreach ($fileDataIds as $fileDataId) {
+                if (!isset($result[$fileDataId])) {
+                    $this->log->getIconFileNamesByFileDataIdsNotFound($fileDataId);
+                }
+            }
+
+            return $result;
+        } finally {
+            $this->log->getIconFileNamesByFileDataIdsEnd();
+        }
+    }
+
+    /**
+     * @param  array<int>         $fileDataIds
+     * @return array<int, string>
+     */
+    private function parseIconFileNames(string $csvFilePath, array $fileDataIds): array
+    {
+        $handle = fopen($csvFilePath, 'r');
+        if ($handle === false) {
+            $this->log->getIconFileNamesByFileDataIdsUnableToOpenFile($csvFilePath);
+
+            return [];
+        }
+
+        // Keyed so that the per-row lookup below stays O(1) - the CSV holds hundreds of thousands of rows
+        $wantedFileDataIds = array_flip($fileDataIds);
+        $result            = [];
+
+        try {
+            // Skip the header row (ID,FilePath,FileName)
+            fgetcsv($handle, escape: '');
+
+            while (($row = fgetcsv($handle, escape: '')) !== false) {
+                if (count($row) < 3) {
+                    continue;
+                }
+
+                [$fileDataId, $filePath, $fileName] = $row;
+
+                if (!isset($wantedFileDataIds[(int)$fileDataId])) {
+                    continue;
+                }
+
+                // The DB2 is inconsistently cased - `Interface\ICONS\` and `interface\ICONS\` both occur
+                if (strtolower((string)$filePath) !== self::ICONS_FILE_PATH) {
+                    continue;
+                }
+
+                $result[(int)$fileDataId] = strtolower(pathinfo((string)$fileName, PATHINFO_FILENAME));
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return $result;
+    }
+}

--- a/app/Service/Wago/WagoToolsServiceInterface.php
+++ b/app/Service/Wago/WagoToolsServiceInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Service\Wago;
+
+interface WagoToolsServiceInterface
+{
+    /**
+     * Resolves interface texture FileDataIDs - the `info.texture` MDT puts on its map POIs - to the icon file
+     * names they are known by on Wowhead's CDN, e.g. 4620673 => `ui_profession_engineering`.
+     *
+     * FileDataIDs that are not an interface icon are absent from the result.
+     *
+     * @param  array<int>         $fileDataIds
+     * @return array<int, string> FileDataID => icon file name, without extension, lowercased.
+     */
+    public function getIconFileNamesByFileDataIds(array $fileDataIds): array;
+}

--- a/app/Service/Wowhead/WowheadService.php
+++ b/app/Service/Wowhead/WowheadService.php
@@ -22,6 +22,8 @@ class WowheadService implements WowheadServiceInterface
 {
     use Curl;
 
+    private const string ICON_URL_FORMAT = 'https://wow.zamimg.com/images/wow/icons/large/%s';
+
     private const string IDENTIFYING_TOKEN_HEALTH     = '$(document).ready(function(){$(".infobox li").last().after("<li><div><span class=\"tip\" onmouseover=\"WH.Tooltip.showAtCursor(event, ';
     private const string IDENTIFYING_TOKEN_DISPLAY_ID = 'linksButton.dataset.displayId =';
 
@@ -120,11 +122,16 @@ class WowheadService implements WowheadServiceInterface
 
     public function downloadSpellIcon(Spell $spell, string $targetFolder): bool
     {
-        $fileName       = sprintf('%s.jpg', $spell->icon_name);
+        return $this->downloadIcon($spell->icon_name, $targetFolder);
+    }
+
+    public function downloadIcon(string $iconName, string $targetFolder): bool
+    {
+        $fileName       = sprintf('%s.jpg', $iconName);
         $targetFilePath = sprintf('%s/%s', $targetFolder, $fileName);
 
         $result = $this->curlSaveToFile(
-            sprintf('https://wow.zamimg.com/images/wow/icons/large/%s', $fileName),
+            sprintf(self::ICON_URL_FORMAT, $fileName),
             $targetFilePath,
         );
 

--- a/app/Service/Wowhead/WowheadService.php
+++ b/app/Service/Wowhead/WowheadService.php
@@ -125,6 +125,14 @@ class WowheadService implements WowheadServiceInterface
         return $this->downloadIcon($spell->icon_name, $targetFolder);
     }
 
+    /**
+     * Downloads an icon by its file name off `wow.zamimg.com` - Wowhead's asset CDN, NOT wowhead.com.
+     *
+     * Worth stating explicitly because the two behave differently for us: the CDN serves us normally, while
+     * wowhead.com's pages answer 403 to {@see \App\Service\Traits\Curl}'s spoofed Chrome user agent. So an
+     * icon can always be fetched given its file name - but the name itself cannot be scraped off Wowhead, and
+     * is resolved from a texture FileDataID via wago.tools' ManifestInterfaceData DB2 instead (#3993).
+     */
     public function downloadIcon(string $iconName, string $targetFolder): bool
     {
         $fileName       = sprintf('%s.jpg', $iconName);

--- a/app/Service/Wowhead/WowheadServiceInterface.php
+++ b/app/Service/Wowhead/WowheadServiceInterface.php
@@ -12,6 +12,11 @@ interface WowheadServiceInterface
 
     public function downloadMissingSpellIcons(): bool;
 
+    /**
+     * Downloads an icon off Wowhead's CDN by its icon file name (without extension) into $targetFolder.
+     */
+    public function downloadIcon(string $iconName, string $targetFolder): bool;
+
     public function getNpcDisplayId(GameVersion $gameVersion, Npc $npc, ?string $html = null): ?int;
 
     public function getSpellData(GameVersion $gameVersion, int $spellId, ?string $html = null): ?SpellDataResult;

--- a/database/seeders/MapIconTypesSeeder.php
+++ b/database/seeders/MapIconTypesSeeder.php
@@ -631,6 +631,88 @@ class MapIconTypesSeeder extends Seeder implements TableSeederInterface
                 'height'     => 32,
                 'admin_only' => true,
             ],
+
+            MapIconType::MAP_ICON_TYPE_ALGETHAR_ACADEMY_BLACK_DRAGONFLIGHT_PLEDGE_PIN => [
+                'name'       => 'mapicontypes.algethar_academy_black_dragonflight_pledge_pin',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+            MapIconType::MAP_ICON_TYPE_ALGETHAR_ACADEMY_BLUE_DRAGONFLIGHT_PLEDGE_PIN => [
+                'name'       => 'mapicontypes.algethar_academy_blue_dragonflight_pledge_pin',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+            MapIconType::MAP_ICON_TYPE_ALGETHAR_ACADEMY_BRONZE_DRAGONFLIGHT_PLEDGE_PIN => [
+                'name'       => 'mapicontypes.algethar_academy_bronze_dragonflight_pledge_pin',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+            MapIconType::MAP_ICON_TYPE_ALGETHAR_ACADEMY_GREEN_DRAGONFLIGHT_PLEDGE_PIN => [
+                'name'       => 'mapicontypes.algethar_academy_green_dragonflight_pledge_pin',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+            MapIconType::MAP_ICON_TYPE_ALGETHAR_ACADEMY_RED_DRAGONFLIGHT_PLEDGE_PIN => [
+                'name'       => 'mapicontypes.algethar_academy_red_dragonflight_pledge_pin',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+
+            MapIconType::MAP_ICON_TYPE_MAGISTERS_TERRACE_ARCANE_EMPOWERMENT => [
+                'name'       => 'mapicontypes.magisters_terrace_arcane_empowerment',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+
+            MapIconType::MAP_ICON_TYPE_MURDER_ROW_FEL_CONTRABAND => [
+                'name'       => 'mapicontypes.murder_row_fel_contraband',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+            MapIconType::MAP_ICON_TYPE_MURDER_ROW_FELSTONE => [
+                'name'       => 'mapicontypes.murder_row_felstone',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+            MapIconType::MAP_ICON_TYPE_MURDER_ROW_FELWYRM_EGG => [
+                'name'       => 'mapicontypes.murder_row_felwyrm_egg',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+            MapIconType::MAP_ICON_TYPE_MURDER_ROW_HEARTSTOP_POISON => [
+                'name'       => 'mapicontypes.murder_row_heartstop_poison',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+            MapIconType::MAP_ICON_TYPE_MURDER_ROW_LOADED_PISTOL => [
+                'name'       => 'mapicontypes.murder_row_loaded_pistol',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+            MapIconType::MAP_ICON_TYPE_MURDER_ROW_OVERLOAD_GOLEM => [
+                'name'       => 'mapicontypes.murder_row_overload_golem',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
+
+            MapIconType::MAP_ICON_TYPE_THE_BLINDING_VALE_FLOURISHING_STRIDE => [
+                'name'       => 'mapicontypes.the_blinding_vale_flourishing_stride',
+                'width'      => 32,
+                'height'     => 32,
+                'admin_only' => true,
+            ],
         ];
 
         $mapIconTypeAttributes = [];

--- a/docker-compose.worktree.yml
+++ b/docker-compose.worktree.yml
@@ -27,6 +27,13 @@ services:
       # Live-shares the main checkout's generated thumbnails (#3548) — worktrees don't run
       # Horizon/puppeteer themselves, so this is the only way they see thumbnails at all.
       - ${MAIN_THUMBNAILS_DIR}:/var/www/storage/app/public/thumbnails
+      # The assets repo, at the same path the main stack mounts it (#3993): `base_path('../keystone.guru.assets')`
+      # resolves to /var/keystone.guru.assets, so `mapicon:downloadmdtitemicons` and `mapicon:generateitemicons`
+      # run from a worktree too. Read-write on purpose — both commands write icons. Note this is the one mount
+      # here that is NOT worktree-isolated: writes land in the shared assets repo, so `git status` it afterwards.
+      # The default resolves keystone.guru-worktrees/<branch> -> the main checkout's sibling, which is where
+      # sh/worktree.sh and docker-compose.yml both expect the repo; sh/worktree.sh writes it explicitly.
+      - ${MAIN_ASSETS_DIR:-../../keystone.guru.assets}:/var/keystone.guru.assets
 
   nginx:
     image: nginx:alpine

--- a/lang/en_US/mapicontypes.php
+++ b/lang/en_US/mapicontypes.php
@@ -112,4 +112,18 @@ return [
     'seat_of_the_triumvirate_void_infusion'  => 'Void Infusion',
     'maisara_caverns_hearty_vilebranch_stew' => 'Hearty Vilebranch Stew',
 
+    'algethar_academy_black_dragonflight_pledge_pin'  => 'Black Dragonflight Pledge Pin',
+    'algethar_academy_blue_dragonflight_pledge_pin'   => 'Blue Dragonflight Pledge Pin',
+    'algethar_academy_bronze_dragonflight_pledge_pin' => 'Bronze Dragonflight Pledge Pin',
+    'algethar_academy_green_dragonflight_pledge_pin'  => 'Green Dragonflight Pledge Pin',
+    'algethar_academy_red_dragonflight_pledge_pin'    => 'Red Dragonflight Pledge Pin',
+    'magisters_terrace_arcane_empowerment'            => 'Arcane Empowerment',
+    'murder_row_fel_contraband'                       => 'Fel Contraband',
+    'murder_row_felstone'                             => 'Felstone',
+    'murder_row_felwyrm_egg'                          => 'Felwyrm Egg',
+    'murder_row_heartstop_poison'                     => 'Heartstop Poison',
+    'murder_row_loaded_pistol'                        => 'Loaded Pistol',
+    'murder_row_overload_golem'                       => 'Overload Golem',
+    'the_blinding_vale_flourishing_stride'            => 'Flourishing Stride',
+
 ];

--- a/sh/worktree.sh
+++ b/sh/worktree.sh
@@ -396,8 +396,8 @@ EOF
         set_env_var "$wt_path/.env" DB_COMBATLOG_DATABASE "$schema"
         set_env_var "$wt_path/.env" REDIS_PREFIX          "${project}-cache:"
     fi
-    # MAIN_THUMBNAILS_DIR is persisted into the worktree .env (not just exported) so that plain
-    # `docker compose ...` invocations resolve the bind-mount source too — e.g. the profiled
+    # MAIN_THUMBNAILS_DIR / MAIN_ASSETS_DIR are persisted into the worktree .env (not just exported) so
+    # that plain `docker compose ...` invocations resolve the bind-mount sources too — e.g. the profiled
     # `render` service used for Path A thumbnail rendering (see the generating-thumbnails skill).
     cat >> "$wt_path/.env" <<EOF
 
@@ -406,12 +406,19 @@ COMPOSE_PROJECT_NAME=${project}
 COMPOSE_FILE=docker-compose.worktree.yml
 WORKTREE_HTTP_PORT=${port}
 MAIN_THUMBNAILS_DIR=${REPO_ROOT}/storage/app/public/thumbnails
+MAIN_ASSETS_DIR=$(dirname "$REPO_ROOT")/keystone.guru.assets
 EOF
 
     # 4b. Main's thumbnail directory is bind-mounted into the worktree (live-shares thumbnails
     #     generated on the main stack — see #3548); the mount source must exist beforehand.
     export MAIN_THUMBNAILS_DIR="$REPO_ROOT/storage/app/public/thumbnails"
     mkdir -p "$MAIN_THUMBNAILS_DIR"
+
+    # 4c. The assets repo is bind-mounted at the same path the main stack uses, so the mapicon:*
+    #     commands work from a worktree (#3993). It is a checkout, not a generated dir — if it is
+    #     missing, warn rather than mkdir an empty one that would silently shadow nothing.
+    export MAIN_ASSETS_DIR="$(dirname "$REPO_ROOT")/keystone.guru.assets"
+    [ -d "$MAIN_ASSETS_DIR" ] || echo "==> WARNING: assets repo not found at $MAIN_ASSETS_DIR - mapicon:* commands will not work"
 
     # 5. Bring up the stack (reads COMPOSE_* + WORKTREE_HTTP_PORT from the worktree .env).
     echo "==> starting stack '$project' (nginx on :$port)"

--- a/tests/Unit/App/Logic/MDT/ConversionMapPOIMapIconTypeTest.php
+++ b/tests/Unit/App/Logic/MDT/ConversionMapPOIMapIconTypeTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Unit\App\Logic\MDT;
+
+use App\Logic\MDT\Conversion;
+use App\Logic\MDT\Entity\MDTMapPOI;
+use App\Models\MapIconType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+#[Group('MDT')]
+final class ConversionMapPOIMapIconTypeTest extends TestCase
+{
+    #[Test]
+    public function convertMDTMapPOIToMapIconTypeKey_givenMappedType_returnsItsMapIconTypeKey(): void
+    {
+        // Arrange
+        $mdtMapPOI = new MDTMapPOI(1, ['type' => 'graveyard', 'x' => 1.0, 'y' => 2.0]);
+
+        // Act
+        $mapIconTypeKey = Conversion::convertMDTMapPOIToMapIconTypeKey($mdtMapPOI);
+
+        // Assert
+        $this->assertSame(MapIconType::MAP_ICON_TYPE_GRAVEYARD, $mapIconTypeKey);
+    }
+
+    #[Test]
+    #[DataProvider('genericItemSpellIdProvider')]
+    public function convertMDTMapPOIToMapIconTypeKey_givenGenericItemWithKnownSpellId_returnsItsOwnMapIconTypeKey(
+        int    $spellId,
+        string $expectedMapIconTypeKey,
+    ): void {
+        // Arrange
+        $mdtMapPOI = new MDTMapPOI(1, [
+            'type' => 'genericItem',
+            'x'    => 1.0,
+            'y'    => 2.0,
+            'info' => ['spellId' => $spellId, 'texture' => 1003586, 'size' => 10],
+        ]);
+
+        // Act
+        $mapIconTypeKey = Conversion::convertMDTMapPOIToMapIconTypeKey($mdtMapPOI);
+
+        // Assert
+        $this->assertSame($expectedMapIconTypeKey, $mapIconTypeKey);
+        $this->assertFalse(Conversion::isMDTMapPOIUnhandled($mdtMapPOI));
+    }
+
+    /**
+     * @return array<string, array{int, string}>
+     */
+    public static function genericItemSpellIdProvider(): array
+    {
+        return [
+            'Fel Contraband'     => [1270638, MapIconType::MAP_ICON_TYPE_MURDER_ROW_FEL_CONTRABAND],
+            'Overload Golem'     => [1223133, MapIconType::MAP_ICON_TYPE_MURDER_ROW_OVERLOAD_GOLEM],
+            'Felwyrm Egg'        => [1223570, MapIconType::MAP_ICON_TYPE_MURDER_ROW_FELWYRM_EGG],
+            'Arcane Empowerment' => [1254550, MapIconType::MAP_ICON_TYPE_MAGISTERS_TERRACE_ARCANE_EMPOWERMENT],
+            'Void Infusion'      => [244300, MapIconType::MAP_ICON_TYPE_SEAT_OF_THE_TRIUMVIRATE_VOID_INFUSION],
+        ];
+    }
+
+    #[Test]
+    public function convertMDTMapPOIToMapIconTypeKey_givenGenericItemWithUnknownSpellId_returnsNull(): void
+    {
+        // Arrange
+        $mdtMapPOI = new MDTMapPOI(1, [
+            'type' => 'genericItem',
+            'x'    => 1.0,
+            'y'    => 2.0,
+            'info' => ['spellId' => 1, 'texture' => 2],
+        ]);
+
+        // Act
+        $mapIconTypeKey = Conversion::convertMDTMapPOIToMapIconTypeKey($mdtMapPOI);
+
+        // Assert
+        $this->assertNull($mapIconTypeKey);
+    }
+
+    #[Test]
+    public function isMDTMapPOIUnhandled_givenGenericItemWithUnknownSpellId_returnsTrue(): void
+    {
+        // Arrange - the exact shape that silently disappeared before #3993
+        $mdtMapPOI = new MDTMapPOI(1, [
+            'type' => 'genericItem',
+            'x'    => 1.0,
+            'y'    => 2.0,
+            'info' => ['spellId' => 1, 'texture' => 2],
+        ]);
+
+        // Act
+        $unhandled = Conversion::isMDTMapPOIUnhandled($mdtMapPOI);
+
+        // Assert
+        $this->assertTrue($unhandled);
+        $this->assertSame(1, $mdtMapPOI->getSpellId());
+        $this->assertSame(2, $mdtMapPOI->getTextureFileDataId());
+    }
+
+    #[Test]
+    public function isMDTMapPOIUnhandled_givenMapLink_returnsFalse(): void
+    {
+        // Arrange - map links become dungeon floor switch markers instead of map icons
+        $mdtMapPOI = new MDTMapPOI(1, ['type' => 'mapLink', 'x' => 1.0, 'y' => 2.0, 'target' => 2]);
+
+        // Act & Assert
+        $this->assertFalse(Conversion::isMDTMapPOIUnhandled($mdtMapPOI));
+    }
+
+    #[Test]
+    #[DataProvider('notImportedTypeProvider')]
+    public function isMDTMapPOIUnhandled_givenTypeThatIsPartOfMDTsOwnUI_returnsFalse(string $type): void
+    {
+        // Arrange
+        $mdtMapPOI = new MDTMapPOI(1, ['type' => $type, 'x' => 1.0, 'y' => 2.0]);
+
+        // Act & Assert
+        $this->assertFalse(Conversion::isMDTMapPOIUnhandled($mdtMapPOI));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function notImportedTypeProvider(): array
+    {
+        return [
+            'zoom'      => ['zoom'],
+            'textFrame' => ['textFrame'],
+        ];
+    }
+
+    #[Test]
+    public function mapIconTypeMappings_allReferenceAnExistingMapIconType(): void
+    {
+        // Arrange
+        $mapIconTypeKeys = array_merge(
+            array_values(Conversion::MAP_POI_TYPE_MAP_ICON_TYPE_MAPPING),
+            array_values(Conversion::MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING),
+        );
+
+        // Act & Assert - a typo here imports as the wrong icon, or fatals on MapIconType::ALL
+        foreach ($mapIconTypeKeys as $mapIconTypeKey) {
+            $this->assertArrayHasKey($mapIconTypeKey, MapIconType::ALL);
+        }
+    }
+
+    #[Test]
+    public function mapIconTypeMappings_allHaveATranslatedName(): void
+    {
+        // Arrange
+        $mapIconTypeKeys = array_merge(
+            array_values(Conversion::MAP_POI_TYPE_MAP_ICON_TYPE_MAPPING),
+            array_values(Conversion::MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING),
+        );
+
+        // Act & Assert - without this the icon renders with its raw key as its name
+        foreach ($mapIconTypeKeys as $mapIconTypeKey) {
+            $translationKey = sprintf('mapicontypes.%s', $mapIconTypeKey);
+
+            $this->assertNotSame(
+                $translationKey,
+                __($translationKey),
+                sprintf('Missing lang/en_US/mapicontypes.php entry for %s', $mapIconTypeKey),
+            );
+        }
+    }
+}


### PR DESCRIPTION
:robot: Closes #3993

## What was wrong

MDT draws item pickups as `mapPOIs` of type `genericItem`. `MDTMappingImportService::importMapPOIs()`
matched POI types against a flat `type => mapIconTypeId` array, handled `mapLink` in an `elseif`, and
did **nothing at all** for anything else - no icon, no warning, no log line. 19 POIs across 6 Midnight
dungeons disappeared that way, including Murder Row's Fel Contraband, Overload Golem and Felwyrm Egg.

`MDTMapPOIType::GenericItem` is a *known* enum case, so it never tripped the `Found new type ...`
exception the `update-mdt-package` runbook uses to spot gaps - which is why the MDT 6.2.1 import
(#3980) reported "no new POI types".

## What changed

- **The POI -> map icon type mapping moves to `Conversion`** and gains a second, spell-id keyed table.
  `genericItem` is a single MDT type covering every item it draws, distinguished only by the spell it
  shows the tooltip of, so a type-keyed map cannot express it.
- **Unmapped POIs are reported, not dropped.** `importMapPOIsUnhandledMapPOI` logs at ERROR, and
  `mdt:importmapping` renders a summary table. It reads MDT directly rather than the import, so it
  shows up even on `no change detected` - the gap exists either way. Deliberately **not** routed
  through `$importFailures`, which throws `MDTMappingImportPartialFailureException` and deletes the
  whole mapping version.
- **`zoom` and `textFrame` are marked as never-imported** (MDT's own zoom affordance and the user's
  text annotations), so they don't show up as false positives.
- **13 new map icon types** covering every `genericItem` in the current Midnight dungeons.
- **`mapicon:downloadmdtitemicons <dungeon|seasonId>`** fetches the source icons automatically.

## Getting an icon out of MDT, automatically

Wowhead is not usable from the app container - `https://www.wowhead.com/spell=<id>` returns **403**
(CloudFront), so `WowheadService::getSpellData()` returns an empty `SpellDataResult`. Worth a separate
issue: `wowhead:fetchspelldata` is degraded by the same thing.

A deterministic path exists instead. MDT's `info.texture` is a FileDataID:

1. `wago.tools/db2/ManifestInterfaceData/csv` maps FileDataID -> icon file name
   (`4620673` -> `UI_Profession_Engineering.blp`) - the new `WagoToolsService`.
2. `wow.zamimg.com/images/wow/icons/large/<name>.jpg` serves it - `WowheadService::downloadIcon()`,
   split out of `downloadSpellIcon()`.

It validates against existing hand-picked data: Maisara Caverns' FileDataID resolves to exactly the
`inv_cooking_10_heartystew` that was chosen by hand in a18f9799e.

## The 19 POIs

| Dungeon | spellId | Name | texture FDID | icon |
|---|---|---|---|---|
| Algeth'ar Academy | 389501 | Red Dragonflight Pledge Pin | 132532 | `inv_bijou_red` |
| Algeth'ar Academy | 389512 | Bronze Dragonflight Pledge Pin | 132530 | `inv_bijou_orange` |
| Algeth'ar Academy | 389516 | Black Dragonflight Pledge Pin | 132533 | `inv_bijou_silver` |
| Algeth'ar Academy | 389521 | Blue Dragonflight Pledge Pin | 132526 | `inv_bijou_blue` |
| Algeth'ar Academy | 389536 | Green Dragonflight Pledge Pin | 132529 | `inv_bijou_green` |
| Magisters' Terrace | 1254550 | Arcane Empowerment | 135740 | `spell_arcane_mindmastery` |
| Maisara Caverns | 1269056 | Hearty Vilebranch Stew | 4659336 | existing |
| Murder Row | 1270638 x3 | Fel Contraband | 1003586 | `inv_enchanting_wod_crystal` |
| Murder Row | 1223133 x3 | Overload Golem | 4620673 | `ui_profession_engineering` |
| Murder Row | 1223570 | Felwyrm Egg | 236999 | `inv_egg_08` |
| Murder Row | 1223537 | Felstone | 1394959 | `inv_infernalbrimstone` |
| Murder Row | 1217960 | Loaded Pistol | 331438 | `inv_weapon_rifle_40` |
| Murder Row | 1223607 | Heartstop Poison | 1120423 | `ability_boss_kilrogg_heartseeker` |
| Seat of the Triumvirate | 244300 | Void Infusion | 6891020 | existing |
| The Blinding Vale | 1265942 | Flourishing Stride | 348567 | `spell_lifegivingspeed` |

## Verification

Force-reimported Murder Row against an isolated worktree DB - the new mapping version carries exactly
what MDT draws:

```
dungeon_start x1
murder_row_felwyrm_egg x1
murder_row_fel_contraband x3
murder_row_loaded_pistol x1
murder_row_felstone x1
murder_row_heartstop_poison x1
murder_row_overload_golem x3
```

All 6 Midnight dungeons now report 0 unhandled POIs. The table was verified against `therookery`,
which still has an unmapped `rookItem`.

## Out of scope

- **No reimport.** `importMapPOIs` is gated on `mdt_mapping_hash`, so existing mapping versions keep
  their missing icons until the next MDT bump. Agreed with Wotuu - a `--force` across 6 dungeons means
  6 new mapping versions with enemy/checkpoint churn and seeder diffs.
- **The generalised reporting surfaced 62 more unhandled POIs in 12 older dungeons**
  (`nwItem`, `brackenhideCage`, `neltharusChain`, `mistsItem`, `cotItem`, `rookItem`, ...). None are in
  the current season, so they are left for whenever those dungeons come back around.
- **Assets:** the 13 generated `mapicon/*.png` and their 13 `mapicon_gen/*.jpg` sources are staged in
  `keystone.guru.assets` but **not committed** - that repo's `main` is not mine to push to. They must
  land before this merges, or the new icons 404.

## Cold review

4 findings, all fixed in a3ea1a1e9, all threads resolved. The blocking one: spell IDs `1269056`
(Maisara Caverns) and `244300` (Seat of the Triumvirate) already have hand-placed icons that
`copyMappingVersionContentsToDungeon()` clones into every new mapping version, sitting 5.3 and 13.9
lat/lng off MDT's position - outside `getMapIconNearLocation()`'s ±5 window, so the import would have
added a second copy of each. Fixed by having `importMapPOIs()` delete the cloned
`genericItem`-derived icons and re-create the full set from MDT: every map icon type in
`MAP_POI_GENERIC_ITEM_SPELL_ID_MAP_ICON_TYPE_MAPPING` exists for exactly one MDT POI, so MDT owning
them is the right semantic. Verified by force-reimporting both dungeons - one icon each, at MDT's
coordinates.

## Held in draft on purpose

**Resolved:** the `keystone.guru.assets` commit has been pushed, so the icons are in place.


