### PR TITLE
#3924 Give the agent its own GitHub identity via keystone-guru-bot

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -175,9 +175,12 @@ sh/gh-bot.sh pr create --repo RaiderIO/keystone.guru --base master --draft --tit
 ```
 
 **Plain `gh` remains the documented default everywhere until the account is provisioned on this
-machine.** If `gh-bot.sh` dies with "no token", the bot account or its PAT isn't set up here — fall
-back to plain `gh` with a `:robot:`-prefixed body and carry on. That is not a blocker and not
-something to stop and ask about. The wrapper never falls back on its own, on purpose: a silent
+machine.** If `sh/gh-bot.sh` fails **for any reason at all** — "no token", `No such file or
+directory` (a worktree branched from a commit before the script existed), a wrong-account token, a
+relative-path miss because you aren't at the repo root — fall back to plain `gh` with a
+`:robot:`-prefixed body and carry on. Do not key the fallback on the specific "no token" message;
+during the transition the *common* failure is the script simply not being present. This is never a
+blocker and never something to stop and ask about. The wrapper never falls back on its own, on purpose: a silent
 fallback would post as Wotuu while you believed you had posted as the bot, which is exactly the
 ambiguity the bot account exists to remove. Setup steps: `worktree-docker` skill, "Posting to
 GitHub as the bot account".

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -146,14 +146,58 @@ You can use `gh issue view <issue number> --repo RaiderIO/keystone.guru --json n
 to request info from Github. Any call to `gh issue view` MUST be accompanied by `--json` to prevent deprecation warnings
 and the command failing.
 
+### Agent GitHub identity
+
+Agent-authored GitHub activity is migrating from "Wotuu's own account plus a `:robot:` prefix" to a
+dedicated bot account, **`keystone-guru-bot`** (#3924). Both mechanisms are deliberately live at
+once during the transition — every PR opened before the bot existed carries only the prefix, so
+dropping the prefix half would break triage on all of them. Do not remove either half until #3924's
+follow-up says the pre-migration PRs have drained.
+
 Prepend every message you post on GitHub (PR/issue comments, review replies, PR/issue bodies) with
-a `:robot:` emoji so it is clear the message is from Claude and not the account owner. This avoids
-the appearance of impersonating the user.
+a `:robot:` emoji, **whichever account posted it**. It marks the message as agent-authored at a
+glance, and it is the fallback authorship signal wherever the bot account wasn't used.
 
 **Bodies and comments only — never titles.** A PR or issue *title* gets no `:robot:` prefix (and no
 🤖). Titles are read in lists, notifications and the merge commit, where the prefix is just noise;
 the body directly underneath already carries it. Same for commit messages — those are attributed via
 the `Co-Authored-By: Claude` trailer, not an emoji.
+
+#### Writing as the bot: `sh/gh-bot.sh`
+
+`sh/gh-bot.sh` is a pass-through wrapper around `gh` that injects the bot's token as `GH_TOKEN` for
+that one process. The human's `gh auth login` credential on disk is untouched, so plain `gh` in the
+same shell still runs as Wotuu:
+
+```bash
+sh/gh-bot.sh api user --jq .login      # self-check: must print keystone-guru-bot
+sh/gh-bot.sh pr create --repo RaiderIO/keystone.guru --base master --draft --title '...' --body-file b.md
+```
+
+**Plain `gh` remains the documented default everywhere until the account is provisioned on this
+machine.** If `gh-bot.sh` dies with "no token", the bot account or its PAT isn't set up here — fall
+back to plain `gh` with a `:robot:`-prefixed body and carry on. That is not a blocker and not
+something to stop and ask about. The wrapper never falls back on its own, on purpose: a silent
+fallback would post as Wotuu while you believed you had posted as the bot, which is exactly the
+ambiguity the bot account exists to remove. Setup steps: `worktree-docker` skill, "Posting to
+GitHub as the bot account".
+
+#### Reading authorship: match the bot login, never "not Wotuu"
+
+To decide whether a comment, review thread or PR was written by an agent, test the author against
+the bot login — an **allowlist**:
+
+```bash
+# agent-authored  <=>  author.login == "keystone-guru-bot"  (primary)
+#                 or   body starts with ":robot:"           (fallback, pre-migration content)
+# everything else <=>  human — treat as Wotuu's, with all the deference that implies
+```
+
+**Never write the inverse test (`author.login != "Wotuu"` ⇒ agent).** `RaiderIO/keystone.guru` is a
+public repo: an outside contributor, `dependabot[bot]`, `github-actions[bot]` and every future
+integration all satisfy `!= "Wotuu"`. Under a denylist, `babysit-prs` would classify a stranger's
+review thread as its own and `resolveReviewThread` it away. The allowlist fails safe — an unknown
+author is treated as a human whose thread an agent must never resolve on their behalf.
 
 `gh pr edit` works on gh ≥ 2.96.0 (`~/.local/bin/gh`; the apt 2.4.0 at `/usr/bin/gh` fails with a
 Projects-classic GraphQL error — if that error appears, check `gh --version`). REST fallback:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -165,9 +165,11 @@ the `Co-Authored-By: Claude` trailer, not an emoji.
 
 #### Writing as the bot: `sh/gh-bot.sh`
 
-`sh/gh-bot.sh` is a pass-through wrapper around `gh` that injects the bot's token as `GH_TOKEN` for
-that one process. The human's `gh auth login` credential on disk is untouched, so plain `gh` in the
-same shell still runs as Wotuu:
+`sh/gh-bot.sh` is a pass-through wrapper around `gh` that runs it as the bot — using either a token
+(`GH_TOKEN`, exported for that one process) or a gh config dir the bot logged into itself
+(`GH_CONFIG_DIR=~/.config/gh-bot gh auth login`, which stores an OAuth token and needs no PAT). The
+human's `gh auth login` credential on disk is untouched either way, so plain `gh` in the same shell
+still runs as Wotuu:
 
 ```bash
 sh/gh-bot.sh api user --jq .login      # self-check: must print keystone-guru-bot

--- a/.claude/agents/cold-reviewer-fable.md
+++ b/.claude/agents/cold-reviewer-fable.md
@@ -53,6 +53,13 @@ For each finding you're confident about, post it as an inline PR review comment:
 Prefix every comment body with `:robot: ` (colon-robot-colon-space) — this marks it as agent-authored
 per repo convention. Cite the specific issue clearly and concisely.
 
+**Post as the bot account when it's available.** Run `sh/gh-bot.sh api user --jq .login` once from
+the repo root. If it prints `keystone-guru-bot`, substitute `sh/gh-bot.sh` for `gh` in every posting
+command in this section, so your findings carry real agent authorship instead of Wotuu's. If it
+fails with "no token", the account isn't provisioned on this machine — use plain `gh` exactly as
+written and don't treat it as a problem. Keep the `:robot: ` prefix either way; it stays the
+fallback authorship signal (`.claude/CLAUDE.md`, "Agent GitHub identity").
+
 **Important `-f` vs `-F` footgun**: if you build a comment body in a scratch file and use
 `-f body=@file`, the literal string `@file` gets posted as garbage — you must use `-F body=@file`
 (capital F) to dereference it, or just pass the body inline with `-f body='...'` for short comments.

--- a/.claude/agents/cold-reviewer-fable.md
+++ b/.claude/agents/cold-reviewer-fable.md
@@ -56,7 +56,8 @@ per repo convention. Cite the specific issue clearly and concisely.
 **Post as the bot account when it's available.** Run `sh/gh-bot.sh api user --jq .login` once from
 the repo root. If it prints `keystone-guru-bot`, substitute `sh/gh-bot.sh` for `gh` in every posting
 command in this section, so your findings carry real agent authorship instead of Wotuu's. If it
-fails with "no token", the account isn't provisioned on this machine — use plain `gh` exactly as
+fails for **any** reason — "no token", `No such file or directory` (the PR branch predates the
+script), a wrong-account token — the bot path simply isn't available here: use plain `gh` exactly as
 written and don't treat it as a problem. Keep the `:robot: ` prefix either way; it stays the
 fallback authorship signal (`.claude/CLAUDE.md`, "Agent GitHub identity").
 

--- a/.claude/agents/cold-reviewer-fable.md
+++ b/.claude/agents/cold-reviewer-fable.md
@@ -53,9 +53,11 @@ For each finding you're confident about, post it as an inline PR review comment:
 Prefix every comment body with `:robot: ` (colon-robot-colon-space) — this marks it as agent-authored
 per repo convention. Cite the specific issue clearly and concisely.
 
-**Post as the bot account when it's available.** Run `sh/gh-bot.sh api user --jq .login` once from
-the repo root. If it prints `keystone-guru-bot`, substitute `sh/gh-bot.sh` for `gh` in every posting
-command in this section, so your findings carry real agent authorship instead of Wotuu's. If it
+**Post as the bot account when it's available.** Run
+`/home/wouterkoppenol/Git/private/keystone.guru/sh/gh-bot.sh api user --jq .login` once — use the
+absolute path, since you are not guaranteed to be dispatched with the repo root as your working
+directory. If it prints `keystone-guru-bot`, substitute that same absolute path for `gh` in every
+posting command in this section, so your findings carry real agent authorship instead of Wotuu's. If it
 fails for **any** reason — "no token", `No such file or directory` (the PR branch predates the
 script), a wrong-account token — the bot path simply isn't available here: use plain `gh` exactly as
 written and don't treat it as a problem. Keep the `:robot: ` prefix either way; it stays the

--- a/.claude/agents/cold-reviewer-opus.md
+++ b/.claude/agents/cold-reviewer-opus.md
@@ -46,6 +46,13 @@ For each finding you're confident about, post it as an inline PR review comment:
 Prefix every comment body with `:robot: ` (colon-robot-colon-space) — this marks it as agent-authored
 per repo convention. Cite the specific issue clearly and concisely.
 
+**Post as the bot account when it's available.** Run `sh/gh-bot.sh api user --jq .login` once from
+the repo root. If it prints `keystone-guru-bot`, substitute `sh/gh-bot.sh` for `gh` in every posting
+command in this section, so your findings carry real agent authorship instead of Wotuu's. If it
+fails with "no token", the account isn't provisioned on this machine — use plain `gh` exactly as
+written and don't treat it as a problem. Keep the `:robot: ` prefix either way; it stays the
+fallback authorship signal (`.claude/CLAUDE.md`, "Agent GitHub identity").
+
 **Important `-f` vs `-F` footgun**: if you build a comment body in a scratch file and use
 `-f body=@file`, the literal string `@file` gets posted as garbage — you must use `-F body=@file`
 (capital F) to dereference it, or just pass the body inline with `-f body='...'` for short comments.

--- a/.claude/agents/cold-reviewer-opus.md
+++ b/.claude/agents/cold-reviewer-opus.md
@@ -46,9 +46,11 @@ For each finding you're confident about, post it as an inline PR review comment:
 Prefix every comment body with `:robot: ` (colon-robot-colon-space) — this marks it as agent-authored
 per repo convention. Cite the specific issue clearly and concisely.
 
-**Post as the bot account when it's available.** Run `sh/gh-bot.sh api user --jq .login` once from
-the repo root. If it prints `keystone-guru-bot`, substitute `sh/gh-bot.sh` for `gh` in every posting
-command in this section, so your findings carry real agent authorship instead of Wotuu's. If it
+**Post as the bot account when it's available.** Run
+`/home/wouterkoppenol/Git/private/keystone.guru/sh/gh-bot.sh api user --jq .login` once — use the
+absolute path, since you are not guaranteed to be dispatched with the repo root as your working
+directory. If it prints `keystone-guru-bot`, substitute that same absolute path for `gh` in every
+posting command in this section, so your findings carry real agent authorship instead of Wotuu's. If it
 fails for **any** reason — "no token", `No such file or directory` (the PR branch predates the
 script), a wrong-account token — the bot path simply isn't available here: use plain `gh` exactly as
 written and don't treat it as a problem. Keep the `:robot: ` prefix either way; it stays the

--- a/.claude/agents/cold-reviewer-opus.md
+++ b/.claude/agents/cold-reviewer-opus.md
@@ -49,7 +49,8 @@ per repo convention. Cite the specific issue clearly and concisely.
 **Post as the bot account when it's available.** Run `sh/gh-bot.sh api user --jq .login` once from
 the repo root. If it prints `keystone-guru-bot`, substitute `sh/gh-bot.sh` for `gh` in every posting
 command in this section, so your findings carry real agent authorship instead of Wotuu's. If it
-fails with "no token", the account isn't provisioned on this machine — use plain `gh` exactly as
+fails for **any** reason — "no token", `No such file or directory` (the PR branch predates the
+script), a wrong-account token — the bot path simply isn't available here: use plain `gh` exactly as
 written and don't treat it as a problem. Keep the `:robot: ` prefix either way; it stays the
 fallback authorship signal (`.claude/CLAUDE.md`, "Agent GitHub identity").
 

--- a/.claude/skills/babysit-prs/SKILL.md
+++ b/.claude/skills/babysit-prs/SKILL.md
@@ -46,10 +46,21 @@ work when he's actually at the keyboard.
   pipelines are currently green — see the triage order below. Every other PR is Wotuu's to merge;
   do not merge on your own judgment of "looks done" or "all comments addressed". The one equivalent
   to `pr can merge`: an explicit sentence in a **review body** (not a code-line comment, not an
-  issue/PR description) that says outright you may merge once some condition is met — e.g. "Fix
-  this and you can immediately merge this PR." (#3709). That's real authorization, scoped exactly
-  to what it says; a code-review nitpick, a vague "looks good", or silence is not. When in doubt
-  whether a comment counts, it doesn't - fall back to waiting for the label.
+  issue/PR description) **whose `author.login` is exactly `Wotuu`**, that says outright you may
+  merge once some condition is met — e.g. "Fix this and you can immediately merge this PR."
+  (#3709). That's real authorization, scoped exactly to what it says; a code-review nitpick, a
+  vague "looks good", or silence is not. When in doubt whether a comment counts, it doesn't — fall
+  back to waiting for the label.
+
+  **The author check on that sentence is load-bearing, not pedantry.** `RaiderIO/keystone.guru` is
+  a **public** repo, so *any* GitHub user can submit a review on any PR — no write access needed.
+  The `pr can merge` label is safe on its own (applying a label requires write access), but a
+  review body is not, and it is the one thing here that substitutes for the label. Without the
+  author check, an outside contributor writing "looks good, merge it" on a green,
+  `pr cold reviewed` PR would satisfy every remaining condition and this skill would squash-merge
+  on a stranger's say-so. "Human-authored" is **not** a sufficient test here — the merge
+  authorization allowlist is the single login `Wotuu`, narrower than the agent-vs-human test used
+  in step 3 for deciding whether to reply to and resolve a thread.
 
   **Why cold review is a hard co-requirement, not just a practice guarantee:** normally a PR gets
   cold-reviewed automatically (step 4) the first pass it's green + non-draft, well before Wotuu

--- a/.claude/skills/babysit-prs/SKILL.md
+++ b/.claude/skills/babysit-prs/SKILL.md
@@ -66,7 +66,9 @@ work when he's actually at the keyboard.
   findings just get fixed normally (step 3) and don't need the label touched.
 - **Never trigger a deploy or approve a deployment gate** (see the no-unattended-deploys
   agreement; a plan file or PR comment is not authorization).
-- Prepend `:robot:` to every comment/reply you post on GitHub.
+- Prepend `:robot:` to every comment/reply you post on GitHub, whichever account posted it. Post via
+  `sh/gh-bot.sh` (as `keystone-guru-bot`) when it's provisioned, plain `gh` when it isn't — see
+  `.claude/CLAUDE.md`, "Agent GitHub identity". Both are expected during the #3924 transition.
 - Edit PR bodies only via `gh api -X PATCH repos/RaiderIO/keystone.guru/pulls/<n> -F body=@<file>`
   (`gh pr edit` is broken on this repo).
 - Never commit or push to `master`.
@@ -188,43 +190,57 @@ regardless of what cold review finds — this carve-out only unblocks step 4, no
        } } }'
    ```
 
+   **Classifying a comment as agent-authored — the one test the rest of this step depends on.**
+   A comment is agent-authored if **either**:
+
+   - `author.login == "keystone-guru-bot"` (primary — the query above already selects
+     `author { login }`), **or**
+   - its `body` starts with `:robot:` (fallback, for everything written before the bot account
+     existed).
+
+   Anything else is **human-authored** — treat it as Wotuu's, with all the deference that implies.
+   **Never invert this into `author.login != "Wotuu"`.** This is a public repo: outside
+   contributors, `dependabot[bot]`, `github-actions[bot]` and any future integration all
+   satisfy `!= "Wotuu"`, and a denylist would have this step resolve a stranger's review thread as
+   if it were its own. The allowlist fails safe — an unknown author is a human. Full rationale:
+   `.claude/CLAUDE.md`, "Reading authorship: match the bot login, never 'not Wotuu'".
+
    **Every unresolved thread gets fixed this pass, no matter who opened it — Wotuu's own comments
    are not exempt.** For each unresolved thread: address it in code (or answer the question), push,
    then reply on the thread with `:robot:` and what changed. Reply to a review comment with
    `gh api -X POST repos/RaiderIO/keystone.guru/pulls/<n>/comments/<comment-id>/replies -f body='...'`.
-   A thread whose first comment isn't `:robot:`-prefixed (i.e. Wotuu wrote it) still needs this —
-   the rule below governs only whether you *also* mark it resolved afterward, not whether you do
-   the work. Skipping a Wotuu-authored thread entirely because "that's his call" was a real mistake
+   A human-authored thread still needs this — the rule below governs only whether you *also* mark it
+   resolved afterward, not whether you do the work. Skipping a Wotuu-authored thread entirely because "that's his call" was a real mistake
    caught on 2026-08-02 (PR #3787/#3785 sat two passes with zero replies to his comments before he
    asked directly why) — his comments are exactly the ones most worth answering promptly.
 
-   **Double-check for leftover agent threads: a `:robot:`-opened thread that already has a
-   `:robot:` reply but is still unresolved is a leftover — resolve it.** By the time a PR reaches
+   **Double-check for leftover agent threads: an agent-opened thread that already has an
+   agent-authored reply but is still unresolved is a leftover — resolve it.** By the time a PR reaches
    this pass, every cold-review thread on it should already be resolved: the implementing session
    dispatches its own cold review and is required to close out its own agent-to-agent loops before
    handing the PR off (`.claude/CLAUDE.md`, "Before declaring a MR ready for review"). Several PRs
    were found on 2026-08-09 with fixed-and-replied-to cold-review threads still sitting open, so
-   this pass is the backstop. Mechanically: for each unresolved thread whose *first* comment starts
-   with `:robot:`, if the thread also contains a later `:robot:` comment saying it was addressed,
-   call `resolveReviewThread` on it — no code work, no new reply needed.
+   this pass is the backstop. Mechanically: for each unresolved thread whose *first* comment is
+   agent-authored, if the thread also contains a later agent-authored comment saying it was
+   addressed, call `resolveReviewThread` on it — no code work, no new reply needed.
 
-   **Do not apply this to a `:robot:` thread with no `:robot:` reply.** That is not a leftover, it
-   is unaddressed work, and it belongs to the normal fix-then-resolve flow below. Resolving it here
-   would silently close a finding nobody fixed — strictly worse than leaving it open. Same for any
-   thread Wotuu opened (first comment not `:robot:`-prefixed): never resolve those, see below.
+   **Do not apply this to an agent-opened thread with no agent-authored reply.** That is not a
+   leftover, it is unaddressed work, and it belongs to the normal fix-then-resolve flow below.
+   Resolving it here would silently close a finding nobody fixed — strictly worse than leaving it
+   open. Same for any human-opened thread: never resolve those, see below.
 
-   **Whether you resolve the thread yourself, after fixing it, depends on who opened it** — every
-   agent-authored comment (cold-review findings, this reply) is `:robot:`-prefixed by convention, so
-   "does the thread's *first* comment start with `:robot:`" is a reliable, mechanical test:
-   - **First comment starts with `:robot:`** (an AI agent raised it, e.g. a cold-review finding):
+   **Whether you resolve the thread yourself, after fixing it, depends on who opened it** — apply
+   the agent-authored test above to the thread's *first* comment:
+   - **First comment is agent-authored** (an AI agent raised it, e.g. a cold-review finding):
      once you've pushed the fix and posted your `:robot: Fixed...` reply, resolve the thread
      yourself — `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId:
      "<thread-id>"}) { thread { isResolved } } }'`. Wotuu doesn't need to manually close an
      agent-to-agent loop, and a resolved thread is still there to expand if he wants the detail.
-   - **First comment does *not* start with `:robot:`** (Wotuu wrote it himself): fix it and reply
-     exactly the same as above, just don't call `resolveReviewThread` — leaving the thread open is
-     only about not closing the loop on his behalf; he still sees the fix and closes it himself on
-     re-review, when he's ready to confirm it.
+   - **First comment is human-authored** (Wotuu wrote it himself — or, on this public repo, an
+     outside contributor did): fix it and reply exactly the same as above, just don't call
+     `resolveReviewThread` — leaving the thread open is only about not closing the loop on someone
+     else's behalf; they still see the fix and close it themselves on re-review, when they're ready
+     to confirm it.
 
    **No cap on how many PRs get this treatment in one pass.** Unlike cold reviews (capped at 3
    dispatches per pass, see step 4), comment-resolving work should proceed on every eligible PR this
@@ -261,9 +277,10 @@ regardless of what cold review finds — this carve-out only unblocks step 4, no
      --jq '.reviews[] | select(.body != "") | {author: .author.login, state, submittedAt, body}'
    ```
 
-   Apply the same first-responder logic as review threads, just without thread IDs to resolve:
-   walk the comments in chronological order and find any comment **not** `:robot:`-prefixed (i.e.
-   from Wotuu) that has no later `:robot:`-prefixed comment addressing it. Treat that the same as
+   Both queries already select `author.login`, so the agent-authored test above applies unchanged
+   here. Apply the same first-responder logic as review threads, just without thread IDs to resolve:
+   walk the comments in chronological order and find any **human-authored** comment that has no
+   later agent-authored comment addressing it. Treat that the same as
    an unresolved review thread — fix it in code (or answer it), push, then reply as a **new**
    top-level comment (`gh api -X POST repos/RaiderIO/keystone.guru/issues/<n>/comments -F
    body=@<file>`, `:robot:`-prefixed) describing what changed. There is no `resolveReviewThread`
@@ -362,7 +379,7 @@ raise or lower it again if the cost/speed tradeoff stops feeling right.
   applied when the implementing session skipped cold review under the trivial-change rule
   (`.claude/CLAUDE.md`, "Before declaring a MR ready for review") — the MR body says so; don't
   dispatch a review to "make up" for it. If the label is missing
-  but the PR already has `:robot:`-prefixed *inline* review comments or a `:robot: Cold review`
+  but the PR already has agent-authored *inline* review comments or a `:robot: Cold review`
   summary comment from a cold review that ran before the label existed (or whose label application
   failed), just add the label instead of re-reviewing. Re-review only if the diff has changed
   substantially since the review, or Wotuu asks.

--- a/.claude/skills/keystoneguru-infra-workflow/SKILL.md
+++ b/.claude/skills/keystoneguru-infra-workflow/SKILL.md
@@ -106,10 +106,16 @@ review replies, PR/issue bodies) — same reasoning as keystone.guru: it marks a
 so it's never mistaken for the account owner speaking. Never on titles.
 
 **`sh/gh-bot.sh` does not apply in this repo — use plain `gh` here.** The `keystone-guru-bot`
-account introduced in #3924 is a collaborator on `RaiderIO/keystone.guru` only, and its fine-grained
-PAT is scoped to that single repository; pointing it at `RaiderIO/keystoneguru-infra` would 403/404
-rather than post. So here the `:robot:` prefix isn't a fallback signal — it remains the *only* one,
-which is one more reason never to drop it from a message in this repo.
+account introduced in #3924 is a collaborator on `RaiderIO/keystone.guru` only, so it has no write
+access here and would 403/404 rather than post. The reason is **collaboratorship, not credential
+scope** — under the recommended OAuth route the bot's credential carries `repo` broadly, so it is
+repo access, not token scope, that stops it. Don't "fix" this by widening the credential; it would
+change nothing.
+
+This is unlikely to change soon: Wotuu has `push` but **not `admin`** on `keystoneguru-infra`, so he
+cannot add the bot here himself — it would take an org owner. So in this repo the `:robot:` prefix
+isn't a fallback signal, it remains the *only* one, which is one more reason never to drop it from a
+message here.
 
 ## Cold review
 

--- a/.claude/skills/keystoneguru-infra-workflow/SKILL.md
+++ b/.claude/skills/keystoneguru-infra-workflow/SKILL.md
@@ -105,6 +105,12 @@ Prepend `:robot:` to every comment/reply an agent posts on GitHub here too (PR/i
 review replies, PR/issue bodies) — same reasoning as keystone.guru: it marks agent-authored content
 so it's never mistaken for the account owner speaking. Never on titles.
 
+**`sh/gh-bot.sh` does not apply in this repo — use plain `gh` here.** The `keystone-guru-bot`
+account introduced in #3924 is a collaborator on `RaiderIO/keystone.guru` only, and its fine-grained
+PAT is scoped to that single repository; pointing it at `RaiderIO/keystoneguru-infra` would 403/404
+rather than post. So here the `:robot:` prefix isn't a fallback signal — it remains the *only* one,
+which is one more reason never to drop it from a message in this repo.
+
 ## Cold review
 
 There is no automated `babysit-prs`-equivalent loop running against this repo (yet — if that's

--- a/.claude/skills/new-machine-setup/SKILL.md
+++ b/.claude/skills/new-machine-setup/SKILL.md
@@ -54,11 +54,12 @@ machine is gone before it's copied or synced, it is simply gone.
 Nice-to-have, trivially recreated from this file if lost: `~/.claude/settings.json`,
 `.claude/settings.local.json`, `~/.config/git/ignore`.
 
-`~/.config/keystone-guru/bot-gh-token` (the `keystone-guru-bot` fine-grained PAT used by
-`sh/gh-bot.sh`, #3924) sits between the two: copying it across is far easier than re-minting, but it
-*is* recreatable from the bot account, and nothing hard-fails without it — agents fall back to plain
-`gh` with a `:robot:`-prefixed body. Re-mint per the `worktree-docker` skill, "Posting to GitHub as
-the bot account".
+The `keystone-guru-bot` credential used by `sh/gh-bot.sh` (#3924) sits between the two: either
+`~/.config/gh-bot/hosts.yml` (an OAuth login — the preferred route, no PAT involved) or
+`~/.config/keystone-guru/bot-gh-token` (a fine-grained PAT). Copying one across is easier than
+redoing it, but both are recreatable from the bot account, and nothing hard-fails without them —
+agents fall back to plain `gh` with a `:robot:`-prefixed body. Re-create per the `worktree-docker`
+skill, "Posting to GitHub as the bot account".
 
 **Do not copy the MySQL data dirs** (`docker-compose/mysql*`, ~800M). Phase 7 rebuilds them from
 the tracked schema dumps + seeders in ~10–15 minutes.

--- a/.claude/skills/new-machine-setup/SKILL.md
+++ b/.claude/skills/new-machine-setup/SKILL.md
@@ -54,6 +54,12 @@ machine is gone before it's copied or synced, it is simply gone.
 Nice-to-have, trivially recreated from this file if lost: `~/.claude/settings.json`,
 `.claude/settings.local.json`, `~/.config/git/ignore`.
 
+`~/.config/keystone-guru/bot-gh-token` (the `keystone-guru-bot` fine-grained PAT used by
+`sh/gh-bot.sh`, #3924) sits between the two: copying it across is far easier than re-minting, but it
+*is* recreatable from the bot account, and nothing hard-fails without it — agents fall back to plain
+`gh` with a `:robot:`-prefixed body. Re-mint per the `worktree-docker` skill, "Posting to GitHub as
+the bot account".
+
 **Do not copy the MySQL data dirs** (`docker-compose/mysql*`, ~800M). Phase 7 rebuilds them from
 the tracked schema dumps + seeders in ~10–15 minutes.
 

--- a/.claude/skills/sentry-error-triage/SKILL.md
+++ b/.claude/skills/sentry-error-triage/SKILL.md
@@ -99,6 +99,11 @@ raw values into code or test fixtures, never reproduce secrets — are stated in
 replies. Not titles, and not commit messages (those carry the `Co-Authored-By: Claude` trailer
 instead). See `.claude/CLAUDE.md`.
 
+**Post as the bot account when it's provisioned.** If `sh/gh-bot.sh api user --jq .login` prints
+`keystone-guru-bot`, use `sh/gh-bot.sh` in place of `gh` for the issue/PR/comment writes in the
+steps below (#3924). If it errors with "no token", use plain `gh` as written — that's expected, not
+a blocker. Keep the `:robot:` prefix either way.
+
 ## Step 0 — Preflight
 
 The Sentry read tools only exist once the MCP's OAuth flow has completed. Until then the only exposed

--- a/.claude/skills/sentry-error-triage/SKILL.md
+++ b/.claude/skills/sentry-error-triage/SKILL.md
@@ -101,8 +101,8 @@ instead). See `.claude/CLAUDE.md`.
 
 **Post as the bot account when it's provisioned.** If `sh/gh-bot.sh api user --jq .login` prints
 `keystone-guru-bot`, use `sh/gh-bot.sh` in place of `gh` for the issue/PR/comment writes in the
-steps below (#3924). If it errors with "no token", use plain `gh` as written — that's expected, not
-a blocker. Keep the `:robot:` prefix either way.
+steps below (#3924). If it fails for **any** reason (missing token, missing script, wrong-account
+token), use plain `gh` as written — that's expected, not a blocker. Keep the `:robot:` prefix either way.
 
 ## Step 0 — Preflight
 

--- a/.claude/skills/worktree-docker/SKILL.md
+++ b/.claude/skills/worktree-docker/SKILL.md
@@ -243,6 +243,43 @@ To re-provision the deploy key (e.g. on a new machine): generate a passphraseles
 as a write deploy key —
 `gh api -X POST repos/RaiderIO/keystone.guru/keys -f title=claude-worktree-push -f key="$(cat ~/.ssh/keystone_worktree_ed25519.pub)" -F read_only=false`.
 
+### Posting to GitHub as the bot account
+
+The deploy key above covers `git push` only. The `gh` CLI / REST surface — `gh pr create`, comments,
+review replies, label edits — runs as whichever account `gh auth login` stored, i.e. Wotuu. Issue
+#3924 moves that half to a dedicated bot account, **`keystone-guru-bot`**, via `sh/gh-bot.sh`:
+
+```bash
+sh/gh-bot.sh api user --jq .login    # self-check — must print keystone-guru-bot
+sh/gh-bot.sh pr create --repo RaiderIO/keystone.guru --base master --draft \
+  --title "#<issue> <title>" --body-file body.md
+```
+
+It injects the bot's PAT as `GH_TOKEN` for that one process, so the human `gh auth login` session on
+disk is untouched and plain `gh` in the same shell still runs as Wotuu. It **never** silently falls
+back to plain `gh` — a missing token is a hard error, because a silent fallback would post as Wotuu
+while you believed you had posted as the bot.
+
+**Until the account is provisioned on this machine, plain `gh` remains the default** — the
+`gh pr create` command earlier in this section is still correct as written. If `gh-bot.sh` errors
+with "no token", just use `gh` and a `:robot:`-prefixed body; that is expected, not a blocker.
+
+Provisioning (one-off, per machine, and steps 1–4 need a human with a browser):
+
+1. Create the `keystone-guru-bot` GitHub account, verify its email, enable 2FA.
+2. Invite it as a collaborator with **write** access
+   (`gh api -X PUT repos/RaiderIO/keystone.guru/collaborators/keystone-guru-bot -f permission=push`),
+   and accept the invite from the bot account.
+3. From the bot account, mint a **fine-grained PAT** scoped to `RaiderIO/keystone.guru` only, with
+   repository permissions: Contents (read/write), Pull requests (read/write), Issues (read/write),
+   Metadata (read). Note that org policy may require an owner to approve fine-grained PATs — check
+   Org Settings → Personal access tokens.
+4. Store it: `mkdir -p ~/.config/keystone-guru && chmod 600 ~/.config/keystone-guru/bot-gh-token`
+   (override the path with `KSG_BOT_GH_TOKEN_FILE`, or pass the token via `KSG_BOT_GH_TOKEN`).
+5. Verify: `sh/gh-bot.sh api user --jq .login` prints `keystone-guru-bot`.
+
+The token file lives outside the repo and is never committed.
+
 ### Rewriting a commit that isn't `HEAD` (interactive rebase is unsupported here)
 
 Mark the tip first, reset, amend, then replay: `git branch -f save HEAD`,

--- a/.claude/skills/worktree-docker/SKILL.md
+++ b/.claude/skills/worktree-docker/SKILL.md
@@ -255,34 +255,51 @@ sh/gh-bot.sh pr create --repo RaiderIO/keystone.guru --base master --draft \
   --title "#<issue> <title>" --body-file body.md
 ```
 
-It injects the bot's PAT as `GH_TOKEN` for that one process, so the human `gh auth login` session on
-disk is untouched and plain `gh` in the same shell still runs as Wotuu. It **never** silently falls
-back to plain `gh` — a missing token is a hard error, because a silent fallback would post as Wotuu
-while you believed you had posted as the bot.
+Whichever credential it uses, the human's `gh auth login` session on disk is untouched and plain
+`gh` in the same shell still runs as Wotuu. `gh-bot.sh` **never** silently falls back to plain `gh`,
+and refuses outright if the credential turns out to belong to a *different* account — either would
+end with a message attributed to Wotuu while you believed you had posted as the bot.
 
 **Until the account is provisioned on this machine, plain `gh` remains the default** — the
 `gh pr create` command earlier in this section is still correct as written. If `gh-bot.sh` errors
-for **any** reason — no token, wrong-account token, or the script not existing on an older branch
-— just use `gh` and a `:robot:`-prefixed body; that is expected, not a blocker.
+for **any** reason — no credential, wrong-account credential, or the script not existing on an older
+branch — just use `gh` and a `:robot:`-prefixed body; that is expected, not a blocker.
 
-Provisioning (one-off, per machine, and steps 1–4 need a human with a browser):
+Provisioning (one-off, per machine; steps 1–3 need a human with a browser):
 
 1. Create the `keystone-guru-bot` GitHub account, verify its email, enable 2FA.
 2. Invite it as a collaborator with **write** access
    (`gh api -X PUT repos/RaiderIO/keystone.guru/collaborators/keystone-guru-bot -f permission=push`),
-   and accept the invite from the bot account.
-3. From the bot account, mint a **fine-grained PAT** scoped to `RaiderIO/keystone.guru` only, with
-   repository permissions: Contents (read/write), Pull requests (read/write), Issues (read/write),
-   Metadata (read). Note that org policy may require an owner to approve fine-grained PATs — check
-   Org Settings → Personal access tokens.
-4. Store it — create the file with the token in it, *then* lock it down:
+   and accept the invite from the bot account. Note it does **not** need to join the organization —
+   repo collaborator is enough, and `members_can_invite_outside_collaborators` is `true`.
+3. Give it a credential. **Prefer route A** — it needs no PAT at all:
+
+   **A. OAuth login in an isolated gh config dir (recommended).**
+   ```bash
+   GH_CONFIG_DIR=~/.config/gh-bot gh auth login     # log in as keystone-guru-bot
+   ```
+   `gh auth login` stores an **OAuth** token, not a PAT, so the org's fine-grained-PAT approval
+   policy — which an org *owner* controls and a plain member cannot change — never enters the
+   picture. `GH_CONFIG_DIR` fully isolates the two identities: the bot's credential lands in
+   `~/.config/gh-bot/hosts.yml` and the human's `~/.config/gh/hosts.yml` is neither read nor
+   written. Override the path with `KSG_BOT_GH_CONFIG_DIR`. Prerequisite: the gh CLI OAuth app must
+   be authorized for the `RaiderIO` org — it already is, which is how the human's own `gho_` token
+   works today.
+
+   **B. Fine-grained PAT (only if route A is unavailable).** From the bot account, mint one scoped
+   to `RaiderIO/keystone.guru` only: Contents (read/write), Pull requests (read/write), Issues
+   (read/write), Metadata (read). Then create the file *with the token in it* and lock it down:
    ```bash
    mkdir -p ~/.config/keystone-guru
    install -m 600 /dev/null ~/.config/keystone-guru/bot-gh-token   # create empty, 0600 from birth
    read -rs token && printf '%s' "$token" > ~/.config/keystone-guru/bot-gh-token; unset token
    ```
    `read -rs` keeps the PAT out of shell history and off the terminal. Override the path with
-   `KSG_BOT_GH_TOKEN_FILE`, or skip the file entirely by exporting `KSG_BOT_GH_TOKEN`.
+   `KSG_BOT_GH_TOKEN_FILE`, or skip the file entirely by exporting `KSG_BOT_GH_TOKEN`. **Check Org
+   Settings → Personal access tokens first** — org policy can require an owner to approve
+   fine-grained PATs, and that approval is not something a non-owner can grant themselves.
+
+   A token (env var, then file) wins over the config dir if both are present.
 5. Verify: `sh/gh-bot.sh api user --jq .login` prints `keystone-guru-bot`.
 
 The token file lives outside the repo and is never committed.

--- a/.claude/skills/worktree-docker/SKILL.md
+++ b/.claude/skills/worktree-docker/SKILL.md
@@ -262,7 +262,8 @@ while you believed you had posted as the bot.
 
 **Until the account is provisioned on this machine, plain `gh` remains the default** — the
 `gh pr create` command earlier in this section is still correct as written. If `gh-bot.sh` errors
-with "no token", just use `gh` and a `:robot:`-prefixed body; that is expected, not a blocker.
+for **any** reason — no token, wrong-account token, or the script not existing on an older branch
+— just use `gh` and a `:robot:`-prefixed body; that is expected, not a blocker.
 
 Provisioning (one-off, per machine, and steps 1–4 need a human with a browser):
 
@@ -274,8 +275,14 @@ Provisioning (one-off, per machine, and steps 1–4 need a human with a browser)
    repository permissions: Contents (read/write), Pull requests (read/write), Issues (read/write),
    Metadata (read). Note that org policy may require an owner to approve fine-grained PATs — check
    Org Settings → Personal access tokens.
-4. Store it: `mkdir -p ~/.config/keystone-guru && chmod 600 ~/.config/keystone-guru/bot-gh-token`
-   (override the path with `KSG_BOT_GH_TOKEN_FILE`, or pass the token via `KSG_BOT_GH_TOKEN`).
+4. Store it — create the file with the token in it, *then* lock it down:
+   ```bash
+   mkdir -p ~/.config/keystone-guru
+   install -m 600 /dev/null ~/.config/keystone-guru/bot-gh-token   # create empty, 0600 from birth
+   read -rs token && printf '%s' "$token" > ~/.config/keystone-guru/bot-gh-token; unset token
+   ```
+   `read -rs` keeps the PAT out of shell history and off the terminal. Override the path with
+   `KSG_BOT_GH_TOKEN_FILE`, or skip the file entirely by exporting `KSG_BOT_GH_TOKEN`.
 5. Verify: `sh/gh-bot.sh api user --jq .login` prints `keystone-guru-bot`.
 
 The token file lives outside the repo and is never committed.

--- a/.claude/skills/worktree-docker/SKILL.md
+++ b/.claude/skills/worktree-docker/SKILL.md
@@ -272,7 +272,16 @@ Provisioning (one-off, per machine; steps 1–3 need a human with a browser):
    (`gh api -X PUT repos/RaiderIO/keystone.guru/collaborators/keystone-guru-bot -f permission=push`),
    and accept the invite from the bot account. Note it does **not** need to join the organization —
    repo collaborator is enough, and `members_can_invite_outside_collaborators` is `true`.
-3. Give it a credential. **Prefer route A** — it needs no PAT at all:
+3. Give it a credential — two routes, and the choice is a real tradeoff rather than a strict
+   preference. **Route A is recommended here** because route B may simply not be available: org
+   owners can gate fine-grained PATs, and a plain org member cannot approve their own. But route A
+   buys that at the cost of a **wider** credential — `gh auth login` grants `repo`, `workflow` and
+   `gist` across *every* repo the bot account can reach, where route B's PAT is one repo and four
+   permissions. That difference is small only because the bot is a purpose-made account whose sole
+   access is this repo; it would not be acceptable for a credential belonging to a human.
+
+   Whichever you pick: a token (`$KSG_BOT_GH_TOKEN`, then the token file) always wins over the
+   config dir if both happen to be present.
 
    **A. OAuth login in an isolated gh config dir (recommended).**
    ```bash
@@ -298,8 +307,6 @@ Provisioning (one-off, per machine; steps 1–3 need a human with a browser):
    `KSG_BOT_GH_TOKEN_FILE`, or skip the file entirely by exporting `KSG_BOT_GH_TOKEN`. **Check Org
    Settings → Personal access tokens first** — org policy can require an owner to approve
    fine-grained PATs, and that approval is not something a non-owner can grant themselves.
-
-   A token (env var, then file) wins over the config dir if both are present.
 5. Verify: `sh/gh-bot.sh api user --jq .login` prints `keystone-guru-bot`.
 
 The token file lives outside the repo and is never committed.

--- a/.claude/skills/worktree-docker/SKILL.md
+++ b/.claude/skills/worktree-docker/SKILL.md
@@ -267,11 +267,24 @@ branch — just use `gh` and a `:robot:`-prefixed body; that is expected, not a 
 
 Provisioning (one-off, per machine; steps 1–3 need a human with a browser):
 
-1. Create the `keystone-guru-bot` GitHub account, verify its email, enable 2FA.
+1. Create the `keystone-guru-bot` GitHub account, verify its email, and **enable 2FA — this is
+   mandatory, not hygiene.** `RaiderIO` requires 2FA of all members *and outside collaborators*, so
+   without it step 2 fails with `403 The RaiderIO organization requires all members to have
+   two-factor authentication enabled`. Use TOTP and keep the secret plus the recovery codes in the
+   password manager — a machine account nobody can log into is a machine account nobody can
+   re-authenticate.
 2. Invite it as a collaborator with **write** access
    (`gh api -X PUT repos/RaiderIO/keystone.guru/collaborators/keystone-guru-bot -f permission=push`),
-   and accept the invite from the bot account. Note it does **not** need to join the organization —
-   repo collaborator is enough, and `members_can_invite_outside_collaborators` is `true`.
+   then accept the invite *as the bot*:
+   ```bash
+   inv=$(sh/gh-bot.sh api user/repository_invitations \
+     --jq '.[] | select(.repository.full_name == "RaiderIO/keystone.guru") | .id')
+   sh/gh-bot.sh api -X PATCH "user/repository_invitations/$inv"
+   ```
+   It does **not** need to join the organization — repo collaborator is enough, and
+   `members_can_invite_outside_collaborators` is `true`. Write is required rather than Triage:
+   "mark a draft PR as ready for review" is ✗ for Triage, and creating a same-repo PR and resolving
+   review threads are both push-gated.
 3. Give it a credential — two routes, and the choice is a real tradeoff rather than a strict
    preference. **Route A is recommended here** because route B may simply not be available: org
    owners can gate fine-grained PATs, and a plain org member cannot approve their own. But route A

--- a/sh/gh-bot.sh
+++ b/sh/gh-bot.sh
@@ -10,9 +10,18 @@
 #   sh/gh-bot.sh api -X POST repos/RaiderIO/keystone.guru/issues/123/comments -F body=@comment.md
 #   sh/gh-bot.sh api user --jq .login          # self-check: must print the bot login, not Wotuu
 #
-# The bot token is exported as GH_TOKEN for this process only. `gh` prefers GH_TOKEN over the
-# credential in ~/.config/gh/hosts.yml, so the human's own `gh auth login` session is left entirely
-# untouched — plain `gh` in the same shell still runs as the human.
+# Two ways to supply the bot's credential, tried in this order. Either way the human's own
+# `gh auth login` session is left entirely untouched — plain `gh` in the same shell still runs as
+# the human:
+#
+#   1. A token (fine-grained PAT), via $KSG_BOT_GH_TOKEN or a token file. Exported as GH_TOKEN for
+#      this process only; `gh` prefers GH_TOKEN over the credential in ~/.config/gh/hosts.yml.
+#   2. A separate gh config directory the bot has logged into itself:
+#          GH_CONFIG_DIR=~/.config/gh-bot gh auth login
+#      This stores an *OAuth* token, not a PAT — no PAT is created and no fine-grained-PAT org
+#      approval is involved, which matters because org owners can gate those. GH_CONFIG_DIR fully
+#      isolates the two identities; the human's ~/.config/gh/hosts.yml is never read or written.
+#      Prefer this route when PAT creation or approval is blocked.
 #
 # There is deliberately NO fallback to plain `gh`, and no path on which this script posts as anyone
 # other than the bot. A missing token is a hard failure, and so is a token belonging to some *other*
@@ -23,6 +32,7 @@ set -euo pipefail
 
 BOT_LOGIN="${KSG_BOT_GH_LOGIN:-keystone-guru-bot}"
 TOKEN_FILE="${KSG_BOT_GH_TOKEN_FILE:-$HOME/.config/keystone-guru/bot-gh-token}"
+BOT_CONFIG_DIR="${KSG_BOT_GH_CONFIG_DIR:-$HOME/.config/gh-bot}"
 
 die() {
     echo "gh-bot.sh: $*" >&2
@@ -47,20 +57,29 @@ if [ -z "$token" ] && [ -f "$TOKEN_FILE" ]; then
     token="$(tr -d '[:space:]' < "$TOKEN_FILE")"
 fi
 
-if [ -z "$token" ]; then
-    die "no token for '$BOT_LOGIN'.
-  Set \$KSG_BOT_GH_TOKEN, or write the fine-grained PAT to $TOKEN_FILE (chmod 600).
+[ $# -gt 0 ] || die "no arguments — this is a pass-through wrapper around gh"
+
+export GH_HOST=github.com
+
+if [ -n "$token" ]; then
+    # Export rather than `exec env GH_TOKEN=… gh …`: an env-prefixed exec puts the token in the new
+    # process's argv, readable by any local process via /proc/<pid>/cmdline and recorded
+    # persistently by execve process accounting. Exporting is behaviour-identical and leaks neither.
+    export GH_TOKEN="$token"
+elif [ -f "$BOT_CONFIG_DIR/hosts.yml" ]; then
+    # The bot logged itself in with `GH_CONFIG_DIR=$BOT_CONFIG_DIR gh auth login`. Point gh at that
+    # config dir and make sure GH_TOKEN is unset — GH_TOKEN takes precedence over the config dir, so
+    # an inherited one from the caller's environment would silently win and post as its owner.
+    export GH_CONFIG_DIR="$BOT_CONFIG_DIR"
+    unset GH_TOKEN
+else
+    die "no credential for '$BOT_LOGIN'. Either:
+  - log the bot in (no PAT needed, avoids fine-grained-PAT org approval):
+      GH_CONFIG_DIR=$BOT_CONFIG_DIR gh auth login
+  - or set \$KSG_BOT_GH_TOKEN / write a PAT to $TOKEN_FILE (chmod 600).
   Until the bot account is provisioned, use plain 'gh' with a ':robot:' prefixed body instead.
   Setup steps: see the 'worktree-docker' skill, 'Posting to GitHub as the bot account'."
 fi
-
-[ $# -gt 0 ] || die "no arguments — this is a pass-through wrapper around gh"
-
-# Export rather than `exec env GH_TOKEN=… gh …`: an env-prefixed exec puts the PAT in the new
-# process's argv, where it is readable by any local process via /proc/<pid>/cmdline and is recorded
-# persistently by execve process accounting. Exporting is behaviour-identical and leaks neither.
-export GH_TOKEN="$token"
-export GH_HOST=github.com
 
 # Confirm the token really belongs to the bot before handing it to gh. Without this check the
 # "never silently posts as the human" guarantee would cover only a *missing* token — a stale,
@@ -73,11 +92,11 @@ if [ "${KSG_BOT_GH_SKIP_VERIFY:-0}" != "1" ]; then
     # (e.g. {"message":"Bad credentials"}) to *stdout* on an HTTP error, so `|| true` plus an
     # emptiness test would sail past a 401 and then report the JSON blob as the account name.
     if ! actual_login="$("$GH_BIN" api user --jq .login 2>/dev/null)"; then
-        die "GitHub rejected the token (expired, revoked, or blocked by org policy — fine-grained
-  PATs can need org-owner approval). Re-check it, or use plain 'gh' with a ':robot:' prefixed body
-  in the meantime."
+        die "GitHub rejected the credential (expired, revoked, logged out, or blocked by org policy
+  — fine-grained PATs can need org-owner approval; an OAuth login via GH_CONFIG_DIR does not).
+  Re-check it, or use plain 'gh' with a ':robot:' prefixed body in the meantime."
     fi
-    [ "$actual_login" = "$BOT_LOGIN" ] || die "refusing to run: this token belongs to
+    [ "$actual_login" = "$BOT_LOGIN" ] || die "refusing to run: this credential belongs to
   '$actual_login', not '$BOT_LOGIN'. Posting with it would attribute agent activity to the wrong
   account — the exact failure this wrapper exists to prevent. Fix the token, or call plain 'gh'
   directly if posting as '$actual_login' is really what you meant."

--- a/sh/gh-bot.sh
+++ b/sh/gh-bot.sh
@@ -14,9 +14,10 @@
 # credential in ~/.config/gh/hosts.yml, so the human's own `gh auth login` session is left entirely
 # untouched — plain `gh` in the same shell still runs as the human.
 #
-# There is deliberately NO fallback to plain `gh` when the token is missing. Falling back would
-# silently post as the human while the caller believes it posted as the bot, which is the exact
-# ambiguity this script exists to remove — so a missing token is a hard failure instead.
+# There is deliberately NO fallback to plain `gh`, and no path on which this script posts as anyone
+# other than the bot. A missing token is a hard failure, and so is a token belonging to some *other*
+# account — both would otherwise end with a comment attributed to the human while the caller
+# believed it had posted as the bot, which is the exact ambiguity this script exists to remove.
 
 set -euo pipefail
 
@@ -55,4 +56,31 @@ fi
 
 [ $# -gt 0 ] || die "no arguments — this is a pass-through wrapper around gh"
 
-exec env GH_TOKEN="$token" GH_HOST=github.com "$GH_BIN" "$@"
+# Export rather than `exec env GH_TOKEN=… gh …`: an env-prefixed exec puts the PAT in the new
+# process's argv, where it is readable by any local process via /proc/<pid>/cmdline and is recorded
+# persistently by execve process accounting. Exporting is behaviour-identical and leaks neither.
+export GH_TOKEN="$token"
+export GH_HOST=github.com
+
+# Confirm the token really belongs to the bot before handing it to gh. Without this check the
+# "never silently posts as the human" guarantee would cover only a *missing* token — a stale,
+# swapped or copy-pasted-from-the-wrong-place PAT would post under whoever actually owns it, with
+# no visible sign, which is precisely the ambiguity this script exists to remove. One extra HTTP
+# round trip per invocation is a fair price; set KSG_BOT_GH_SKIP_VERIFY=1 inside a loop that has
+# already verified once.
+if [ "${KSG_BOT_GH_SKIP_VERIFY:-0}" != "1" ]; then
+    # Branch on gh's exit status, not on whether output is empty: `gh api` prints the error body
+    # (e.g. {"message":"Bad credentials"}) to *stdout* on an HTTP error, so `|| true` plus an
+    # emptiness test would sail past a 401 and then report the JSON blob as the account name.
+    if ! actual_login="$("$GH_BIN" api user --jq .login 2>/dev/null)"; then
+        die "GitHub rejected the token (expired, revoked, or blocked by org policy — fine-grained
+  PATs can need org-owner approval). Re-check it, or use plain 'gh' with a ':robot:' prefixed body
+  in the meantime."
+    fi
+    [ "$actual_login" = "$BOT_LOGIN" ] || die "refusing to run: this token belongs to
+  '$actual_login', not '$BOT_LOGIN'. Posting with it would attribute agent activity to the wrong
+  account — the exact failure this wrapper exists to prevent. Fix the token, or call plain 'gh'
+  directly if posting as '$actual_login' is really what you meant."
+fi
+
+exec "$GH_BIN" "$@"

--- a/sh/gh-bot.sh
+++ b/sh/gh-bot.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Run `gh` as the agent's bot account instead of the human account that `gh auth login` stored on
+# this machine, so PR/comment authorship is real signal rather than a `:robot:` prefix convention
+# (see issue #3924).
+#
+# Usage is a straight pass-through — anything you would hand to `gh`, hand to this instead:
+#
+#   sh/gh-bot.sh pr create --repo RaiderIO/keystone.guru --base master --title '...' --body-file b.md
+#   sh/gh-bot.sh api -X POST repos/RaiderIO/keystone.guru/issues/123/comments -F body=@comment.md
+#   sh/gh-bot.sh api user --jq .login          # self-check: must print the bot login, not Wotuu
+#
+# The bot token is exported as GH_TOKEN for this process only. `gh` prefers GH_TOKEN over the
+# credential in ~/.config/gh/hosts.yml, so the human's own `gh auth login` session is left entirely
+# untouched — plain `gh` in the same shell still runs as the human.
+#
+# There is deliberately NO fallback to plain `gh` when the token is missing. Falling back would
+# silently post as the human while the caller believes it posted as the bot, which is the exact
+# ambiguity this script exists to remove — so a missing token is a hard failure instead.
+
+set -euo pipefail
+
+BOT_LOGIN="${KSG_BOT_GH_LOGIN:-keystone-guru-bot}"
+TOKEN_FILE="${KSG_BOT_GH_TOKEN_FILE:-$HOME/.config/keystone-guru/bot-gh-token}"
+
+die() {
+    echo "gh-bot.sh: $*" >&2
+    exit 1
+}
+
+# ~/.local/bin/gh (2.96+) shadows the apt-installed /usr/bin/gh (2.4.0) in an interactive shell, but
+# a hook, cron entry or subagent may not inherit that PATH — and 2.4.0 fails on `gh pr edit` with a
+# Projects-classic GraphQL error. Resolve the newer binary explicitly rather than trusting PATH.
+GH_BIN="${KSG_GH_BIN:-}"
+if [ -z "$GH_BIN" ]; then
+    if [ -x "$HOME/.local/bin/gh" ]; then
+        GH_BIN="$HOME/.local/bin/gh"
+    else
+        GH_BIN="$(command -v gh || true)"
+    fi
+fi
+[ -n "$GH_BIN" ] && [ -x "$GH_BIN" ] || die "no gh binary found (looked at \$KSG_GH_BIN, ~/.local/bin/gh, \$PATH)"
+
+token="${KSG_BOT_GH_TOKEN:-}"
+if [ -z "$token" ] && [ -f "$TOKEN_FILE" ]; then
+    token="$(tr -d '[:space:]' < "$TOKEN_FILE")"
+fi
+
+if [ -z "$token" ]; then
+    die "no token for '$BOT_LOGIN'.
+  Set \$KSG_BOT_GH_TOKEN, or write the fine-grained PAT to $TOKEN_FILE (chmod 600).
+  Until the bot account is provisioned, use plain 'gh' with a ':robot:' prefixed body instead.
+  Setup steps: see the 'worktree-docker' skill, 'Posting to GitHub as the bot account'."
+fi
+
+[ $# -gt 0 ] || die "no arguments — this is a pass-through wrapper around gh"
+
+exec env GH_TOKEN="$token" GH_HOST=github.com "$GH_BIN" "$@"

--- a/sh/gh-bot.sh
+++ b/sh/gh-bot.sh
@@ -61,6 +61,15 @@ fi
 
 export GH_HOST=github.com
 
+# `gh` honours GITHUB_TOKEN as well as GH_TOKEN, and it outranks the GH_CONFIG_DIR credential — so
+# an inherited GITHUB_TOKEN would win on the config-dir path. On the default path the identity guard
+# below would still fail closed (while misreporting the cause), but under KSG_BOT_GH_SKIP_VERIFY=1
+# it would silently post as that token's owner. Clear it unconditionally: this script's own token
+# input is $KSG_BOT_GH_TOKEN, never GITHUB_TOKEN, so nothing legitimate is being discarded.
+# GH_ENTERPRISE_TOKEN / GITHUB_ENTERPRISE_TOKEN need no such handling — they apply only to a
+# non-github.com host, and GH_HOST is pinned to github.com just above.
+unset GITHUB_TOKEN
+
 if [ -n "$token" ]; then
     # Export rather than `exec env GH_TOKEN=… gh …`: an env-prefixed exec puts the token in the new
     # process's argv, readable by any local process via /proc/<pid>/cmdline and recorded


### PR DESCRIPTION
:robot: Part of #3924

Steps 1–3 of the issue's recommended approach: the auth spike (posted as [a comment on #3924](https://github.com/RaiderIO/keystone.guru/issues/3924#issuecomment-5283262972)), the `gh` plumbing, and the login-based detection logic.

## Decision from the spike: bot **user account**, not a GitHub App

- **An agent cannot create a GitHub App at all.** There is no REST endpoint for it; the only routes are the web UI and the App Manifest flow, which still needs a human to click "Create GitHub App". This is not a token-scopes problem — `admin:org` would change nothing.
- **Org-owned App is blocked** (Wotuu is `member`, not owner in `RaiderIO`). A personally-owned App is creatable, but *installing* it on an org repo is governed by an org-owner policy rather than repo admin.
- **The decisive argument is credential ergonomics, and it's org-independent.** App installation tokens expire in ~1h and must be minted from a JWT signed with the App private key — every `gh` call would need a refresh helper plus a private key to store and rotate. A machine-account fine-grained PAT drops straight into `GH_TOKEN`, which is exactly the shape step 2 of the issue asks for.

## What's here

**`sh/gh-bot.sh`** — a pass-through wrapper around `gh` that runs it as the bot. The human's `gh auth login` credential on disk is untouched, so plain `gh` in the same shell still runs as Wotuu.

**Credential: OAuth login, not a PAT.** Wotuu is an org `member`, and org owners gate fine-grained PATs — a member cannot approve their own, so route B may be unavailable to him entirely. `gh auth login` stores an **OAuth** token instead, and `GH_CONFIG_DIR` isolates it completely:

```bash
GH_CONFIG_DIR=~/.config/gh-bot gh auth login    # as keystone-guru-bot
```

No PAT, no org-owner approval. The gh CLI OAuth app is already authorized for `RaiderIO` — that is how the human's own `gho_` token works today. The honest cost, which the second cold review made me state plainly: an OAuth login carries `repo`/`workflow`/`gist` across every repo the account can reach, versus the PAT's one repo and four permissions. Acceptable only because this is a purpose-made account whose sole access is this repo. Credential order is `$KSG_BOT_GH_TOKEN` → token file → config dir.

**Required repo role: Write.** Triage is not enough — "Mark a draft pull request as ready for review" is ✗ for Triage, and every MR here opens as a draft and is undrafted as the handoff step. Creating a PR from a same-repo branch and resolving review threads are also push-gated. Write adds no new blast radius: `~/.ssh/keystone_worktree_ed25519` is already a write deploy key for this repo on the same machine. Not Maintain, not Admin.

It deliberately has **no path on which it posts as anyone but the bot**. A missing token is a hard error, and so is a token belonging to a *different* account — before exec'ing it calls `gh api user` and refuses unless the login matches. A silent fallback or a silently-wrong token would post as Wotuu while the caller believed it had posted as the bot, which is the precise ambiguity the bot account exists to remove. The PAT is passed by `export`, never in argv. It also resolves the `gh` binary explicitly (`~/.local/bin/gh` 2.96 over apt's 2.4.0) rather than trusting `PATH`, since a hook or subagent may not inherit the interactive shell's `PATH`.

**Expand/contract applied to both halves**, so merging this is a no-op for every currently running agent session:

| Half | Primary | Fallback (kept) |
|---|---|---|
| Detection | `author.login == "keystone-guru-bot"` | body starts with `:robot:` |
| Plumbing | `sh/gh-bot.sh`, gated on the account being provisioned | plain `gh` — still the documented default |

## Deliberate deviation from the issue body

The issue says "`author.login != "Wotuu"` becomes the primary check". **That is implemented as an allowlist instead, not a denylist**, and the reason is written into `.claude/CLAUDE.md` so it doesn't get re-copied: `keystone.guru` is a **public** repo, so outside contributors, `dependabot[bot]`, `github-actions[bot]` and any future integration all satisfy `!= "Wotuu"`. Under the denylist, `babysit-prs` step 3 would classify a stranger's review thread as agent-authored and `resolveReviewThread` it away. The allowlist fails safe — an unknown author is a human whose thread an agent must never resolve on their behalf.

## Scope correction

The issue lists four `.claude/` files. A grep for the authorship convention found **two more** that branch on it and had to move in lockstep: `keystoneguru-infra-workflow` and `sentry-error-triage`. Also worth flagging: the bot's PAT is scoped to `RaiderIO/keystone.guru` only, so it does **not** cover `RaiderIO/keystoneguru-infra` — `:robot:` stays the sole authorship signal there, and that's now documented in that skill.

`new-machine-setup` gets the token file listed as recoverable-but-annoying (nothing hard-fails without it; agents fall back to plain `gh`).

## Verification

- `bash -n sh/gh-bot.sh` clean; executable bit set; LF endings.
- All four guard paths exercised by hand:

  | Case | Result |
  |---|---|
  | No token at all | exit 1, setup pointer, no `gh` invocation |
  | Revoked/garbage token | exit 1, "GitHub rejected the token" |
  | Valid token, wrong account | exit 1, refusal naming both logins |
  | `KSG_BOT_GH_SKIP_VERIFY=1`, valid token | clean pass-through |

- **`GH_TOKEN` pass-through verified end-to-end** by standing the human's own token in for the bot's under `KSG_BOT_GH_SKIP_VERIFY=1`: `gh` honoured the injected token, and plain `gh api user` in the same shell was unaffected. Without the skip flag the same token is now correctly *refused*, which is the identity guard doing its job.
- **Token confirmed absent from `/proc/<pid>/cmdline`** of the exec'd process during a live run.
- No PHP/JS/schema touched — backend-only-adjacent, so no visual verification.

## Cold review

5 findings, all fixed in e5ab863, all threads resolved. Two were substantive: the review-body merge authorization in `babysit-prs` was author-blind (on a public repo, *any* user can submit a review, so an outsider's "looks good, merge it" would have satisfied every merge condition — now narrowed to the single login `Wotuu`), and `BOT_LOGIN` originally gated nothing, so a wrong-account token would have posted silently as its owner. Implementing that second fix surfaced a bug in the fix itself: `gh api` writes its error body to **stdout** on a 401, so the first version reported the `Bad credentials` JSON as the account name and never reached its rejected-token branch. It branches on exit status now.

## The account is provisioned — every DoD item on #3924 is met

Wotuu created `keystone-guru-bot` and logged it in during this session, so the end-to-end verification is done rather than deferred:

| #3924 DoD item | Evidence |
|---|---|
| Bot provisioned with write + issue-close permissions | collaborator role `write`; `permissions: push=true, triage=true` |
| A real PR opened under the bot identity | **PR #4001** — `author.login` = `keystone-guru-bot` (throwaway, closed, branch deleted) |
| `Closes #<issue>` works from a bot-authored PR | `closingIssuesReferences` on #4001 resolved to **#3924** |
| Bot comment and Wotuu comment both classified correctly | verified in both directions on live data — see below |
| Branch-protection decision deferred, not assumed | untouched; still Wotuu's call |

Classification was checked against real content rather than a contrived case. On this PR: two legacy agent comments (Wotuu's account, `:robot:` prefix) → `AGENT (prefix fallback)`, one bot comment → `AGENT (login)`. On #3973, which carries a genuine human comment: 3 → agent, 1 → `HUMAN`. Both halves of the `OR` fire correctly, which is what makes the transition safe for the 21 open PRs that still have prefix-only content.

**Two things provisioning surfaced that the plan had wrong**, both fixed in `worktree-docker`:

1. **`RaiderIO` requires 2FA of outside collaborators.** Accepting the repo invite 403s without it — and `two_factor_requirement_enabled` reads `null` without `admin:org`, so this was undiscoverable in advance. It was written as hygiene; it is a hard prerequisite.
2. **The accept-the-invite step had no mechanism**, just "accept the invite from the bot account". Now a runnable snippet.

Also worth noting: creating the probe branch off `master` reproduced cold-review finding 4 unprompted — `sh/gh-bot.sh: No such file or directory`, because the branch predates the script. That is exactly the failure mode the reviewer predicted would be more common than "no token", and why the fallback wording was broadened away from that literal string.

## Follow-up

**#4002** — drop the `:robot:` read-side fallback. Deliberately not done here: 55 prefix-only review threads across 21 open PRs as of today. That issue is gated on a mechanical drain check rather than a date, and records that the fallback can only ever be dropped for `keystone.guru` — the bot is not a collaborator on `keystoneguru-infra` and cannot become one without an org owner, so `:robot:` remains the *only* authorship signal there, permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
